### PR TITLE
fix: esbuild fails when SENTRY_DSN environment variable is not defined

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -27,7 +27,7 @@ const config = {
   sourcemap: isSourcemap,
   minify: isMinify,
   define: {
-    GLOBAL_SENTRY_DSN: JSON.stringify(process.env.SENTRY_DSN),
+    GLOBAL_SENTRY_DSN: JSON.stringify(process.env.SENTRY_DSN || null),
     GLOBAL_RELEASE_VERSION: isProduction ? JSON.stringify(version) : JSON.stringify("dev"),
   },
   plugins: [


### PR DESCRIPTION
### Problem
The esbuild build fails when the `SENTRY_DSN` environment variable is not defined, with the error:

### Root Cause
1. esbuild's define option requires all values to be JSON serializable
2. When `process.env.SENTRY_DSN` is undefined, it results in an `undefined` value which is not a valid JSON value

### Solution
Add a `null` fallback value for `GLOBAL_SENTRY_DSN` in `esbuild.config.mjs`:
```javascript
GLOBAL_SENTRY_DSN: JSON.stringify(process.env.SENTRY_DSN || null)