### PR TITLE
Adds support for code signing post build

### DIFF
--- a/docs/dev/debug.md
+++ b/docs/dev/debug.md
@@ -20,21 +20,37 @@ cd sweetpad
 npm install
 ```
 
-4. Open the project in Visual Studio Code:
+4. Copy the `.evn.example` file to `.env` by issuing:
+
+```shell
+cp .env.example .env
+```
+
+5. Edit the `.env` file and make any necessary changes, then save.
+
+6. Build the extension to ensure the environment variables are injected:
+
+```shell
+npm run build
+```
+
+7. Open the project in Visual Studio Code:
 
 ```shell
 code .
 ```
 
-5. Press **F5** to build and run the extension in a new window. You should now see two VSCode windows: one with the
+8. Open the Extensions Marketplace (Shift+Cmd+X) and search for "esbuild Problem Matchers" by Connor Peet. Install the extension.
+
+9. Press **F5** to build and run the extension in a new window. You should now see two VSCode windows: one with the
    extension running and the other with the source code. The window with **[Extension Development Host]** in the title
    is where the extension is running.
 
-6. Return to the source code window and add breakpoints to the code where you want to debug.
+10. Return to the source code window and add breakpoints to the code where you want to debug.
 
-7. Switch to the window with the running extension and restart it by pressing **Cmd+R**.
+11. Switch to the window with the running extension and restart it by pressing **Cmd+R**.
 
-8. Now, when you perform the action that triggers the breakpoint, the extension will pause, and you can inspect the
+12. Now, when you perform the action that triggers the breakpoint, the extension will pause, and you can inspect the
    variables and the call stack in the source code window.
 
 On example below you can see:

--- a/package.json
+++ b/package.json
@@ -632,6 +632,26 @@
           "type": "string",
           "default": "-",
           "description": "Signing identity to use for code signing (e.g., 'Developer ID Application: Your Name (XXXXXXXXXX)')"
+        },
+        "sweetpad.build.codesign.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable code signing for the build process"
+        },
+        "sweetpad.build.codesign.useHardenedRuntime": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use hardened runtime when code signing"
+        },
+        "sweetpad.build.codesign.signingIdentity": {
+          "type": "string",
+          "default": "-",
+          "description": "Signing identity to use for code signing"
+        },
+        "sweetpad.build.codesign.useEntitlements": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use entitlements file during code signing"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -617,6 +617,21 @@
           "type": "boolean",
           "default": false,
           "description": "Watch for new .swift files and regenerate the project using Tuist. Restart VSCode to apply the settings."
+        },
+        "sweetpad.build.enableCodeSigning": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable code signing after building the app"
+        },
+        "sweetpad.build.useHardenedRuntime": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use hardened runtime when code signing (requires enableCodeSigning to be true)"
+        },
+        "sweetpad.build.signingIdentity": {
+          "type": "string",
+          "default": "-",
+          "description": "Signing identity to use for code signing (e.g., 'Developer ID Application: Your Name (XXXXXXXXXX)')"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -618,21 +618,6 @@
           "default": false,
           "description": "Watch for new .swift files and regenerate the project using Tuist. Restart VSCode to apply the settings."
         },
-        "sweetpad.build.enableCodeSigning": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enable code signing after building the app"
-        },
-        "sweetpad.build.useHardenedRuntime": {
-          "type": "boolean",
-          "default": false,
-          "description": "Use hardened runtime when code signing (requires enableCodeSigning to be true)"
-        },
-        "sweetpad.build.signingIdentity": {
-          "type": "string",
-          "default": "-",
-          "description": "Signing identity to use for code signing (e.g., 'Developer ID Application: Your Name (XXXXXXXXXX)')"
-        },
         "sweetpad.build.codesign.enabled": {
           "type": "boolean",
           "default": false,

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -405,3 +405,32 @@ export async function restartSwiftLSP() {
     });
   }
 }
+
+export async function findEntitlementsFile(context: ExtensionContext, buildSettings: XcodeBuildSettings): Promise<string | undefined> {
+  const intermediatesPath = buildSettings.intermediatesDir;
+  if (!intermediatesPath) {
+    commonLogger.warn("Intermediates path not found", { intermediatesPath });
+    return undefined;
+  }
+
+  const entitlementsFileName = `${buildSettings.appName}.xcent`;
+
+  try {
+    const files = await findFilesRecursive({
+      directory: intermediatesPath,
+      matcher: (file) => file.name === entitlementsFileName,
+      depth: 4,
+    });
+
+    if (files.length > 0) {
+      const entitlementsPath = files[0];
+      commonLogger.debug("Entitlements file found", { path: entitlementsPath });
+      return entitlementsPath;
+    }
+  } catch (error) {
+    commonLogger.warn("Error searching for entitlements file", { error });
+  }
+
+  commonLogger.warn("Entitlements file not found", { entitlementsFileName });
+  return undefined;
+}

--- a/src/common/cli/scripts.ts
+++ b/src/common/cli/scripts.ts
@@ -85,6 +85,12 @@ export class XcodeBuildSettings {
     return this.settings.TARGET_BUILD_DIR;
   }
 
+  get intermediatesDir() {
+    // Example:
+    // - /Users/hyzyla/Library/Developer/Xcode/DerivedData/ControlRoom-gdvrildvemgjaiameavxoegdskby/Build/Intermediates.noindex
+    return this.settings.OBJROOT;
+  }
+
   get executablePath() {
     // Example:
     // - {targetBuildDir}/Control Room.app/Contents/MacOS/Control Room

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -13,9 +13,10 @@ type Config = {
   "system.enableSentry": boolean;
   "xcodegen.autogenerate": boolean;
   "tuist.autogenerate": boolean;
-  "build.enableCodeSigning": boolean;
-  "build.useHardenedRuntime": boolean;
-  "build.signingIdentity": string;
+  "build.codesign.enabled": boolean;
+  "build.codesign.useHardenedRuntime": boolean;
+  "build.codesign.signingIdentity": string;
+  "build.codesign.useEntitlements": boolean;
 };
 
 type ConfigKey = keyof Config;

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -13,6 +13,9 @@ type Config = {
   "system.enableSentry": boolean;
   "xcodegen.autogenerate": boolean;
   "tuist.autogenerate": boolean;
+  "build.enableCodeSigning": boolean;
+  "build.useHardenedRuntime": boolean;
+  "build.signingIdentity": string;
 };
 
 type ConfigKey = keyof Config;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import {
   resolveDependenciesCommand,
   selectXcodeSchemeCommand,
   testCommand,
+  codeSignCommand, // Add this line
 } from "./build/commands.js";
 import { selectXcodeWorkspaceCommand } from "./build/commands.js";
 import { BuildManager } from "./build/manager.js";
@@ -173,6 +174,9 @@ export function activate(context: vscode.ExtensionContext) {
   d(command("sweetpad.system.createIssue.generic", createIssueGenericCommand));
   d(command("sweetpad.system.createIssue.noSchemes", createIssueNoSchemesCommand));
   d(command("sweetpad.system.testErrorReporting", testErrorReportingCommand));
+
+  // Code Sign
+  d(command("sweetpad.build.codeSign", codeSignCommand));
 }
 
 export function deactivate() {}


### PR DESCRIPTION
Initial attempt at add code signing support.

Added new settings:

```json
    "sweetpad.build.codesign.enabled": true,
    "sweetpad.build.codesign.signingIdentity": "Apple Development",
    "sweetpad.build.codesign.useHardenedRuntime": true,
    "sweetpad.build.codesign.useEntitlements": true
```

resolves #47 