### PR TITLE
feat: add separate watchOS device support

### DIFF
--- a/src/build/commands.ts
+++ b/src/build/commands.ts
@@ -252,7 +252,10 @@ export function getXcodeBuildDestinationString(options: { destination: Destinati
   if (destination.type === "visionOSSimulator") {
     return `platform=visionOS Simulator,id=${destination.udid}`;
   }
-  assertUnreachable(destination);
+  if (destination.type === "watchOSDevice") {
+    return `platform=watchOS,id=${destination.udid}`;
+  }
+  return assertUnreachable(destination);
 }
 
 class XcodeCommandBuilder {
@@ -562,6 +565,14 @@ export async function launchCommand(execution: CommandExecution, item?: BuildTre
           configuration: configuration,
           xcworkspace: xcworkspace,
         });
+      } else if (destination.type === "watchOSDevice") {
+        await runOniOSDevice(execution.context, terminal, {
+          scheme: scheme,
+          deviceId: destination.udid ?? "",
+          sdk: sdk,
+          configuration: configuration,
+          xcworkspace: xcworkspace,
+        });
       } else {
         assertUnreachable(destination);
       }
@@ -617,6 +628,14 @@ export async function runCommand(execution: CommandExecution, item?: BuildTreeIt
           watchMarker: false,
         });
       } else if (destination.type === "iOSDevice") {
+        await runOniOSDevice(execution.context, terminal, {
+          scheme: scheme,
+          deviceId: destination.udid ?? "",
+          sdk: sdk,
+          configuration: configuration,
+          xcworkspace: xcworkspace,
+        });
+      } else if (destination.type === "watchOSDevice") {
         await runOniOSDevice(execution.context, terminal, {
           scheme: scheme,
           deviceId: destination.udid ?? "",

--- a/src/common/xcode/devicectl.ts
+++ b/src/common/xcode/devicectl.ts
@@ -47,7 +47,7 @@ type DeviceCtlDeviceProperties = {
   rootFileSystemIsWritable: boolean;
 };
 
-export type DeviceCtlDeviceType = "iPhone" | "iPad";
+export type DeviceCtlDeviceType = "iPhone" | "iPad" | "appleWatch";
 
 type DeviceCtlHardwareProperties = {
   cpuType: DeviceCtlCpuType;

--- a/src/destination/constants.ts
+++ b/src/destination/constants.ts
@@ -21,7 +21,7 @@ export const SUPPORTED_DESTINATION_PLATFORMS: DestinationPlatform[] = [
   "iphoneos",
   "iphonesimulator",
   "watchsimulator",
-  // "watchos",
+  "watchos",
   "macosx",
   "xrsimulator",
   "appletvsimulator",
@@ -31,7 +31,7 @@ export const DESTINATION_TYPE_PRIORITY: DestinationType[] = [
   "iOSSimulator",
   "iOSDevice",
   "watchOSSimulator",
-  // "watchOSDevice",
+  "watchOSDevice",
   "macOS",
   "visionOSSimulator",
 ];

--- a/src/destination/manager.ts
+++ b/src/destination/manager.ts
@@ -1,7 +1,7 @@
 import events from "node:events";
 import type { ExtensionContext } from "../common/commands";
 import type { DevicesManager } from "../devices/manager";
-import type { iOSDeviceDestination } from "../devices/types";
+import type { iOSDeviceDestination, watchOSDeviceDestination } from "../devices/types";
 import type { SimulatorsManager } from "../simulators/manager";
 import type {
   SimulatorDestination,
@@ -71,13 +71,13 @@ export class DestinationsManager {
     return await this.simulatorsManager.refresh();
   }
 
-  async refreshiOSDevices() {
+  async refreshDevices() {
     await this.devicesManager.refresh();
   }
 
   async refresh() {
     await this.refreshSimulators();
-    await this.refreshiOSDevices();
+    await this.refreshDevices();
   }
 
   isUsageStatsExist(): boolean {
@@ -139,7 +139,12 @@ export class DestinationsManager {
 
   async getiOSDevices(): Promise<iOSDeviceDestination[]> {
     const devices = await this.devicesManager.getDevices();
-    return devices.filter((device) => device.type === "iOSDevice");
+    return devices.filter((device): device is iOSDeviceDestination => device.type === "iOSDevice");
+  }
+
+  async getWatchOSDevices(): Promise<watchOSDeviceDestination[]> {
+    const devices = await this.devicesManager.getDevices();
+    return devices.filter((device): device is watchOSDeviceDestination => device.type === "watchOSDevice");
   }
 
   async getmacOSDevices(): Promise<macOSDestination[]> {
@@ -212,6 +217,11 @@ export class DestinationsManager {
       destinations.push(...devices);
     }
 
+    if (platforms.includes("watchos")) {
+      const devices = await this.getWatchOSDevices();
+      destinations.push(...devices);
+    }
+
     if (platforms.includes("macosx")) {
       const macosDevcices = await this.getmacOSDevices();
       destinations.push(...macosDevcices);
@@ -262,6 +272,10 @@ export class DestinationsManager {
     }
     if (!destination && types.includes("iOSDevice")) {
       const devices = await this.getiOSDevices();
+      destination = devices.find((device) => device.id === options.destinationId);
+    }
+    if (!destination && types.includes("watchOSDevice")) {
+      const devices = await this.getWatchOSDevices();
       destination = devices.find((device) => device.id === options.destinationId);
     }
     if (!destination && types.includes("macOS")) {

--- a/src/destination/types.ts
+++ b/src/destination/types.ts
@@ -1,4 +1,4 @@
-import type { iOSDeviceDestination } from "../devices/types";
+import type { iOSDeviceDestination, watchOSDeviceDestination } from "../devices/types";
 import type {
   iOSSimulatorDestination,
   tvOSSimulatorDestination,
@@ -13,6 +13,7 @@ export type DestinationType =
   | "iOSDevice"
   | "macOS"
   | "watchOSSimulator"
+  | "watchOSDevice"
   | "tvOSSimulator"
   | "visionOSSimulator";
 
@@ -23,7 +24,7 @@ export const ALL_DESTINATION_TYPES: DestinationType[] = [
   "iOSDevice",
   "macOS",
   "watchOSSimulator",
-  // "watchOSDevice",
+  "watchOSDevice",
   "tvOSSimulator",
   "visionOSSimulator",
 ];
@@ -78,6 +79,7 @@ export type Destination =
   | iOSDeviceDestination
   | macOSDestination
   | watchOSSimulatorDestination
+  | watchOSDeviceDestination
   | tvOSSimulatorDestination
   | visionOSSimulatorDestination;
 

--- a/src/devices/types.ts
+++ b/src/devices/types.ts
@@ -63,3 +63,52 @@ export class iOSDeviceDestination implements IDestination {
     return this.device.hardwareProperties.deviceType;
   }
 }
+
+export class watchOSDeviceDestination implements IDestination {
+  type = "watchOSDevice" as const;
+  typeLabel = "watchOS Device";
+  platform = "watchos" as const;
+
+  constructor(public device: DeviceCtlDevice) {
+    this.device = device;
+  }
+
+  get id(): string {
+    return `watchosdevice-${this.udid}`;
+  }
+
+  get icon(): string {
+    if (this.isConnected) {
+      return "sweetpad-device-watch";
+    }
+    return "sweetpad-device-watch-pause";
+  }
+
+  get udid() {
+    return this.device.hardwareProperties.udid;
+  }
+
+  get name() {
+    return this.device.deviceProperties.name;
+  }
+
+  get label(): string {
+    return `${this.name} (${this.osVersion})`;
+  }
+
+  get osVersion() {
+    return this.device.deviceProperties.osVersionNumber;
+  }
+
+  get quickPickDetails(): string {
+    return `Type: ${this.typeLabel}, Version: ${this.osVersion}, ID: ${this.udid.toLocaleLowerCase()}`;
+  }
+
+  get state(): "connected" | "disconnected" | "unavailable" {
+    return this.device.connectionProperties.tunnelState;
+  }
+
+  get isConnected(): boolean {
+    return this.state === "connected";
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,7 +173,7 @@ export function activate(context: vscode.ExtensionContext) {
   d(command("sweetpad.simulators.stop", stopSimulatorCommand));
 
   // // Devices
-  d(command("sweetpad.devices.refresh", async () => await destinationsManager.refreshiOSDevices()));
+  d(command("sweetpad.devices.refresh", async () => await destinationsManager.refreshDevices()));
 
   // Desintations
   const destinationBar = new DestinationStatusBar({


### PR DESCRIPTION
### Description
Adds dedicated support for watchOS physical devices, separating them from iOS devices for better handling and visibility.

### Changes
1. UI Changes:
   - Added dedicated watchOS Devices group in tree view
   - Added watchOS device status indicators (connected/disconnected)
   - Proper icons and labels for watchOS devices

Current:
![Current](https://github.com/user-attachments/assets/1c0efb15-6ee9-4fc0-a6ee-0b0ed0be491e)

Updated:
![Updated](https://github.com/user-attachments/assets/5b6dd879-bc34-40cd-b1a0-bbe928c3e18d)



2. Core Functionality:
   - Added watchOSDevice type definition
   - Implemented watchOS device tree item handling
   - Added watchOS device support in build system
   - Updated destination manager to handle watchOS devices separately

3. Build System:
   - Added proper platform specification for watchOS devices
   - Updated xcodebuild command generation for watchOS
   - Added watchOS device handling in launch/run commands

### Implementation Details
- `destination/types.ts`: Added watchOSDevice type definitions
- `destination/tree.ts`: Added watchOSDeviceTreeItem implementation
- `destination/manager.ts`: Added watchOS device management methods
- `destination/constants.ts`: Updated device type priorities
- `build/commands.ts`: Added watchOS device build support

### Testing Steps
1. Connect a watchOS device
2. Open a watchOS app project
3. Verify:
   - watchOS device appears in separate group
   - Build/run commands work correctly
   - Device status is properly displayed
   - Build configuration targets correct platform
