### PR TITLE
👆 Make destination selection inline

### DIFF
--- a/package.json
+++ b/package.json
@@ -500,7 +500,7 @@
       {
         "command": "sweetpad.destinations.select",
         "title": "SweetPad: Select destination",
-        "icon": "$(file-code)"
+        "icon": "$(sweetpad-select)"
       },
       {
         "command": "sweetpad.destinations.selectForTesting",
@@ -610,7 +610,8 @@
         },
         {
           "command": "sweetpad.destinations.select",
-          "when": "view == sweetpad.destinations.view && viewItem =~ /destination-item-.*/"
+          "when": "view == sweetpad.destinations.view && viewItem =~ /destination-item-.*/",
+          "group": "inline@4"
         },
         {
           "command": "sweetpad.tools.documentation",
@@ -1019,6 +1020,13 @@
         "default": {
           "fontPath": "images/icons/tabler-icons.woff",
           "fontCharacter": "\\ea5e"
+        }
+      },
+      "sweetpad-select": {
+        "description": "Select",
+        "default": {
+          "fontPath": "images/icons/tabler-icons.woff",
+          "fontCharacter": "\\eba6"
         }
       },
       "sweetpad-x": {

--- a/package.json
+++ b/package.json
@@ -500,7 +500,7 @@
       {
         "command": "sweetpad.destinations.select",
         "title": "SweetPad: Select destination",
-        "icon": "$(sweetpad-select)"
+        "icon": "$(sweetpad-pin)"
       },
       {
         "command": "sweetpad.destinations.selectForTesting",
@@ -601,17 +601,17 @@
         {
           "command": "sweetpad.simulators.start",
           "when": "view == sweetpad.destinations.view && viewItem == destination-item-simulator-shutdown",
-          "group": "inline"
+          "group": "inline@2"
         },
         {
           "command": "sweetpad.simulators.stop",
           "when": "view == sweetpad.destinations.view && viewItem == destination-item-simulator-booted",
-          "group": "inline"
+          "group": "inline@2"
         },
         {
           "command": "sweetpad.destinations.select",
           "when": "view == sweetpad.destinations.view && viewItem =~ /destination-item-.*/",
-          "group": "inline@4"
+          "group": "inline@1"
         },
         {
           "command": "sweetpad.tools.documentation",
@@ -1022,11 +1022,11 @@
           "fontCharacter": "\\ea5e"
         }
       },
-      "sweetpad-select": {
+      "sweetpad-pin":{
         "description": "Select",
         "default": {
           "fontPath": "images/icons/tabler-icons.woff",
-          "fontCharacter": "\\eba6"
+          "fontCharacter": "\\ec9c"
         }
       },
       "sweetpad-x": {


### PR DESCRIPTION
Loving this extension! I switch between devices quite frequently and right clicking is (a tiny) amount of friction, this makes it a single click instead of a right click followed by a click.

Before:

<img width="475" alt="image" src="https://github.com/user-attachments/assets/c8a0a36b-c4b8-4351-bb27-47a81480fd61" />

After:

<img width="409" alt="image" src="https://github.com/user-attachments/assets/adac4880-ced0-46a3-8d40-ad297443a6d8" />


