### PR TITLE
Updated a grammatical error in the comment on the extension file

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,7 @@ export function activate(context: vscode.ExtensionContext) {
   Logger.setup();
 
   // Managers 💼
-  // This classes are responsible for managing the state of the specific domain. Other parts of the extension can
+  // These classes are responsible for managing the state of the specific domain. Other parts of the extension can
   // interact with them to get the current state of the domain and subscribe to changes. For example
   // "DestinationsManager" have methods to get the list of current ios devices and simulators, and it also have an
   // event emitter that emits an event when the list of devices or simulators changes.


### PR DESCRIPTION
### Description

This PR updated a small grammatical error in the `extension.ts` file by changing `this` to `these` in the comment text.

### Media

<img width="1145" alt="image" src="https://github.com/user-attachments/assets/403b7709-2349-4fc2-9b7c-6c82d9da8187">
