### PR TITLE
Fix device destination: Apple TV to show tvOS instead of VisionOS (Fixes #106)

### DIFF
--- a/src/devices/manager.ts
+++ b/src/devices/manager.ts
@@ -5,6 +5,7 @@ import { listDevices } from "../common/xcode/devicectl";
 import {
   type DeviceDestination,
   iOSDeviceDestination,
+  tvOSDeviceDestination,
   visionOSDeviceDestination,
   watchOSDeviceDestination,
 } from "./types";
@@ -50,7 +51,7 @@ export class DevicesManager {
           return new visionOSDeviceDestination(device);
         }
         if (deviceType === "appleTV") {
-          return new visionOSDeviceDestination(device);
+          return new tvOSDeviceDestination(device);
         }
         checkUnreachable(deviceType);
         return null; // Unsupported device type


### PR DESCRIPTION
This pull request addresses issue [#106](https://github.com/sweetpad-dev/sweetpad/issues/106) where Apple TV devices were incorrectly being associated with a VisionOS device destination. In the DevicesManager, when the device type is "appleTV", the code was mistakenly returning a visionOSDeviceDestination instead of a tvOSDeviceDestination.

•	Removed the incorrect return new visionOSDeviceDestination(device); for the "appleTV" case.
•	Ensured that Apple TV devices now correctly return a tvOSDeviceDestination.