### PR TITLE
Allow user to select formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "sweetpad" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Next]
+
+- Add settings options for alternative formatter, like [swiftformat](https://github.com/nicklockwood/SwiftFormat).
+  Thanks to [Rafael Pedretti](https://github.com/rafaelpedretti-toast) for the adding this feature.
+  [#8](https://github.com/sweetpad-dev/sweetpad/pull/8)
+
 ## [0.1.13] - 2024-05-12
 
 - README.md updates
@@ -113,6 +119,6 @@ Fixed problem with panel icon not showing up
 
 Public release of SweetPad:
 
-- Integration of swift-format (or other formatter of your choice) with VSCode for formatting Swift files.
+- Integration of swift-format with VSCode for formatting Swift files.
 - iOS simulator panel for running and stopping the iOS simulator.
 - Panel for installing iOS tools using Homebrew.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,6 @@ Fixed problem with panel icon not showing up
 
 Public release of SweetPad:
 
-- Integration of swift-format with VSCode for formatting Swift files.
+- Integration of swift-format (or other formatter of your choice) with VSCode for formatting Swift files.
 - iOS simulator panel for running and stopping the iOS simulator.
 - Panel for installing iOS tools using Homebrew.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ so on into VSCode.
   [xcode-build-server](https://github.com/SolaWing/xcode-build-server)
 - 🛠️ **[Build & Run](./docs/wiki/build.md)** — build and run application using
   [xcodebuild](https://developer.apple.com/library/archive/technotes/tn2339/_index.html)
-- 💅🏼 **[Format](./docs/wiki/format.md)** — format files using [swift-format](https://github.com/apple/swift-format) or other formatter of your choice
+- 💅🏼 **[Format](./docs/wiki/format.md)** — format files using [swift-format](https://github.com/apple/swift-format) or
+  other formatter of your choice
 - 📱 **[Simulator](./docs/wiki/simulator.md)** — manage iOS simulators
 - 🛠️ **[Tools](./docs/wiki/tools.md)** — manage essential iOS development tools using [Homebrew](https://brew.sh/)
 - 🪲 **[Debug](./docs/wiki/debug.md)** — debug iOS applications using

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ so on into VSCode.
   [xcode-build-server](https://github.com/SolaWing/xcode-build-server)
 - 🛠️ **[Build & Run](./docs/wiki/build.md)** — build and run application using
   [xcodebuild](https://developer.apple.com/library/archive/technotes/tn2339/_index.html)
-- 💅🏼 **[Format](./docs/wiki/format.md)** — format files using [swift-format](https://github.com/apple/swift-format)
+- 💅🏼 **[Format](./docs/wiki/format.md)** — format files using [swift-format](https://github.com/apple/swift-format) or other formatter of your choice
 - 📱 **[Simulator](./docs/wiki/simulator.md)** — manage iOS simulators
 - 🛠️ **[Tools](./docs/wiki/tools.md)** — manage essential iOS development tools using [Homebrew](https://brew.sh/)
 - 🪲 **[Debug](./docs/wiki/debug.md)** — debug iOS applications using

--- a/docs/wiki/format.md
+++ b/docs/wiki/format.md
@@ -1,6 +1,6 @@
 # SweetPad: Format Swift code
 
-This extension integrates [**swift-format**](https://github.com/apple/swift-format) with VSCode for formatting Swift
+This extension integrates [**swift-format**](https://github.com/apple/swift-format) by default, or other formatter of your choice, with VSCode for formatting Swift
 files. You can also enable "Format on Save" to format Swift files automatically when saving.
 
 [![Swift-format](../images/format-demo.gif)](../images/format-demo.gif)
@@ -27,5 +27,5 @@ Next, add the following configuration to your settings.json file:
 Then, open your Swift file and press `⌘ + S` to format it 💅🏼
 
 > 🙈 In case of errors, open the Command Palette with `⌘ + P` and run `> SweetPad: Show format logs`. This command will
-> open an "Output" panel displaying logs from swift-format. If you encounter issues, grab the logs and open an issue on
+> open an "Output" panel displaying logs from the formatter. If you encounter issues, grab the logs and open an issue on
 > the SweetPad GitHub repository.

--- a/docs/wiki/format.md
+++ b/docs/wiki/format.md
@@ -1,7 +1,8 @@
 # SweetPad: Format Swift code
 
-This extension integrates [**swift-format**](https://github.com/apple/swift-format) by default, or other formatter of your choice, with VSCode for formatting Swift
-files. You can also enable "Format on Save" to format Swift files automatically when saving.
+This extension integrates [**swift-format**](https://github.com/apple/swift-format) by default, or other formatter of
+your choice, with VSCode for formatting Swift files. You can also enable "Format on Save" to format Swift files
+automatically when saving.
 
 [![Swift-format](../images/format-demo.gif)](../images/format-demo.gif)
 
@@ -29,3 +30,21 @@ Then, open your Swift file and press `⌘ + S` to format it 💅🏼
 > 🙈 In case of errors, open the Command Palette with `⌘ + P` and run `> SweetPad: Show format logs`. This command will
 > open an "Output" panel displaying logs from the formatter. If you encounter issues, grab the logs and open an issue on
 > the SweetPad GitHub repository.
+
+### Which formatter to use?
+
+By default, SweetPad is configured to use [**swift-format**](https://github.com/apple/swift-format). This tool is
+developed by Apple, so in general we recommend using it.
+
+However, you can use any other formatter of your choice. We provide several configuration options to customize the
+formatter used by SweetPad. Here is an example of how to use another formatter
+[**swiftformat**](https://github.com/nicklockwood/SwiftFormat):
+
+```json
+{
+  "sweetpad.format.path": "swiftformat",
+  // The "--quiet" flag is important here to ignore output that "swiftformat" writes to stderr.
+  // Otherwise, the extension thinks that the formatting failed and shows an annoying error message
+  "sweetpad.format.args": ["--quiet", "${file}"]
+}
+```

--- a/package.json
+++ b/package.json
@@ -303,7 +303,15 @@
         "sweetpad.format.path": {
           "type": "string",
           "default": "swift-format",
-          "description": "Command or path to swift-format executable."
+          "description": "Command or path to formatter executable."
+        },
+        "sweetpad.format.args": {
+          "type": "array",
+          "items": {
+              "type": "string"
+          },
+          "default": ["--in-place"],
+          "description": "Command or path to formatter executable."
         },
         "sweetpad.build.xcbeautifyEnabled": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -308,10 +308,13 @@
         "sweetpad.format.args": {
           "type": "array",
           "items": {
-              "type": "string"
+            "type": "string"
           },
-          "default": ["--in-place"],
-          "description": "Command or path to formatter executable."
+          "default": [
+            "--in-place",
+            "${file}"
+          ],
+          "description": "Command or path to formatter executable. Use ${file} as a placeholder for the file path. Placehodler ${file} is supported only as a separate item in the array."
         },
         "sweetpad.build.xcbeautifyEnabled": {
           "type": "boolean",

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-type ConfigKey = "format.path" | "build.xcbeautifyEnabled" | "system.taskExecutor" | "xcodegen.autogenerate";
+type ConfigKey = "format.path" | "format.args" | "build.xcbeautifyEnabled" | "system.taskExecutor" | "xcodegen.autogenerate";
 
 export function getWorkspaceConfig<T = any>(key: ConfigKey): T | undefined {
   const config = vscode.workspace.getConfiguration("sweetpad");

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,6 +1,11 @@
 import * as vscode from "vscode";
 
-type ConfigKey = "format.path" | "format.args" | "build.xcbeautifyEnabled" | "system.taskExecutor" | "xcodegen.autogenerate";
+type ConfigKey =
+  | "format.path"
+  | "format.args"
+  | "build.xcbeautifyEnabled"
+  | "system.taskExecutor"
+  | "xcodegen.autogenerate";
 
 export function getWorkspaceConfig<T = any>(key: ConfigKey): T | undefined {
   const config = vscode.workspace.getConfiguration("sweetpad");

--- a/src/format/formatter.ts
+++ b/src/format/formatter.ts
@@ -5,11 +5,22 @@ import { Timer } from "../common/timer.js";
 import { getWorkspaceConfig } from "../common/config.js";
 
 /**
- * Get path to swift-format executable from user settings.
+ * Get path to formatter executable from user settings.
  */
-function getSwiftFormatPath(): string {
+function getFormatterPath(): string {
   const path = getWorkspaceConfig("format.path");
   return path ?? "swift-format";
+}
+
+/**
+ * Get args for the formatter executable from user settings.
+ */
+function getFormatterArgs(): string[] {
+  const args: string[] | undefined = getWorkspaceConfig("format.args");
+
+  return args ?? [
+    "--in-place",
+  ];
 }
 
 /**
@@ -19,7 +30,8 @@ export async function formatDocument(document: vscode.TextDocument) {
   if (document.languageId !== "swift") {
     return;
   }
-  const executable = getSwiftFormatPath();
+  const executable = getFormatterPath();
+  const args = getFormatterArgs();
 
   const filename = document.fileName;
 
@@ -27,7 +39,7 @@ export async function formatDocument(document: vscode.TextDocument) {
   try {
     await exec({
       command: executable,
-      args: ["--in-place", filename],
+      args: [...args, filename],
     });
   } catch (error) {
     formatLogger.error("Failed to format code", {

--- a/src/format/formatter.ts
+++ b/src/format/formatter.ts
@@ -13,7 +13,8 @@ function getFormatterCommand(filename: string): {
 } {
   const path = getWorkspaceConfig<string>("format.path");
 
-  // We use "swift-format" as default command if no path is provided, args are ignored in this case.
+  // We use "swift-format" as default command if no path is provided,
+  // "args" config are ignored in this case
   if (!path) {
     return {
       command: "swift-format",
@@ -21,8 +22,7 @@ function getFormatterCommand(filename: string): {
     };
   }
 
-  // By default we "swift-format" args.
-  // Also we replace "${file}" with actual filename to provide more flexibility to users.
+  // By default we use "swift-format" arguments
   const args: string[] | undefined = getWorkspaceConfig("format.args") ?? ["--in-place", "${file}"];
   const replacedArgs = args.map((arg) => (arg === "${file}" ? filename : arg));
 

--- a/src/format/formatter.ts
+++ b/src/format/formatter.ts
@@ -5,22 +5,31 @@ import { Timer } from "../common/timer.js";
 import { getWorkspaceConfig } from "../common/config.js";
 
 /**
- * Get path to formatter executable from user settings.
+ * Get formatter command parameters from workspace configuration.
  */
-function getFormatterPath(): string {
-  const path = getWorkspaceConfig("format.path");
-  return path ?? "swift-format";
-}
+function getFormatterCommand(filename: string): {
+  command: string;
+  args: string[];
+} {
+  const path = getWorkspaceConfig<string>("format.path");
 
-/**
- * Get args for the formatter executable from user settings.
- */
-function getFormatterArgs(): string[] {
-  const args: string[] | undefined = getWorkspaceConfig("format.args");
+  // We use "swift-format" as default command if no path is provided, args are ignored in this case.
+  if (!path) {
+    return {
+      command: "swift-format",
+      args: ["--in-place", filename],
+    };
+  }
 
-  return args ?? [
-    "--in-place",
-  ];
+  // By default we "swift-format" args.
+  // Also we replace "${file}" with actual filename to provide more flexibility to users.
+  const args: string[] | undefined = getWorkspaceConfig("format.args") ?? ["--in-place", "${file}"];
+  const replacedArgs = args.map((arg) => (arg === "${file}" ? filename : arg));
+
+  return {
+    command: path,
+    args: replacedArgs,
+  };
 }
 
 /**
@@ -30,20 +39,20 @@ export async function formatDocument(document: vscode.TextDocument) {
   if (document.languageId !== "swift") {
     return;
   }
-  const executable = getFormatterPath();
-  const args = getFormatterArgs();
 
   const filename = document.fileName;
+  const { command, args } = getFormatterCommand(filename);
 
   const timer = new Timer();
   try {
     await exec({
-      command: executable,
-      args: [...args, filename],
+      command: command,
+      args: args,
     });
   } catch (error) {
     formatLogger.error("Failed to format code", {
-      executable: executable,
+      executable: command,
+      args: args,
       filename: filename,
       execTime: `${timer.elapsed}ms`,
       error: error,
@@ -52,7 +61,8 @@ export async function formatDocument(document: vscode.TextDocument) {
   }
 
   formatLogger.log("Code successfully formatted", {
-    executable: executable,
+    executable: command,
+    args: args,
     filename: filename,
     execTime: `${timer.elapsed}ms`,
   });


### PR DESCRIPTION
On my company we use `swiftformat` as our formatter and I felt the need to add this feature into the plugin

This PR introduces the ability for the user to use any formatter he wishes and pass any arguments to it.

The change still uses the default `swift-format` with default `--in-place` argument