### PR TITLE
Remember app path for iOS device

### DIFF
--- a/src/build/commands.ts
+++ b/src/build/commands.ts
@@ -169,6 +169,8 @@ export async function runOniOSDevice(
     args: ["devicectl", "device", "install", "app", "--device", device, targetPath],
   });
 
+  context.updateWorkspaceState("build.lastLaunchedAppPath", targetPath);
+
   await using jsonOuputPath = await tempFilePath(context, {
     prefix: "json",
   });


### PR DESCRIPTION
It looks like debugging on iOS device is not currently supported, but it really may be done with this patch and 'iOS Debug' extension using following configuration:

```
{
        {
            "name": "iOS Debug",
            "type": "lldb",
            "request": "attach",
            "program": "${command:sweetpad.debugger.getAppPath}",
            "iosBundleId": "<BUNDLE_ID",
            "iosTarget": "select",
        }
    ]
}
```

p.s.: for debugging iOS 17 and higher you will need iOS debug plugin compiled with the following PR: https://github.com/nisargjhaveri/vscode-ios-debug/pull/25