### PR TITLE
Add Status Items when running commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -501,6 +501,11 @@
         "icon": "$(bug)"
       },
       {
+        "command": "sweetpad.system.openTerminalPanel",
+        "title": "SweetPad: Open Terminal Panel",
+        "icon": "$(terminal)"
+      },
+      {
         "command": "sweetpad.debugger.getAppPath",
         "title": "SweetPad: Get app path for debugging",
         "icon": "$(file-code)"
@@ -828,7 +833,12 @@
         "sweetpad.system.autoRevealTerminal": {
           "type": "boolean",
           "default": true,
-          "description": "Automatically reveal the terminal when executing a command"
+          "description": "Automatically reveal the terminal when executing a command or task"
+        },
+        "sweetpad.system.showProgressStatusBar": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show progress in the status bar when executing a command or task"
         },
         "sweetpad.xcodegen.autogenerate": {
           "type": "boolean",

--- a/src/build/commands.ts
+++ b/src/build/commands.ts
@@ -640,7 +640,6 @@ async function commonBuildCommand(
  * Build and run application on the simulator or device
  */
 export async function launchCommand(context: ExtensionContext, item?: BuildTreeItem) {
-  context.updateProgressStatus("Starting launch command");
   return commonLaunchCommand(context, item, { debug: false });
 }
 
@@ -649,7 +648,6 @@ export async function launchCommand(context: ExtensionContext, item?: BuildTreeI
  * This is a convenience wrapper around launchCommand that sets the debug flag
  */
 export async function debuggingLaunchCommand(context: ExtensionContext, item?: BuildTreeItem) {
-  context.updateProgressStatus("Starting debugging command");
   return commonLaunchCommand(context, item, { debug: true });
 }
 

--- a/src/build/commands.ts
+++ b/src/build/commands.ts
@@ -13,7 +13,7 @@ import {
   getIsXcodeBuildServerInstalled,
   getXcodeVersionInstalled,
 } from "../common/cli/scripts";
-import { CommandExecution, ExtensionContext } from "../common/commands";
+import type { ExtensionContext } from "../common/commands";
 import { getWorkspaceConfig, updateWorkspaceConfig } from "../common/config";
 import { ExecBaseError, ExtensionError } from "../common/errors";
 import { exec } from "../common/exec";
@@ -22,7 +22,9 @@ import { commonLogger } from "../common/logger";
 import { showInputBox } from "../common/quick-pick";
 import { type Command, type TaskTerminal, runTask } from "../common/tasks";
 import { assertUnreachable } from "../common/types";
-import type { Destination, DestinationType } from "../destination/types";
+import type { Destination } from "../destination/types";
+import type { DeviceDestination } from "../devices/types";
+import type { SimulatorDestination } from "../simulators/types";
 import { getSimulatorByUdid } from "../simulators/utils";
 import { DEFAULT_BUILD_PROBLEM_MATCHERS } from "./constants";
 import {
@@ -39,8 +41,6 @@ import {
   restartSwiftLSP,
   selectXcodeWorkspace,
 } from "./utils";
-import { DeviceDestination, iOSDeviceDestination } from "../devices/types";
-import { iOSSimulatorDestination, SimulatorDestination } from "../simulators/types";
 
 function writeWatchMarkers(terminal: TaskTerminal) {
   terminal.write("🍭 SweetPad: watch marker (start)\n");
@@ -60,7 +60,7 @@ async function ensureAppPathExists(appPath: string | undefined): Promise<string>
 }
 
 export async function runOnMac(
-  executionContext: ExtensionContext | CommandExecution,
+  context: ExtensionContext,
   terminal: TaskTerminal,
   options: {
     scheme: string;
@@ -71,7 +71,7 @@ export async function runOnMac(
     launchEnv: Record<string, string>;
   },
 ) {
-  const context = executionContext instanceof ExtensionContext ? executionContext : executionContext.context;
+  context.updateProgressStatus("Extracting build settings");
   const buildSettings = await getBuildSettingsToLaunch({
     scheme: options.scheme,
     configuration: options.configuration,
@@ -89,9 +89,7 @@ export async function runOnMac(
     writeWatchMarkers(terminal);
   }
 
-  if (executionContext instanceof CommandExecution) {
-    executionContext.setStatusText(`Running ${options.scheme} on Mac…`);
-  }
+  context.updateProgressStatus(`Running "${options.scheme}" on Mac`);
   await terminal.execute({
     command: executablePath,
     env: options.launchEnv,
@@ -100,7 +98,7 @@ export async function runOnMac(
 }
 
 export async function runOniOSSimulator(
-  executionContext: ExtensionContext | CommandExecution,
+  context: ExtensionContext,
   terminal: TaskTerminal,
   options: {
     scheme: string;
@@ -115,33 +113,33 @@ export async function runOniOSSimulator(
   },
 ) {
   const simulatorId = options.destination.udid;
+
+  context.updateProgressStatus("Extracting build settings");
   const buildSettings = await getBuildSettingsToLaunch({
     scheme: options.scheme,
     configuration: options.configuration,
     sdk: options.sdk,
     xcworkspace: options.xcworkspace,
   });
-  const context = executionContext instanceof ExtensionContext ? executionContext : executionContext.context;
-
   const appPath = await ensureAppPathExists(buildSettings.appPath);
   const bundlerId = buildSettings.bundleIdentifier;
 
   // Open simulator
-  if (executionContext instanceof CommandExecution) {
-    executionContext.setStatusText(`Launching ${options.destination.name}…`);
-  }
+  context.updateProgressStatus("Launching Simulator.app");
   await terminal.execute({
     command: "open",
     args: ["-a", "Simulator"],
   });
 
   // Get simulator with fresh state
+  context.updateProgressStatus(`Searching for simulator "${simulatorId}"`);
   const simulator = await getSimulatorByUdid(context, {
     udid: simulatorId,
   });
 
   // Boot device
   if (!simulator.isBooted) {
+    context.updateProgressStatus(`Booting simulator "${simulator.name}"`);
     await terminal.execute({
       command: "xcrun",
       args: ["simctl", "boot", simulator.udid],
@@ -152,9 +150,7 @@ export async function runOniOSSimulator(
   }
 
   // Install app
-  if (executionContext instanceof CommandExecution) {
-    executionContext.setStatusText(`Installing ${options.scheme} on ${simulator.name}…`);
-  }
+  context.updateProgressStatus(`Installing "${options.scheme}" on "${simulator.name}"`);
   await terminal.execute({
     command: "xcrun",
     args: ["simctl", "install", simulator.udid, appPath],
@@ -182,9 +178,7 @@ export async function runOniOSSimulator(
   ];
 
   // Run app
-  if (executionContext instanceof CommandExecution) {
-    executionContext.setStatusText(`Running ${options.scheme} on ${simulator.name}…`);
-  }
+  context.updateProgressStatus(`Running "${options.scheme}" on "${simulator.name}"`);
   await terminal.execute({
     command: "xcrun",
     args: launchArgs,
@@ -194,7 +188,7 @@ export async function runOniOSSimulator(
 }
 
 export async function runOniOSDevice(
-  executionContext: ExtensionContext | CommandExecution,
+  context: ExtensionContext,
   terminal: TaskTerminal,
   option: {
     scheme: string;
@@ -207,10 +201,10 @@ export async function runOniOSDevice(
     launchEnv: Record<string, string>;
   },
 ) {
-  const context = executionContext instanceof ExtensionContext ? executionContext : executionContext.context;
   const { scheme, configuration, destination } = option;
   const { udid: deviceId, type: destinationType, name: destinationName } = destination;
 
+  context.updateProgressStatus("Extracting build settings");
   const buildSettings = await getBuildSettingsToLaunch({
     scheme: scheme,
     configuration: configuration,
@@ -222,9 +216,7 @@ export async function runOniOSDevice(
   const bundlerId = buildSettings.bundleIdentifier;
 
   // Install app on device
-  if (executionContext instanceof CommandExecution) {
-    executionContext.setStatusText(`Installing ${scheme} on ${destinationName}…`);
-  }
+  context.updateProgressStatus(`Installing "${scheme}" on "${destinationName}"`);
   await terminal.execute({
     command: "xcrun",
     args: ["devicectl", "device", "install", "app", "--device", deviceId, targetPath],
@@ -242,6 +234,7 @@ export async function runOniOSDevice(
     prefix: "json",
   });
 
+  context.updateProgressStatus("Extracting Xcode version");
   const xcodeVersion = await getXcodeVersionInstalled();
   const isConsoleOptionSupported = xcodeVersion.major >= 16;
 
@@ -268,9 +261,7 @@ export async function runOniOSDevice(
   ].filter((arg) => arg !== null); // Filter out null arguments
 
   // Launch app on device
-  if (executionContext instanceof CommandExecution) {
-    executionContext.setStatusText(`Running ${scheme} on ${destinationName}…`);
-  }
+  context.updateProgressStatus(`Running "${option.scheme}" on "${option.destination.name}"`);
   await terminal.execute({
     command: "xcrun",
     args: launchArgs,
@@ -482,7 +473,7 @@ class XcodeCommandBuilder {
 }
 
 export async function buildApp(
-  executionContext: ExtensionContext | CommandExecution,
+  context: ExtensionContext,
   terminal: TaskTerminal,
   options: {
     scheme: string;
@@ -496,7 +487,6 @@ export async function buildApp(
     debug: boolean;
   },
 ) {
-  const context = executionContext instanceof ExtensionContext ? executionContext : executionContext.context;
   const useXcbeatify = isXcbeautifyEnabled() && (await getIsXcbeautifyInstalled());
   const bundlePath = await prepareBundleDir(context, options.scheme);
   const derivedDataPath = prepareDerivedDataPath();
@@ -559,8 +549,13 @@ export async function buildApp(
   if (useXcbeatify) {
     pipes = [{ command: "xcbeautify", args: [] }];
   }
-  if (executionContext instanceof CommandExecution) {
-    executionContext.setStatusText("Building…");
+
+  if (options.shouldClean) {
+    context.updateProgressStatus(`Cleaning "${options.scheme}"`);
+  } else if (options.shouldBuild) {
+    context.updateProgressStatus(`Building "${options.scheme}"`);
+  } else if (options.shouldTest) {
+    context.updateProgressStatus(`Building "${options.scheme}"`);
   }
   await terminal.execute({
     command: commandParts[0],
@@ -575,31 +570,38 @@ export async function buildApp(
 /**
  * Build app without running
  */
-export async function buildCommand(execution: CommandExecution, item?: BuildTreeItem) {
-  return commonBuildCommand(execution, item, { debug: false });
+export async function buildCommand(context: ExtensionContext, item?: BuildTreeItem) {
+  context.updateProgressStatus("Starting build command");
+  return commonBuildCommand(context, item, { debug: false });
 }
 
 /**
  * Build app in debug mode without running
  */
-export async function debuggingBuildCommand(execution: CommandExecution, item?: BuildTreeItem) {
-  return commonBuildCommand(execution, item, { debug: true });
+export async function debuggingBuildCommand(context: ExtensionContext, item?: BuildTreeItem) {
+  context.updateProgressStatus("Building the app (debug mode)");
+  return commonBuildCommand(context, item, { debug: true });
 }
 
 /**
  * Build app without running
  */
 async function commonBuildCommand(
-  execution: CommandExecution,
+  context: ExtensionContext,
   item: BuildTreeItem | undefined,
   options: { debug: boolean },
 ) {
-  const xcworkspace = await askXcodeWorkspacePath(execution.context);
-  const scheme =
-    item?.scheme ??
-    (await askSchemeForBuild(execution, { title: "Select scheme to build", xcworkspace: xcworkspace }));
-  const configuration = await askConfiguration(execution, { xcworkspace: xcworkspace });
+  context.updateProgressStatus("Searching for workspace");
+  const xcworkspace = await askXcodeWorkspacePath(context);
 
+  context.updateProgressStatus("Searching for scheme");
+  const scheme =
+    item?.scheme ?? (await askSchemeForBuild(context, { title: "Select scheme to build", xcworkspace: xcworkspace }));
+
+  context.updateProgressStatus("Searching for configuration");
+  const configuration = await askConfiguration(context, { xcworkspace: xcworkspace });
+
+  context.updateProgressStatus("Extracting build settings");
   const buildSettings = await getBuildSettingsToAskDestination({
     scheme: scheme,
     configuration: configuration,
@@ -607,18 +609,19 @@ async function commonBuildCommand(
     xcworkspace: xcworkspace,
   });
 
-  const destination = await askDestinationToRunOn(execution, buildSettings);
+  context.updateProgressStatus("Searching for destination");
+  const destination = await askDestinationToRunOn(context, buildSettings);
   const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 
   const sdk = destination.platform;
 
-  await runTask(execution.context, {
+  await runTask(context, {
     name: "Build",
     lock: "sweetpad.build",
     terminateLocked: true,
     problemMatchers: DEFAULT_BUILD_PROBLEM_MATCHERS,
     callback: async (terminal) => {
-      await buildApp(execution, terminal, {
+      await buildApp(context, terminal, {
         scheme: scheme,
         sdk: sdk,
         configuration: configuration,
@@ -636,39 +639,50 @@ async function commonBuildCommand(
 /**
  * Build and run application on the simulator or device
  */
-export async function launchCommand(execution: CommandExecution, item?: BuildTreeItem) {
-  return commonLaunchCommand(execution, item, { debug: false });
+export async function launchCommand(context: ExtensionContext, item?: BuildTreeItem) {
+  context.updateProgressStatus("Starting launch command");
+  return commonLaunchCommand(context, item, { debug: false });
 }
 
 /**
  * Builds and launches the application in debug mode
  * This is a convenience wrapper around launchCommand that sets the debug flag
  */
-export async function debuggingLaunchCommand(execution: CommandExecution, item?: BuildTreeItem) {
-  return commonLaunchCommand(execution, item, { debug: true });
+export async function debuggingLaunchCommand(context: ExtensionContext, item?: BuildTreeItem) {
+  context.updateProgressStatus("Starting debugging command");
+  return commonLaunchCommand(context, item, { debug: true });
 }
 
 /**
  * Build and run application on the simulator or device
  */
 async function commonLaunchCommand(
-  execution: CommandExecution,
+  context: ExtensionContext,
   item: BuildTreeItem | undefined,
   options: { debug: boolean },
 ) {
-  const xcworkspace = await askXcodeWorkspacePath(execution.context);
+  context.updateProgressStatus("Searching for workspace");
+  const xcworkspace = await askXcodeWorkspacePath(context);
 
+  context.updateProgressStatus("Searching for scheme");
   const scheme =
     item?.scheme ??
-    (await askSchemeForBuild(execution, { title: "Select scheme to build and run", xcworkspace: xcworkspace }));
-  const configuration = await askConfiguration(execution, { xcworkspace: xcworkspace });
+    (await askSchemeForBuild(context, { title: "Select scheme to build and run", xcworkspace: xcworkspace }));
+
+  context.updateProgressStatus("Searching for configuration");
+  const configuration = await askConfiguration(context, { xcworkspace: xcworkspace });
+
+  context.updateProgressStatus("Searching for destination");
   const buildSettings = await getBuildSettingsToAskDestination({
     scheme: scheme,
     configuration: configuration,
     sdk: undefined,
     xcworkspace: xcworkspace,
   });
-  const destination = await askDestinationToRunOn(execution, buildSettings);
+
+  context.updateProgressStatus("Searching for destination");
+  const destination = await askDestinationToRunOn(context, buildSettings);
+
   const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 
   const sdk = destination.platform;
@@ -676,13 +690,13 @@ async function commonLaunchCommand(
   const launchArgs = getWorkspaceConfig("build.launchArgs") ?? [];
   const launchEnv = getWorkspaceConfig("build.launchEnv") ?? {};
 
-  await runTask(execution.context, {
+  await runTask(context, {
     name: options.debug ? "Debug" : "Launch",
     lock: "sweetpad.build",
     terminateLocked: true,
     problemMatchers: DEFAULT_BUILD_PROBLEM_MATCHERS,
     callback: async (terminal) => {
-      await buildApp(execution, terminal, {
+      await buildApp(context, terminal, {
         scheme: scheme,
         sdk: sdk,
         configuration: configuration,
@@ -695,7 +709,7 @@ async function commonLaunchCommand(
       });
 
       if (destination.type === "macOS") {
-        await runOnMac(execution, terminal, {
+        await runOnMac(context, terminal, {
           scheme: scheme,
           xcworkspace: xcworkspace,
           configuration: configuration,
@@ -709,7 +723,7 @@ async function commonLaunchCommand(
         destination.type === "tvOSSimulator" ||
         destination.type === "visionOSSimulator"
       ) {
-        await runOniOSSimulator(execution, terminal, {
+        await runOniOSSimulator(context, terminal, {
           scheme: scheme,
           destination: destination,
           sdk: sdk,
@@ -726,8 +740,7 @@ async function commonLaunchCommand(
         destination.type === "tvOSDevice" ||
         destination.type === "visionOSDevice"
       ) {
-
-        await runOniOSDevice(execution, terminal, {
+        await runOniOSDevice(context, terminal, {
           scheme: scheme,
           destination: destination,
           sdk: sdk,
@@ -747,32 +760,39 @@ async function commonLaunchCommand(
 /**
  * Run application on the simulator or device without building
  */
-export async function runCommand(execution: CommandExecution, item?: BuildTreeItem) {
-  return commonRunCommand(execution, item, { debug: false });
+export async function runCommand(context: ExtensionContext, item?: BuildTreeItem) {
+  context.updateProgressStatus("Starting run command");
+  return commonRunCommand(context, item, { debug: false });
 }
 
 /**
  * Run application on the simulator or device without building in debug mode
  */
-export async function debuggingRunCommand(execution: CommandExecution, item?: BuildTreeItem) {
-  return commonRunCommand(execution, item, { debug: true });
+export async function debuggingRunCommand(context: ExtensionContext, item?: BuildTreeItem) {
+  context.updateProgressStatus("Starting debugging command");
+  return commonRunCommand(context, item, { debug: true });
 }
 
 /**
  * Run application on the simulator or device without building
  */
 async function commonRunCommand(
-  execution: CommandExecution,
+  context: ExtensionContext,
   item: BuildTreeItem | undefined,
   options: { debug: boolean },
 ) {
-  const xcworkspace = await askXcodeWorkspacePath(execution.context);
+  context.updateProgressStatus("Searching for workspace");
+  const xcworkspace = await askXcodeWorkspacePath(context);
 
+  context.updateProgressStatus("Searching for scheme");
   const scheme =
     item?.scheme ??
-    (await askSchemeForBuild(execution, { title: "Select scheme to build and run", xcworkspace: xcworkspace }));
-  const configuration = await askConfiguration(execution, { xcworkspace: xcworkspace });
+    (await askSchemeForBuild(context, { title: "Select scheme to build and run", xcworkspace: xcworkspace }));
 
+  context.updateProgressStatus("Searching for configuration");
+  const configuration = await askConfiguration(context, { xcworkspace: xcworkspace });
+
+  context.updateProgressStatus("Searching for destination");
   const buildSettings = await getBuildSettingsToAskDestination({
     scheme: scheme,
     configuration: configuration,
@@ -780,21 +800,22 @@ async function commonRunCommand(
     xcworkspace: xcworkspace,
   });
 
-  const destination = await askDestinationToRunOn(execution, buildSettings);
+  context.updateProgressStatus("Searching for destination");
+  const destination = await askDestinationToRunOn(context, buildSettings);
 
   const sdk = destination.platform;
 
   const launchArgs = getWorkspaceConfig("build.launchArgs") ?? [];
   const launchEnv = getWorkspaceConfig("build.launchEnv") ?? {};
 
-  await runTask(execution.context, {
+  await runTask(context, {
     name: "Run",
     lock: "sweetpad.build",
     terminateLocked: true,
     problemMatchers: DEFAULT_BUILD_PROBLEM_MATCHERS,
     callback: async (terminal) => {
       if (destination.type === "macOS") {
-        await runOnMac(execution, terminal, {
+        await runOnMac(context, terminal, {
           scheme: scheme,
           xcworkspace: xcworkspace,
           configuration: configuration,
@@ -808,7 +829,7 @@ async function commonRunCommand(
         destination.type === "visionOSSimulator" ||
         destination.type === "tvOSSimulator"
       ) {
-        await runOniOSSimulator(execution, terminal, {
+        await runOniOSSimulator(context, terminal, {
           scheme: scheme,
           destination: destination,
           sdk: sdk,
@@ -825,7 +846,7 @@ async function commonRunCommand(
         destination.type === "tvOSDevice" ||
         destination.type === "visionOSDevice"
       ) {
-        await runOniOSDevice(execution, terminal, {
+        await runOniOSDevice(context, terminal, {
           scheme: scheme,
           destination: destination,
           sdk: sdk,
@@ -845,13 +866,18 @@ async function commonRunCommand(
 /**
  * Clean build artifacts
  */
-export async function cleanCommand(execution: CommandExecution, item?: BuildTreeItem) {
-  const xcworkspace = await askXcodeWorkspacePath(execution.context);
-  const scheme =
-    item?.scheme ??
-    (await askSchemeForBuild(execution, { title: "Select scheme to clean", xcworkspace: xcworkspace }));
-  const configuration = await askConfiguration(execution, { xcworkspace: xcworkspace });
+export async function cleanCommand(context: ExtensionContext, item?: BuildTreeItem) {
+  context.updateProgressStatus("Searching for workspace");
+  const xcworkspace = await askXcodeWorkspacePath(context);
 
+  context.updateProgressStatus("Searching for scheme");
+  const scheme =
+    item?.scheme ?? (await askSchemeForBuild(context, { title: "Select scheme to clean", xcworkspace: xcworkspace }));
+
+  context.updateProgressStatus("Searching for configuration");
+  const configuration = await askConfiguration(context, { xcworkspace: xcworkspace });
+
+  context.updateProgressStatus("Extracting build settings");
   const buildSettings = await getBuildSettingsToAskDestination({
     scheme: scheme,
     configuration: configuration,
@@ -859,18 +885,19 @@ export async function cleanCommand(execution: CommandExecution, item?: BuildTree
     xcworkspace: xcworkspace,
   });
 
-  const destination = await askDestinationToRunOn(execution, buildSettings);
+  context.updateProgressStatus("Searching for destination");
+  const destination = await askDestinationToRunOn(context, buildSettings);
   const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 
   const sdk = destination.platform;
 
-  await runTask(execution.context, {
+  await runTask(context, {
     name: "Clean",
     lock: "sweetpad.build",
     terminateLocked: true,
     problemMatchers: DEFAULT_BUILD_PROBLEM_MATCHERS,
     callback: async (terminal) => {
-      await buildApp(execution, terminal, {
+      await buildApp(context, terminal, {
         scheme: scheme,
         sdk: sdk,
         configuration: configuration,
@@ -885,13 +912,18 @@ export async function cleanCommand(execution: CommandExecution, item?: BuildTree
   });
 }
 
-export async function testCommand(execution: CommandExecution, item?: BuildTreeItem) {
-  const xcworkspace = await askXcodeWorkspacePath(execution.context);
-  const scheme =
-    item?.scheme ??
-    (await askSchemeForBuild(execution, { title: "Select scheme to test", xcworkspace: xcworkspace }));
-  const configuration = await askConfiguration(execution, { xcworkspace: xcworkspace });
+export async function testCommand(context: ExtensionContext, item?: BuildTreeItem) {
+  context.updateProgressStatus("Searching for workspace");
+  const xcworkspace = await askXcodeWorkspacePath(context);
 
+  context.updateProgressStatus("Searching for scheme");
+  const scheme =
+    item?.scheme ?? (await askSchemeForBuild(context, { title: "Select scheme to test", xcworkspace: xcworkspace }));
+
+  context.updateProgressStatus("Searching for configuration");
+  const configuration = await askConfiguration(context, { xcworkspace: xcworkspace });
+
+  context.updateProgressStatus("Extracting build settings");
   const buildSettings = await getBuildSettingsToAskDestination({
     scheme: scheme,
     configuration: configuration,
@@ -899,18 +931,19 @@ export async function testCommand(execution: CommandExecution, item?: BuildTreeI
     xcworkspace: xcworkspace,
   });
 
-  const destination = await askDestinationToRunOn(execution, buildSettings);
+  context.updateProgressStatus("Searching for destination");
+  const destination = await askDestinationToRunOn(context, buildSettings);
   const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 
   const sdk = destination.platform;
 
-  await runTask(execution.context, {
+  await runTask(context, {
     name: "Test",
     lock: "sweetpad.build",
     terminateLocked: true,
     problemMatchers: DEFAULT_BUILD_PROBLEM_MATCHERS,
     callback: async (terminal) => {
-      await buildApp(execution, terminal, {
+      await buildApp(context, terminal, {
         scheme: scheme,
         sdk: sdk,
         configuration: configuration,
@@ -926,16 +959,14 @@ export async function testCommand(execution: CommandExecution, item?: BuildTreeI
 }
 
 export async function resolveDependencies(
-  executionContext: ExtensionContext | CommandExecution,
+  context: ExtensionContext,
   options: {
     scheme: string;
     xcworkspace: string;
   },
-) {
-  const context = executionContext instanceof CommandExecution ? executionContext.context : executionContext
-  if (executionContext instanceof CommandExecution) {
-    executionContext.setStatusText("Resolving Dependencies…");
-  }
+): Promise<void> {
+  context.updateProgressStatus("Resolving dependencies");
+
   await runTask(context, {
     name: "Resolve Dependencies",
     lock: "sweetpad.build",
@@ -952,17 +983,19 @@ export async function resolveDependencies(
 /**
  * Resolve dependencies for the Xcode project
  */
-export async function resolveDependenciesCommand(execution: CommandExecution, item?: BuildTreeItem) {
-  const xcworkspace = await askXcodeWorkspacePath(execution.context);
+export async function resolveDependenciesCommand(context: ExtensionContext, item?: BuildTreeItem) {
+  context.updateProgressStatus("Searching for workspace");
+  const xcworkspace = await askXcodeWorkspacePath(context);
 
+  context.updateProgressStatus("Searching for scheme");
   const scheme =
     item?.scheme ??
-    (await askSchemeForBuild(execution, {
+    (await askSchemeForBuild(context, {
       title: "Select scheme to resolve dependencies",
       xcworkspace: xcworkspace,
     }));
 
-  await resolveDependencies(execution, {
+  await resolveDependencies(context, {
     scheme: scheme,
     xcworkspace: xcworkspace,
   });
@@ -973,8 +1006,9 @@ export async function resolveDependenciesCommand(execution: CommandExecution, it
  *
  * Context: we are storing build artifacts in the `build` directory in the storage path for support xcode-build-server.
  */
-export async function removeBundleDirCommand(execution: CommandExecution) {
-  const storagePath = await prepareStoragePath(execution.context);
+export async function removeBundleDirCommand(context: ExtensionContext) {
+  context.updateProgressStatus("Removing build artifacts directory");
+  const storagePath = await prepareStoragePath(context);
   const bundleDir = path.join(storagePath, "build");
 
   await removeDirectory(bundleDir);
@@ -985,45 +1019,48 @@ export async function removeBundleDirCommand(execution: CommandExecution) {
  * Generate buildServer.json in the workspace root for xcode-build-server —
  * a tool that enable LSP server to see packages from the Xcode project.
  */
-export async function generateBuildServerConfigCommand(execution: CommandExecution, item?: BuildTreeItem) {
+export async function generateBuildServerConfigCommand(context: ExtensionContext, item?: BuildTreeItem) {
+  context.updateProgressStatus("Starting buildServer.json generation");
+
   const isServerInstalled = await getIsXcodeBuildServerInstalled();
   if (!isServerInstalled) {
     throw new ExtensionError("xcode-build-server is not installed");
   }
 
-  const xcworkspace = await askXcodeWorkspacePath(execution.context);
+  context.updateProgressStatus("Searching for workspace");
+  const xcworkspace = await askXcodeWorkspacePath(context);
 
+  context.updateProgressStatus("Searching for scheme");
   const scheme =
     item?.scheme ??
-    (await askSchemeForBuild(execution, {
+    (await askSchemeForBuild(context, {
       title: "Select scheme for build server",
       xcworkspace: xcworkspace,
     }));
 
-  execution.setStatusText("Generating…");
+  context.updateProgressStatus("Generating buildServer.json");
   await generateBuildServerConfig({
     xcworkspace: xcworkspace,
     scheme: scheme,
   });
   await restartSwiftLSP();
 
-  const selected = vscode.window
-    .showInformationMessage("buildServer.json generated in workspace root", "Open")
-    .then(selected => {
-      if (selected === "Open") {
-        const workspacePath = getWorkspacePath();
-        const buildServerPath = vscode.Uri.file(path.join(workspacePath, "buildServer.json"));
-        vscode.commands.executeCommand("vscode.open", buildServerPath);
-      }
-    });
+  vscode.window.showInformationMessage("buildServer.json generated in workspace root", "Open").then((selected) => {
+    if (selected === "Open") {
+      const workspacePath = getWorkspacePath();
+      const buildServerPath = vscode.Uri.file(path.join(workspacePath, "buildServer.json"));
+      vscode.commands.executeCommand("vscode.open", buildServerPath);
+    }
+  });
 }
 
 /**
  *
  * Open current project in Xcode
  */
-export async function openXcodeCommand(execution: CommandExecution) {
-  const xcworkspace = await askXcodeWorkspacePath(execution.context);
+export async function openXcodeCommand(context: ExtensionContext) {
+  context.updateProgressStatus("Opening project in Xcode");
+  const xcworkspace = await askXcodeWorkspacePath(context);
 
   await exec({
     command: "open",
@@ -1034,7 +1071,8 @@ export async function openXcodeCommand(execution: CommandExecution) {
 /**
  * Select Xcode workspace and save it to the workspace state
  */
-export async function selectXcodeWorkspaceCommand(execution: CommandExecution) {
+export async function selectXcodeWorkspaceCommand(context: ExtensionContext) {
+  context.updateProgressStatus("Searching for workspace");
   const workspace = await selectXcodeWorkspace({
     autoselect: false,
   });
@@ -1044,22 +1082,25 @@ export async function selectXcodeWorkspaceCommand(execution: CommandExecution) {
   if (updateAnswer) {
     const relative = getWorkspaceRelativePath(workspace);
     await updateWorkspaceConfig("build.xcodeWorkspacePath", relative);
-    execution.context.updateWorkspaceState("build.xcodeWorkspacePath", undefined);
+    context.updateWorkspaceState("build.xcodeWorkspacePath", undefined);
   } else {
-    execution.context.updateWorkspaceState("build.xcodeWorkspacePath", workspace);
+    context.updateWorkspaceState("build.xcodeWorkspacePath", workspace);
   }
 
-  execution.context.buildManager.refresh();
+  context.buildManager.refresh();
 }
 
-export async function selectXcodeSchemeForBuildCommand(execution: CommandExecution, item?: BuildTreeItem) {
+export async function selectXcodeSchemeForBuildCommand(context: ExtensionContext, item?: BuildTreeItem) {
   if (item) {
     item.provider.buildManager.setDefaultSchemeForBuild(item.scheme);
     return;
   }
 
-  const xcworkspace = await askXcodeWorkspacePath(execution.context);
-  await askSchemeForBuild(execution, {
+  context.updateProgressStatus("Searching for workspace");
+  const xcworkspace = await askXcodeWorkspacePath(context);
+
+  context.updateProgressStatus("Searching for scheme");
+  await askSchemeForBuild(context, {
     title: "Select scheme to set as default",
     xcworkspace: xcworkspace,
     ignoreCache: true,
@@ -1069,14 +1110,15 @@ export async function selectXcodeSchemeForBuildCommand(execution: CommandExecuti
 /**
  * Ask user to select configuration for build and save it to the build manager cache
  */
-export async function selectConfigurationForBuildCommand(execution: CommandExecution): Promise<void> {
-  const xcworkspace = await askXcodeWorkspacePath(execution.context);
-  execution.setStatusText("Retrieving configurations…")
+export async function selectConfigurationForBuildCommand(context: ExtensionContext): Promise<void> {
+  context.updateProgressStatus("Searching for workspace");
+  const xcworkspace = await askXcodeWorkspacePath(context);
+
+  context.updateProgressStatus("Searching for configurations");
   const configurations = await getBuildConfigurations({
     xcworkspace: xcworkspace,
   });
 
-  execution.setStatusText("")
   let selected: string | undefined;
   if (configurations.length === 0) {
     selected = await showInputBox({
@@ -1096,14 +1138,14 @@ export async function selectConfigurationForBuildCommand(execution: CommandExecu
   });
   if (saveAnswer) {
     await updateWorkspaceConfig("build.configuration", selected);
-    execution.context.buildManager.setDefaultConfigurationForBuild(undefined);
+    context.buildManager.setDefaultConfigurationForBuild(undefined);
   } else {
-    execution.context.buildManager.setDefaultConfigurationForBuild(selected);
+    context.buildManager.setDefaultConfigurationForBuild(selected);
   }
 }
 
-export async function diagnoseBuildSetupCommand(execution: CommandExecution): Promise<void> {
-  const context = execution.context;
+export async function diagnoseBuildSetupCommand(context: ExtensionContext): Promise<void> {
+  context.updateProgressStatus("Diagnosing build setup");
 
   await runTask(context, {
     name: "Diagnose Build Setup",

--- a/src/build/commands.ts
+++ b/src/build/commands.ts
@@ -672,7 +672,7 @@ async function commonLaunchCommand(
   context.updateProgressStatus("Searching for configuration");
   const configuration = await askConfiguration(context, { xcworkspace: xcworkspace });
 
-  context.updateProgressStatus("Searching for destination");
+  context.updateProgressStatus("Extracting build settings");
   const buildSettings = await getBuildSettingsToAskDestination({
     scheme: scheme,
     configuration: configuration,
@@ -792,7 +792,7 @@ async function commonRunCommand(
   context.updateProgressStatus("Searching for configuration");
   const configuration = await askConfiguration(context, { xcworkspace: xcworkspace });
 
-  context.updateProgressStatus("Searching for destination");
+  context.updateProgressStatus("Extracting build settings");
   const buildSettings = await getBuildSettingsToAskDestination({
     scheme: scheme,
     configuration: configuration,

--- a/src/build/manager.ts
+++ b/src/build/manager.ts
@@ -53,6 +53,7 @@ export class BuildManager {
     const scheme = await getSchemes({
       xcworkspace: xcworkspace,
     });
+
     this.cache = scheme;
     this.emitter.emit("updated");
     return this.cache;

--- a/src/build/provider.ts
+++ b/src/build/provider.ts
@@ -139,7 +139,7 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
-    this.context.updateProgressStatus("Searching for destination");
+    this.context.updateProgressStatus("Extracting build settings");
     const buildSettings = await getBuildSettingsToAskDestination({
       scheme: scheme,
       configuration: configuration,
@@ -246,7 +246,7 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
-    this.context.updateProgressStatus("Searching for configuration");
+    this.context.updateProgressStatus("Extracting build settings");
     const buildSettings = await getBuildSettingsToAskDestination({
       scheme: scheme,
       configuration: configuration,
@@ -306,7 +306,7 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
-    this.context.updateProgressStatus("Searching for configuration");
+    this.context.updateProgressStatus("Extracting build settings");
     const buildSettings = await getBuildSettingsToAskDestination({
       scheme: scheme,
       configuration: configuration,
@@ -391,7 +391,7 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
-    this.context.updateProgressStatus("Searching for configuration");
+    this.context.updateProgressStatus("Searching for build settings");
     const buildSettings = await getBuildSettingsToAskDestination({
       scheme: scheme,
       configuration: configuration,
@@ -437,7 +437,7 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
-    this.context.updateProgressStatus("Searching for configuration");
+    this.context.updateProgressStatus("Extracting build settings");
     const buildSettings = await getBuildSettingsToAskDestination({
       scheme: scheme,
       configuration: configuration,

--- a/src/build/provider.ts
+++ b/src/build/provider.ts
@@ -1,13 +1,15 @@
 import * as vscode from "vscode";
 import { type XcodeBuildSettings, getBuildSettingsToAskDestination } from "../common/cli/scripts";
-import type { ExtensionContext } from "../common/commands";
+import { type ExtensionContext, TaskExecutionScope } from "../common/commands";
 import { getWorkspaceConfig } from "../common/config";
+import { errorReporting } from "../common/error-reporting";
 import {
   type TaskTerminal,
   TaskTerminalV1,
   TaskTerminalV1Parent,
   TaskTerminalV2,
   getTaskExecutorName,
+  setTaskPresentationOptions,
 } from "../common/tasks";
 import { assertUnreachable } from "../common/types";
 import type { Destination } from "../destination/types";
@@ -119,7 +121,10 @@ class ActionDispatcher {
   }
 
   private async commonLaunchCallback(terminal: TaskTerminal, definition: TaskDefinition, options: { debug: boolean }) {
+    this.context.updateProgressStatus("Searching for workspace");
     const xcworkspace = await askXcodeWorkspacePath(this.context);
+
+    this.context.updateProgressStatus("Searching for scheme");
     const scheme =
       definition.scheme ??
       (await askSchemeForBuild(this.context, {
@@ -127,12 +132,14 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
+    this.context.updateProgressStatus("Searching for configuration");
     const configuration =
       definition.configuration ??
       (await askConfiguration(this.context, {
         xcworkspace: xcworkspace,
       }));
 
+    this.context.updateProgressStatus("Searching for destination");
     const buildSettings = await getBuildSettingsToAskDestination({
       scheme: scheme,
       configuration: configuration,
@@ -140,6 +147,7 @@ class ActionDispatcher {
       xcworkspace: xcworkspace,
     });
 
+    this.context.updateProgressStatus("Searching for destination");
     const destination = await this.getDestination({
       definition: definition,
       buildSettings: buildSettings,
@@ -223,7 +231,10 @@ class ActionDispatcher {
   }
 
   private async commonBuildCallback(terminal: TaskTerminal, definition: TaskDefinition, options: { debug: boolean }) {
+    this.context.updateProgressStatus("Searching for workspace");
     const xcworkspace = await askXcodeWorkspacePath(this.context);
+
+    this.context.updateProgressStatus("Searching for scheme");
     const scheme =
       definition.scheme ??
       (await askSchemeForBuild(this.context, {
@@ -235,6 +246,7 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
+    this.context.updateProgressStatus("Searching for configuration");
     const buildSettings = await getBuildSettingsToAskDestination({
       scheme: scheme,
       configuration: configuration,
@@ -242,6 +254,7 @@ class ActionDispatcher {
       xcworkspace: xcworkspace,
     });
 
+    this.context.updateProgressStatus("Searching for destination");
     const destination = await this.getDestination({
       definition: definition,
       buildSettings: buildSettings,
@@ -276,18 +289,24 @@ class ActionDispatcher {
   }
 
   private async commonRunCallback(terminal: TaskTerminal, definition: TaskDefinition, options: { debug: boolean }) {
+    this.context.updateProgressStatus("Searching for workspace");
     const xcworkspace = await askXcodeWorkspacePath(this.context);
+
+    this.context.updateProgressStatus("Searching for scheme");
     const scheme =
       definition.scheme ??
       (await askSchemeForBuild(this.context, {
         xcworkspace: xcworkspace,
       }));
+
+    this.context.updateProgressStatus("Searching for configuration");
     const configuration =
       definition.configuration ??
       (await askConfiguration(this.context, {
         xcworkspace: xcworkspace,
       }));
 
+    this.context.updateProgressStatus("Searching for configuration");
     const buildSettings = await getBuildSettingsToAskDestination({
       scheme: scheme,
       configuration: configuration,
@@ -295,6 +314,7 @@ class ActionDispatcher {
       xcworkspace: xcworkspace,
     });
 
+    this.context.updateProgressStatus("Searching for destination");
     const destination = await this.getDestination({
       definition: definition,
       buildSettings: buildSettings,
@@ -354,19 +374,24 @@ class ActionDispatcher {
   }
 
   private async cleanCallback(terminal: TaskTerminal, definition: TaskDefinition) {
+    this.context.updateProgressStatus("Searching for workspace");
     const xcworkspace = await askXcodeWorkspacePath(this.context);
 
+    this.context.updateProgressStatus("Searching for scheme");
     const scheme =
       definition.scheme ??
       (await askSchemeForBuild(this.context, {
         xcworkspace: xcworkspace,
       }));
+
+    this.context.updateProgressStatus("Searching for configuration");
     const configuration =
       definition.configuration ??
       (await askConfiguration(this.context, {
         xcworkspace: xcworkspace,
       }));
 
+    this.context.updateProgressStatus("Searching for configuration");
     const buildSettings = await getBuildSettingsToAskDestination({
       scheme: scheme,
       configuration: configuration,
@@ -374,6 +399,7 @@ class ActionDispatcher {
       xcworkspace: xcworkspace,
     });
 
+    this.context.updateProgressStatus("Searching for destination");
     const destination = await this.getDestination({
       definition: definition,
       buildSettings: buildSettings,
@@ -396,7 +422,10 @@ class ActionDispatcher {
   }
 
   private async testCallback(terminal: TaskTerminal, definition: TaskDefinition) {
+    this.context.updateProgressStatus("Searching for workspace");
     const xcworkspace = await askXcodeWorkspacePath(this.context);
+
+    this.context.updateProgressStatus("Searching for scheme");
     const scheme =
       definition.scheme ??
       (await askSchemeForBuild(this.context, {
@@ -408,6 +437,7 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
+    this.context.updateProgressStatus("Searching for configuration");
     const buildSettings = await getBuildSettingsToAskDestination({
       scheme: scheme,
       configuration: configuration,
@@ -415,6 +445,7 @@ class ActionDispatcher {
       xcworkspace: xcworkspace,
     });
 
+    this.context.updateProgressStatus("Searching for destination");
     const destination = await this.getDestination({
       definition: definition,
       buildSettings: buildSettings,
@@ -437,7 +468,10 @@ class ActionDispatcher {
   }
 
   private async resolveDependenciesCallback(terminal: TaskTerminal, definition: TaskDefinition) {
+    this.context.updateProgressStatus("Searching for workspace");
     const xcworkspacePath = definition.workspace ?? (await askXcodeWorkspacePath(this.context));
+
+    this.context.updateProgressStatus("Searching for scheme");
     const scheme =
       definition.scheme ??
       (await askSchemeForBuild(this.context, {
@@ -535,6 +569,15 @@ export class XcodeBuildTaskProvider implements vscode.TaskProvider {
     ];
   }
 
+  async dispatchTask(terminal: TaskTerminal, definition: TaskDefinition): Promise<void> {
+    const taskScope = new TaskExecutionScope({ action: definition.action });
+    return await errorReporting.withScope(async () => {
+      return await this.context.startExecutionScope(taskScope, async () => {
+        await this.dispathcer.do(terminal, definition);
+      });
+    });
+  }
+
   private getTask(options: {
     name: string;
     details?: string;
@@ -562,7 +605,7 @@ export class XcodeBuildTaskProvider implements vscode.TaskProvider {
               name: options.name,
               source: "sweetpad",
             });
-            await this.dispathcer.do(terminal, _defition);
+            await this.dispatchTask(terminal, _defition);
 
             // create a dummy terminal to show the task in the terminal panel
             return new TaskTerminalV1Parent();
@@ -573,7 +616,7 @@ export class XcodeBuildTaskProvider implements vscode.TaskProvider {
             // in the current terminal.
             return new TaskTerminalV2(this.context, {
               callback: async (terminal) => {
-                await this.dispathcer.do(terminal, _defition);
+                await this.dispatchTask(terminal, _defition);
               },
             });
           }
@@ -583,6 +626,7 @@ export class XcodeBuildTaskProvider implements vscode.TaskProvider {
       }),
       DEFAULT_BUILD_PROBLEM_MATCHERS, // problemMatchers
     );
+    setTaskPresentationOptions(task);
 
     if (options.isBackground) {
       task.isBackground = true;

--- a/src/build/provider.ts
+++ b/src/build/provider.ts
@@ -240,6 +240,8 @@ class ActionDispatcher {
       (await askSchemeForBuild(this.context, {
         xcworkspace: xcworkspace,
       }));
+
+    this.context.updateProgressStatus("Searching for configuration");
     const configuration =
       definition.configuration ??
       (await askConfiguration(this.context, {

--- a/src/build/status-bar.ts
+++ b/src/build/status-bar.ts
@@ -7,7 +7,9 @@ export class DefaultSchemeStatusBar {
 
   constructor(options: { context: ExtensionContext }) {
     this.context = options.context;
-    this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+    const itemId = "sweetpad.build.statusBar";
+    this.item = vscode.window.createStatusBarItem(itemId, vscode.StatusBarAlignment.Left, 0);
+    this.item.name = "SweetPad: Current Scheme";
     this.item.command = "sweetpad.build.setDefaultScheme";
     this.item.tooltip = "Select the default Xcode scheme for building";
     void this.update();

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -4,7 +4,7 @@ import { type QuickPickItem, showQuickPick } from "../common/quick-pick";
 
 import { askConfigurationBase } from "../common/askers";
 import { type XcodeBuildSettings, getSchemes } from "../common/cli/scripts";
-import { CommandExecution, ExtensionContext } from "../common/commands";
+import type { ExtensionContext } from "../common/commands";
 import { getWorkspaceConfig } from "../common/config";
 import { ExtensionError } from "../common/errors";
 import { createDirectory, findFilesRecursive, isFileExists, removeDirectory } from "../common/files";
@@ -65,18 +65,13 @@ export async function askSimulator(
  * Ask user to select simulator or device to run on
  */
 export async function askDestinationToRunOn(
-  executionContext: ExtensionContext | CommandExecution,
+  context: ExtensionContext,
   buildSettings: XcodeBuildSettings | null,
 ): Promise<Destination> {
-  const context = executionContext instanceof ExtensionContext ? executionContext : executionContext.context;
-
-  if (executionContext instanceof CommandExecution) {
-    executionContext.setStatusText("Retrieving destinations…");
-  }
-  
   // We can remove platforms that are not supported by the project
   const supportedPlatforms = buildSettings?.supportedPlatforms;
 
+  context.updateProgressStatus("Searching for destinations");
   const destinations = await context.destinationsManager.getDestinations({
     mostUsedSort: true,
   });
@@ -181,18 +176,14 @@ export async function getDestinationById(
  * Ask user to select scheme to build
  */
 export async function askSchemeForBuild(
-  executionContext: ExtensionContext | CommandExecution,
+  context: ExtensionContext,
   options: {
     title?: string;
     xcworkspace: string;
     ignoreCache?: boolean;
   },
 ): Promise<string> {
-  const context = executionContext instanceof ExtensionContext ? executionContext : executionContext.context;
-
-  if (executionContext instanceof CommandExecution) {
-    executionContext.setStatusText("Retrieving scheme…");
-  }
+  context.updateProgressStatus("Searching for scheme");
 
   const cachedScheme = context.buildManager.getDefaultSchemeForBuild();
   if (cachedScheme && !options.ignoreCache) {
@@ -314,16 +305,12 @@ export async function askXcodeWorkspacePath(context: ExtensionContext): Promise<
 }
 
 export async function askConfiguration(
-  executionContext: ExtensionContext | CommandExecution,
+  context: ExtensionContext,
   options: {
     xcworkspace: string;
   },
 ): Promise<string> {
-  const context = executionContext instanceof ExtensionContext ? executionContext : executionContext.context;
-
-  if (executionContext instanceof CommandExecution) {
-    executionContext.setStatusText("Retrieving build configuration…");
-  }
+  context.updateProgressStatus("Searching for build configuration");
 
   const fromConfig = getWorkspaceConfig("build.configuration");
   if (fromConfig) {

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import * as crypto from "node:crypto";
 import * as events from "node:events";
 import * as vscode from "vscode";
 import type { BuildManager } from "../build/manager";

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -1,8 +1,11 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import * as events from "node:events";
 import * as vscode from "vscode";
 import type { BuildManager } from "../build/manager";
 import type { DestinationsManager } from "../destination/manager";
 import type { DestinationType, SelectedDestination } from "../destination/types";
 import type { SwiftFormattingProvider } from "../format/formatter";
+import type { ProgressStatusBar } from "../system/status-bar";
 import type { TestingManager } from "../testing/manager";
 import type { ToolsManager } from "../tools/manager";
 import { addTreeProviderErrorReporting, errorReporting } from "./error-reporting";
@@ -53,6 +56,15 @@ type WorkspaceTypes = {
 type WorkspaceStateKey = keyof WorkspaceTypes;
 type SessionStateKey = "NONE_KEY";
 
+/**
+ * Global events that extension can emit
+ */
+type IEventMap = {
+  executionScopeClosed: [scope: ExecutionScope];
+  workspaceConfigChanged: [];
+};
+type IEventKey = keyof IEventMap;
+
 export class ExtensionContext {
   private _context: vscode.ExtensionContext;
   public destinationsManager: DestinationsManager;
@@ -60,7 +72,13 @@ export class ExtensionContext {
   public buildManager: BuildManager;
   public testingManager: TestingManager;
   public formatter: SwiftFormattingProvider;
+  public progressStatusBar: ProgressStatusBar;
   private _sessionState: Map<SessionStateKey, unknown> = new Map();
+
+  // Create for each command and task execution separate execution scope with unique ID
+  // to be able to track what is currently running
+  private executionScope = new AsyncLocalStorage<ExecutionScope | undefined>();
+  private emitter = new events.EventEmitter<IEventMap>();
 
   constructor(options: {
     context: vscode.ExtensionContext;
@@ -69,6 +87,7 @@ export class ExtensionContext {
     toolsManager: ToolsManager;
     testingManager: TestingManager;
     formatter: SwiftFormattingProvider;
+    progressStatusBar: ProgressStatusBar;
   }) {
     this._context = options.context;
     this.destinationsManager = options.destinationsManager;
@@ -76,6 +95,14 @@ export class ExtensionContext {
     this.toolsManager = options.toolsManager;
     this.testingManager = options.testingManager;
     this.formatter = options.formatter;
+    this.progressStatusBar = options.progressStatusBar;
+
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      const affected = event.affectsConfiguration("sweetpad");
+      if (affected) {
+        this.emitter.emit("workspaceConfigChanged");
+      }
+    });
   }
 
   get storageUri() {
@@ -90,11 +117,119 @@ export class ExtensionContext {
     this._context.subscriptions.push(disposable);
   }
 
-  registerCommand(command: string, name: string, callback: (context: CommandExecution, ...args: any[]) => Promise<unknown>) {
-    return vscode.commands.registerCommand(command, (...args: any[]) => {
-      const execution = new CommandExecution(command, name, callback, this);
-      return execution.run(...args);
+  /**
+   * In case if you need to start propage execution scope manually you can use this method
+   */
+  setExecutionScope<T>(scope: ExecutionScope | undefined, callback: () => Promise<T>): Promise<T> {
+    return this.executionScope.run(scope, callback);
+  }
+
+  getExecutionScope(): ExecutionScope | undefined {
+    return this.executionScope.getStore();
+  }
+
+  getExecutionScopeId(): string | undefined {
+    return this.getExecutionScope()?.id;
+  }
+
+  /**
+   * Main method to start execution scope for command or task or other isolated execution context
+   */
+  startExecutionScope<T>(scope: ExecutionScope, callback: () => Promise<T>): Promise<T> {
+    return this.executionScope.run(scope, async () => {
+      try {
+        return await callback();
+      } finally {
+        this.emitter.emit("executionScopeClosed", scope);
+      }
     });
+  }
+
+  on<K extends IEventKey>(event: K, listener: (...args: IEventMap[K]) => void): void {
+    this.emitter.on(event, listener as any); // todo: fix this any
+  }
+
+  registerCommand(commandName: string, callback: (context: ExtensionContext, ...args: any[]) => Promise<unknown>) {
+    return vscode.commands.registerCommand(commandName, async (...args: any[]) => {
+      const commandContext = new CommandExecutionScope({ commandName: commandName });
+
+      return await errorReporting.withScope(async (scope) => {
+        return await this.startExecutionScope(commandContext, async () => {
+          scope.setTag("command", commandName);
+          try {
+            return await callback(this, ...args);
+          } catch (error) {
+            // User can cancel the quick pick dialog by pressing Escape or clicking outside of it.
+            // In this case, we just stop the execution of the command and throw a QuickPickCancelledError.
+            // Since it is more user action, then an error, we skip the error reporting.
+            if (error instanceof QuickPickCancelledError) {
+              return;
+            }
+
+            if (error instanceof ExtensionError) {
+              // Handle default error
+              commonLogger.error(error.message, {
+                command: commandName,
+                errorContext: error.options?.context,
+                error: error,
+              });
+              if (error instanceof TaskError) {
+                return; // do nothing
+              }
+
+              await this.showCommandErrorMessage(`SweetPad: ${error.message}`, {
+                actions: error.options?.actions,
+              });
+              return;
+            }
+
+            // Handle unexpected error
+            const errorMessage: string =
+              error instanceof Error ? error.message : (error?.toString() ?? "[unknown error]");
+            commonLogger.error(errorMessage, {
+              command: commandName,
+              error: error,
+            });
+            errorReporting.captureException(error);
+            await this.showCommandErrorMessage(`SweetPad: ${errorMessage}`);
+          }
+        });
+      });
+    });
+  }
+
+  /**
+   * Show error message with proper actions
+   */
+  async showCommandErrorMessage(
+    message: string,
+    options?: {
+      actions?: ErrorMessageAction[];
+    },
+  ): Promise<void> {
+    const closeAction: ErrorMessageAction = {
+      label: "Close",
+      callback: () => {},
+    };
+    const showLogsAction: ErrorMessageAction = {
+      label: "Show logs",
+      callback: () => commonLogger.show(),
+    };
+
+    const actions = [closeAction];
+    actions.unshift(...(options?.actions ?? [showLogsAction]));
+
+    const actionsLabels = actions.map((action) => action.label);
+
+    const finalMessage = `${message}`;
+    const action = await vscode.window.showErrorMessage(finalMessage, ...actionsLabels);
+
+    if (action) {
+      const callback = actions.find((a) => a.label === action)?.callback;
+      if (callback) {
+        callback();
+      }
+    }
   }
 
   registerTreeDataProvider<T extends vscode.TreeItem>(id: string, tree: vscode.TreeDataProvider<T>) {
@@ -140,124 +275,34 @@ export class ExtensionContext {
     void this.buildManager.refresh();
     void this.destinationsManager.refresh();
   }
-}
 
-/**
- * Class that represents a command execution with proper error handling
- */
-export class CommandExecution {
-
-  private statusBarItem: vscode.StatusBarItem;
-
-  constructor(
-    public readonly command: string,
-    public readonly name: string,
-    public readonly callback: (context: CommandExecution, ...args: unknown[]) => Promise<unknown>,
-    public context: ExtensionContext
-  ) {
-    this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
-  }
-
-  /**
-   * Show error message with proper actions
-   */
-  async showErrorMessage(
-    message: string,
-    options?: {
-      actions?: ErrorMessageAction[];
-    },
-  ): Promise<void> {
-    const closeAction: ErrorMessageAction = {
-      label: "Close",
-      callback: () => {},
-    };
-    const showLogsAction: ErrorMessageAction = {
-      label: "Show logs",
-      callback: () => commonLogger.show(),
-    };
-
-    const actions = [closeAction];
-    actions.unshift(...(options?.actions ?? [showLogsAction]));
-
-    const actionsLabels = actions.map((action) => action.label);
-
-    const finalMessage = `${message}`;
-    const action = await vscode.window.showErrorMessage(finalMessage, ...actionsLabels);
-
-    if (action) {
-      const callback = actions.find((a) => a.label === action)?.callback;
-      if (callback) {
-        callback();
-      }
-    }
-  }
-
-  /**
-   * Run the command with proper error handling. First argument passed to
-   * the callback is this instance itself.
-   */
-  async run(...args: unknown[]) {
-    return await errorReporting.withScope(async (scope) => {
-      scope.setTag("command", this.command);
-      try {
-        this.setupStatusBarItem();
-
-        return await this.callback(this, ...args).finally(() => {
-          this.statusBarItem.dispose();
-        });
-      } catch (error) {
-        if (error instanceof QuickPickCancelledError) {
-          return;
-        }
-
-        if (error instanceof ExtensionError) {
-          // Handle default error
-          commonLogger.error(error.message, {
-            command: this.command,
-            errorContext: error.options?.context,
-            error: error,
-          });
-          if (error instanceof TaskError) {
-            // do nothing
-          } else {
-            await this.showErrorMessage(`SweetPad: ${error.message}`, {
-              actions: error.options?.actions,
-            });
-          }
-        } else {
-          // Handle unexpected error
-          const errorMessage: string =
-            error instanceof Error ? error.message : (error?.toString() ?? "[unknown error]");
-          commonLogger.error(errorMessage, {
-            command: this.command,
-            error: error,
-          });
-          errorReporting.captureException(error);
-          await this.showErrorMessage(`SweetPad: ${errorMessage}`);
-        }
-      }
-    });
-  }
-
-  setStatusText(text: string) {
-    if (text.length > 0) {
-      this.statusBarItem.text = `$(loading~spin) ${this.name} | ${text}`
-    } else {
-      this.statusBarItem.text = `$(loading~spin) ${this.name}`
-    }
-  }
-
-  private setupStatusBarItem() {
-    const commandName = `sweetpad.command.statusOptions.${this.command}.${Date.now()}`;
-    this.statusBarItem.command = commandName;
-
-    // Register the command
-    vscode.commands.registerCommand(commandName, () => {
-      const vscodeWindow = vscode.window;
-      vscodeWindow.terminals[vscodeWindow.terminals.length - 1].show();
-    });
-
-    this.setStatusText("")
-    this.statusBarItem.show();
+  updateProgressStatus(message: string) {
+    this.progressStatusBar.updateText(message);
   }
 }
+
+export class CommandExecutionScope {
+  id: string;
+  type = "command" as const;
+  commandName: string;
+
+  constructor(options: { commandName: string }) {
+    this.id = crypto.randomUUID();
+    this.type = "command";
+    this.commandName = options.commandName;
+  }
+}
+
+export class TaskExecutionScope {
+  id: string;
+  type = "task" as const;
+  taskName: string;
+
+  constructor(options: { action: string }) {
+    this.id = crypto.randomUUID();
+    this.type = "task";
+    this.taskName = options.action;
+  }
+}
+
+export type ExecutionScope = CommandExecutionScope | TaskExecutionScope;

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -252,7 +252,7 @@ export class CommandExecution {
     this.statusBarItem.command = commandName;
 
     // Register the command
-    const commandDisposable = vscode.commands.registerCommand(commandName, () => {
+    vscode.commands.registerCommand(commandName, () => {
       const vscodeWindow = vscode.window;
       vscodeWindow.terminals[vscodeWindow.terminals.length - 1].show();
     });

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -17,6 +17,7 @@ type Config = {
   "system.logLevel": "debug" | "info" | "warn" | "error";
   "system.enableSentry": boolean;
   "system.autoRevealTerminal": boolean;
+  "system.showProgressStatusBar": boolean;
   "xcodegen.autogenerate": boolean;
   "xcodebuildserver.autogenerate": boolean;
   "tuist.autogenerate": boolean;

--- a/src/common/quick-pick.ts
+++ b/src/common/quick-pick.ts
@@ -24,23 +24,27 @@ export async function showQuickPick<T>(options: {
   pick.show();
 
   return new Promise((resolve, reject) => {
+    let isAccepted = false;
     pick.onDidAccept(() => {
       const selected = pick.selectedItems[0];
+      isAccepted = true;
 
+      pick.dispose();
       // I'm not sure if it's possible to select a separator, but just in case and to please the TypeScript checker
       if (!selected || selected?.kind === vscode.QuickPickItemKind.Separator) {
         reject(new Error("No item selected"));
       } else {
         resolve(selected);
       }
-      pick.dispose();
     });
 
     pick.onDidHide(() => {
-      // When the quick pick is cancled by the user (e.g. by pressing Escape), the promise is rejected
-      // with a QuickPickCancelledError to silently cancel the command in which the quick pick was shown.
-      reject(new QuickPickCancelledError());
-      pick.dispose();
+      if (!isAccepted) {
+        // When the quick pick is cancled by the user (e.g. by pressing Escape), the promise is rejected
+        // with a QuickPickCancelledError to silently cancel the command in which the quick pick was shown.
+        reject(new QuickPickCancelledError());
+        pick.dispose();
+      }
     });
   });
 }

--- a/src/common/quick-pick.ts
+++ b/src/common/quick-pick.ts
@@ -40,10 +40,10 @@ export async function showQuickPick<T>(options: {
 
     pick.onDidHide(() => {
       if (!isAccepted) {
+        pick.dispose();
         // When the quick pick is cancled by the user (e.g. by pressing Escape), the promise is rejected
         // with a QuickPickCancelledError to silently cancel the command in which the quick pick was shown.
         reject(new QuickPickCancelledError());
-        pick.dispose();
       }
     });
   });

--- a/src/common/quick-pick.ts
+++ b/src/common/quick-pick.ts
@@ -37,6 +37,8 @@ export async function showQuickPick<T>(options: {
     });
 
     pick.onDidHide(() => {
+      // When the quick pick is cancled by the user (e.g. by pressing Escape), the promise is rejected
+      // with a QuickPickCancelledError to silently cancel the command in which the quick pick was shown.
       reject(new QuickPickCancelledError());
       pick.dispose();
     });

--- a/src/common/tasks.ts
+++ b/src/common/tasks.ts
@@ -77,10 +77,6 @@ export function setTaskPresentationOptions(task: vscode.Task): void {
   task.presentationOptions = {
     // terminal will be revealed, if auto reveal is enabled
     reveal: autoRevealTerminal ? vscode.TaskRevealKind.Always : vscode.TaskRevealKind.Never,
-    // terminal will be focused, if auto reveal is enabled
-    focus: autoRevealTerminal,
-    // terminal will be cleared, if auto reveal is disabled
-    clear: !autoRevealTerminal,
   };
 }
 

--- a/src/debugger/commands.ts
+++ b/src/debugger/commands.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import type { CommandExecution } from "../common/commands";
+import type { ExtensionContext } from "../common/commands";
 import { ExtensionError } from "../common/errors";
 
 const DEBUG_DOCUMENTATION_URL = "https://github.com/sweetpad-dev/sweetpad/blob/main/docs/wiki/debug.md";
@@ -10,8 +10,8 @@ const DEBUG_DOCUMENTATION_URL = "https://github.com/sweetpad-dev/sweetpad/blob/m
  * Now we use "sweetpad-lldb" as the debugger type, which wraps around "lldb" and provides the app path
  * directly to the debugger during resolving the debug configuration.
  */
-export async function getAppPathCommand(execution: CommandExecution): Promise<string> {
-  const lastLaunchedPath = execution.context.getWorkspaceState("build.lastLaunchedApp");
+export async function getAppPathCommand(context: ExtensionContext): Promise<string> {
+  const lastLaunchedPath = context.getWorkspaceState("build.lastLaunchedApp");
   if (!lastLaunchedPath) {
     throw new ExtensionError("No last launched app path found, please launch the app first using the extension", {
       actions: [

--- a/src/destination/commands.ts
+++ b/src/destination/commands.ts
@@ -1,41 +1,47 @@
 import { selectDestinationForBuild } from "../build/utils";
-import type { CommandExecution } from "../common/commands";
+import type { ExtensionContext } from "../common/commands";
 import { selectDestinationForTesting } from "../testing/utils";
 import type { DestinationTreeItem } from "./tree";
 
-export async function selectDestinationForBuildCommand(execution: CommandExecution, item?: DestinationTreeItem) {
+export async function selectDestinationForBuildCommand(context: ExtensionContext, item?: DestinationTreeItem) {
   if (item) {
-    execution.context.destinationsManager.setWorkspaceDestinationForBuild(item.destination);
+    context.destinationsManager.setWorkspaceDestinationForBuild(item.destination);
     return;
   }
-  const destinations = await execution.context.destinationsManager.getDestinations({
+
+  context.updateProgressStatus("Searching for destination");
+  const destinations = await context.destinationsManager.getDestinations({
     mostUsedSort: true,
   });
-  await selectDestinationForBuild(execution.context, {
+
+  await selectDestinationForBuild(context, {
     destinations: destinations,
     supportedPlatforms: undefined, // All platforms
   });
 }
 
-export async function selectDestinationForTestingCommand(execution: CommandExecution, item?: DestinationTreeItem) {
+export async function selectDestinationForTestingCommand(context: ExtensionContext, item?: DestinationTreeItem) {
   if (item) {
-    execution.context.destinationsManager.setWorkspaceDestinationForTesting(item.destination);
+    context.destinationsManager.setWorkspaceDestinationForTesting(item.destination);
     return;
   }
-  const destinations = await execution.context.destinationsManager.getDestinations({
+
+  context.updateProgressStatus("Searching for destination");
+  const destinations = await context.destinationsManager.getDestinations({
     mostUsedSort: true,
   });
-  await selectDestinationForTesting(execution.context, {
+
+  await selectDestinationForTesting(context, {
     destinations: destinations,
     supportedPlatforms: undefined,
   });
 }
 
-export async function removeRecentDestinationCommand(execution: CommandExecution, item?: DestinationTreeItem) {
+export async function removeRecentDestinationCommand(context: ExtensionContext, item?: DestinationTreeItem) {
   if (!item) {
     return;
   }
 
-  const manager = execution.context.destinationsManager;
+  const manager = context.destinationsManager;
   manager.removeRecentDestination(item.destination);
 }

--- a/src/destination/status-bar.ts
+++ b/src/destination/status-bar.ts
@@ -7,7 +7,9 @@ export class DestinationStatusBar {
 
   constructor(options: { context: ExtensionContext }) {
     this.context = options.context;
-    this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+    const itemId = "sweetpad.destinations.statusBar";
+    this.item = vscode.window.createStatusBarItem(itemId, vscode.StatusBarAlignment.Left, 0);
+    this.item.name = "SweetPad: Current Destination";
     this.item.command = "sweetpad.destinations.select";
     this.item.tooltip = "Select destination for debugging";
     void this.update();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,9 +48,11 @@ import { SimulatorsManager } from "./simulators/manager.js";
 import {
   createIssueGenericCommand,
   createIssueNoSchemesCommand,
+  openTerminalPanel,
   resetSweetpadCache,
   testErrorReportingCommand,
 } from "./system/commands.js";
+import { ProgressStatusBar } from "./system/status-bar.js";
 import {
   buildForTestingCommand,
   selectConfigurationForTestingCommand,
@@ -88,8 +90,8 @@ export function activate(context: vscode.ExtensionContext) {
   });
   const toolsManager = new ToolsManager();
   const testingManager = new TestingManager();
-
   const formatter = new SwiftFormattingProvider();
+  const progressStatusBar = new ProgressStatusBar();
 
   // Main context object 🌍
   const _context = new ExtensionContext({
@@ -99,12 +101,14 @@ export function activate(context: vscode.ExtensionContext) {
     toolsManager: toolsManager,
     testingManager: testingManager,
     formatter: formatter,
+    progressStatusBar: progressStatusBar,
   });
   // Here is circular dependency, but I don't care
   buildManager.context = _context;
   devicesManager.context = _context;
   destinationsManager.context = _context;
   testingManager.context = _context;
+  progressStatusBar.context = _context;
 
   // Trees 🎄
   const buildTreeProvider = new BuildTreeProvider({
@@ -134,83 +138,84 @@ export function activate(context: vscode.ExtensionContext) {
   });
   d(schemeStatusBar);
   d(tree("sweetpad.build.view", buildTreeProvider));
-  d(command("sweetpad.build.refreshView", "Refresh View", async () => buildManager.refresh()));
-  d(command("sweetpad.build.launch", "Build & Run", launchCommand));
-  d(command("sweetpad.build.run", "Run", runCommand));
-  d(command("sweetpad.build.build", "Build", buildCommand));
-  d(command("sweetpad.build.clean", "Clean", cleanCommand));
-  d(command("sweetpad.build.test", "Test", testCommand));
-  d(command("sweetpad.build.resolveDependencies", "Resolve Dependencies", resolveDependenciesCommand));
-  d(command("sweetpad.build.removeBundleDir", "Remove Bundle Dir", removeBundleDirCommand));
-  d(command("sweetpad.build.generateBuildServerConfig", "Generate buildServer.json", generateBuildServerConfigCommand));
-  d(command("sweetpad.build.openXcode", "Open Xcode", openXcodeCommand));
-  d(command("sweetpad.build.selectXcodeWorkspace", "Select Xcode Workspace", selectXcodeWorkspaceCommand));
-  d(command("sweetpad.build.setDefaultScheme", "Set Default Scheme", selectXcodeSchemeForBuildCommand));
-  d(command("sweetpad.build.selectConfiguration", "Select Configuration", selectConfigurationForBuildCommand));
-  d(command("sweetpad.build.diagnoseSetup", "Diagnose Setup", diagnoseBuildSetupCommand));
+  d(command("sweetpad.build.refreshView", async () => buildManager.refresh()));
+  d(command("sweetpad.build.launch", launchCommand));
+  d(command("sweetpad.build.run", runCommand));
+  d(command("sweetpad.build.build", buildCommand));
+  d(command("sweetpad.build.clean", cleanCommand));
+  d(command("sweetpad.build.test", testCommand));
+  d(command("sweetpad.build.resolveDependencies", resolveDependenciesCommand));
+  d(command("sweetpad.build.removeBundleDir", removeBundleDirCommand));
+  d(command("sweetpad.build.generateBuildServerConfig", generateBuildServerConfigCommand));
+  d(command("sweetpad.build.openXcode", openXcodeCommand));
+  d(command("sweetpad.build.selectXcodeWorkspace", selectXcodeWorkspaceCommand));
+  d(command("sweetpad.build.setDefaultScheme", selectXcodeSchemeForBuildCommand));
+  d(command("sweetpad.build.selectConfiguration", selectConfigurationForBuildCommand));
+  d(command("sweetpad.build.diagnoseSetup", diagnoseBuildSetupCommand));
 
   // Testing
-  d(command("sweetpad.testing.buildForTesting", "Build for Testing", buildForTestingCommand));
-  d(command("sweetpad.testing.testWithoutBuilding", "Test without Building", testWithoutBuildingCommand));
-  d(command("sweetpad.testing.selectTarget", "Select Target", selectTestingTargetCommand));
-  d(command("sweetpad.testing.setDefaultScheme", "Set Default Scheme", selectXcodeSchemeForTestingCommand));
-  d(command("sweetpad.testing.selectConfiguration", "Select Configuration", selectConfigurationForTestingCommand));
+  d(command("sweetpad.testing.buildForTesting", buildForTestingCommand));
+  d(command("sweetpad.testing.testWithoutBuilding", testWithoutBuildingCommand));
+  d(command("sweetpad.testing.selectTarget", selectTestingTargetCommand));
+  d(command("sweetpad.testing.setDefaultScheme", selectXcodeSchemeForTestingCommand));
+  d(command("sweetpad.testing.selectConfiguration", selectConfigurationForTestingCommand));
 
   // Debugging
   d(registerDebugConfigurationProvider(_context));
-  d(command("sweetpad.debugger.getAppPath", "Get App Path", getAppPathCommand));
-  d(command("sweetpad.debugger.debuggingLaunch", "Debug", debuggingLaunchCommand));
-  d(command("sweetpad.debugger.debuggingRun", "Debug (Run only)", debuggingRunCommand));
-  d(command("sweetpad.debugger.debuggingBuild", "Debug (Build only)", debuggingBuildCommand));
+  d(command("sweetpad.debugger.getAppPath", getAppPathCommand));
+  d(command("sweetpad.debugger.debuggingLaunch", debuggingLaunchCommand));
+  d(command("sweetpad.debugger.debuggingRun", debuggingRunCommand));
+  d(command("sweetpad.debugger.debuggingBuild", debuggingBuildCommand));
 
   // XcodeGen
-  d(command("sweetpad.xcodegen.generate", "Generate project using XcodeGen", xcodgenGenerateCommand));
+  d(command("sweetpad.xcodegen.generate", xcodgenGenerateCommand));
   d(createXcodeGenWatcher(_context));
 
   // Tuist
-  d(command("sweetpad.tuist.generate", "Generate project using Tuist", tuistGenerateCommand));
-  d(command("sweetpad.tuist.install", "Install Swift Package using Tuist", tuistInstallCommand));
-  d(command("sweetpad.tuist.clean", "Clean Tuist project", tuistCleanCommand));
-  d(command("sweetpad.tuist.edit", "Edit Tuist project", tuistEditComnmand));
+  d(command("sweetpad.tuist.generate", tuistGenerateCommand));
+  d(command("sweetpad.tuist.install", tuistInstallCommand));
+  d(command("sweetpad.tuist.clean", tuistCleanCommand));
+  d(command("sweetpad.tuist.edit", tuistEditComnmand));
   d(createTuistWatcher(_context));
 
   // Format
   d(createFormatStatusItem());
   d(registerFormatProvider(formatter));
-  d(command("sweetpad.format.run", "Format", formatCommand));
-  d(command("sweetpad.format.showLogs", "Show Logs", showLogsCommand));
+  d(command("sweetpad.format.run", formatCommand));
+  d(command("sweetpad.format.showLogs", showLogsCommand));
 
   // Simulators
-  d(command("sweetpad.simulators.refresh", "Refresh Simulators", async () => await destinationsManager.refreshSimulators()));
-  d(command("sweetpad.simulators.openSimulator", "Open Simulator", openSimulatorCommand));
-  d(command("sweetpad.simulators.removeCache", "Remove Simulator Cache", removeSimulatorCacheCommand));
-  d(command("sweetpad.simulators.start", "Start Simulator", startSimulatorCommand));
-  d(command("sweetpad.simulators.stop", "Stop Simulator", stopSimulatorCommand));
+  d(command("sweetpad.simulators.refresh", async () => await destinationsManager.refreshSimulators()));
+  d(command("sweetpad.simulators.openSimulator", openSimulatorCommand));
+  d(command("sweetpad.simulators.removeCache", removeSimulatorCacheCommand));
+  d(command("sweetpad.simulators.start", startSimulatorCommand));
+  d(command("sweetpad.simulators.stop", stopSimulatorCommand));
 
   // // Devices
-  d(command("sweetpad.devices.refresh", "Refresh Devices", async () => await destinationsManager.refreshDevices()));
+  d(command("sweetpad.devices.refresh", async () => await destinationsManager.refreshDevices()));
 
   // Desintations
   const destinationBar = new DestinationStatusBar({
     context: _context,
   });
   d(destinationBar);
-  d(command("sweetpad.destinations.select", "Select Destination", selectDestinationForBuildCommand));
-  d(command("sweetpad.destinations.removeRecent", "Remove Recent Destination", removeRecentDestinationCommand));
-  d(command("sweetpad.destinations.selectForTesting", "Select Destination for Testing", selectDestinationForTestingCommand));
+  d(command("sweetpad.destinations.select", selectDestinationForBuildCommand));
+  d(command("sweetpad.destinations.removeRecent", removeRecentDestinationCommand));
+  d(command("sweetpad.destinations.selectForTesting", selectDestinationForTestingCommand));
   d(tree("sweetpad.destinations.view", destinationsTreeProvider));
 
   // Tools
   d(tree("sweetpad.tools.view", toolsTreeProvider));
-  d(command("sweetpad.tools.install", "Install Tool", installToolCommand));
-  d(command("sweetpad.tools.refresh", "Refresh", async () => toolsManager.refresh()));
-  d(command("sweetpad.tools.documentation", "Open Tool Documentation", openDocumentationCommand));
+  d(command("sweetpad.tools.install", installToolCommand));
+  d(command("sweetpad.tools.refresh", async () => toolsManager.refresh()));
+  d(command("sweetpad.tools.documentation", openDocumentationCommand));
 
   // System
-  d(command("sweetpad.system.resetSweetpadCache", "Reset Sweetpad Cache", resetSweetpadCache));
-  d(command("sweetpad.system.createIssue.generic", "Create Issue", createIssueGenericCommand));
-  d(command("sweetpad.system.createIssue.noSchemes", "Create Issue (No Schemes)", createIssueNoSchemesCommand));
-  d(command("sweetpad.system.testErrorReporting", "Test Error Reporting", testErrorReportingCommand));
+  d(command("sweetpad.system.resetSweetpadCache", resetSweetpadCache));
+  d(command("sweetpad.system.createIssue.generic", createIssueGenericCommand));
+  d(command("sweetpad.system.createIssue.noSchemes", createIssueNoSchemesCommand));
+  d(command("sweetpad.system.testErrorReporting", testErrorReportingCommand));
+  d(command("sweetpad.system.openTerminalPanel", openTerminalPanel));
 }
 
 export function deactivate() {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,10 +125,6 @@ export function activate(context: vscode.ExtensionContext) {
 
   const buildTaskProvider = new XcodeBuildTaskProvider(_context);
 
-  // Debug
-  d(registerDebugConfigurationProvider(_context));
-  d(command("sweetpad.debugger.getAppPath", "Get App Path", getAppPathCommand));
-
   // Tasks
   d(vscode.tasks.registerTaskProvider(buildTaskProvider.type, buildTaskProvider));
 
@@ -162,10 +158,10 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Debugging
   d(registerDebugConfigurationProvider(_context));
-  d(command("sweetpad.debugger.getAppPath", getAppPathCommand));
-  d(command("sweetpad.debugger.debuggingLaunch", debuggingLaunchCommand));
-  d(command("sweetpad.debugger.debuggingRun", debuggingRunCommand));
-  d(command("sweetpad.debugger.debuggingBuild", debuggingBuildCommand));
+  d(command("sweetpad.debugger.getAppPath", "Get App Path", getAppPathCommand));
+  d(command("sweetpad.debugger.debuggingLaunch", "Debug", debuggingLaunchCommand));
+  d(command("sweetpad.debugger.debuggingRun", "Debug (Run only)", debuggingRunCommand));
+  d(command("sweetpad.debugger.debuggingBuild", "Debug (Build only)", debuggingBuildCommand));
 
   // XcodeGen
   d(command("sweetpad.xcodegen.generate", "Generate project using XcodeGen", xcodgenGenerateCommand));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,7 +142,7 @@ export function activate(context: vscode.ExtensionContext) {
   d(command("sweetpad.build.test", "Test", testCommand));
   d(command("sweetpad.build.resolveDependencies", "Resolve Dependencies", resolveDependenciesCommand));
   d(command("sweetpad.build.removeBundleDir", "Remove Bundle Dir", removeBundleDirCommand));
-  d(command("sweetpad.build.genereateBuildServerConfig", "Generate buildServer.json", generateBuildServerConfigCommand));
+  d(command("sweetpad.build.generateBuildServerConfig", "Generate buildServer.json", generateBuildServerConfigCommand));
   d(command("sweetpad.build.openXcode", "Open Xcode", openXcodeCommand));
   d(command("sweetpad.build.selectXcodeWorkspace", "Select Xcode Workspace", selectXcodeWorkspaceCommand));
   d(command("sweetpad.build.setDefaultScheme", "Set Default Scheme", selectXcodeSchemeForBuildCommand));

--- a/src/format/commands.ts
+++ b/src/format/commands.ts
@@ -1,18 +1,19 @@
 import * as vscode from "vscode";
-import type { CommandExecution } from "../common/commands.js";
+import type { ExtensionContext } from "../common/commands.js";
 import { formatLogger } from "./logger.js";
 
 /*
  * Format current opened document
  */
-export async function formatCommand(execution: CommandExecution) {
+export async function formatCommand(context: ExtensionContext) {
+  context.updateProgressStatus("Formatting document");
   const editor = vscode.window.activeTextEditor;
   if (!editor) {
     return;
   }
 
   const document = editor.document;
-  await execution.context.formatter.formatDocument(document);
+  await context.formatter.formatDocument(document);
 }
 
 /*

--- a/src/simulators/commands.ts
+++ b/src/simulators/commands.ts
@@ -1,18 +1,19 @@
 import * as vscode from "vscode";
 import { askSimulator } from "../build/utils.js";
-import type { CommandExecution } from "../common/commands.js";
+import type { ExtensionContext } from "../common/commands.js";
 import { runTask } from "../common/tasks.js";
 import type { iOSSimulatorDestinationTreeItem } from "../destination/tree.js";
 
 /**
  * Command to start simulator from the simulator tree view in the sidebar
  */
-export async function startSimulatorCommand(execution: CommandExecution, item?: iOSSimulatorDestinationTreeItem) {
+export async function startSimulatorCommand(context: ExtensionContext, item?: iOSSimulatorDestinationTreeItem) {
   let simulatorUdid: string;
   if (item) {
     simulatorUdid = item.simulator.udid;
   } else {
-    const simulator = await askSimulator(execution.context, {
+    context.updateProgressStatus("Searching for simulator to start");
+    const simulator = await askSimulator(context, {
       title: "Select simulator to start",
       state: "Shutdown",
       error: "No available simulators to start",
@@ -20,7 +21,8 @@ export async function startSimulatorCommand(execution: CommandExecution, item?: 
     simulatorUdid = simulator.udid;
   }
 
-  await runTask(execution.context, {
+  context.updateProgressStatus("Starting simulator");
+  await runTask(context, {
     name: "Start Simulator",
     lock: "sweetpad.simulators",
     terminateLocked: true,
@@ -30,7 +32,7 @@ export async function startSimulatorCommand(execution: CommandExecution, item?: 
         args: ["simctl", "boot", simulatorUdid],
       });
 
-      await execution.context.destinationsManager.refreshSimulators();
+      await context.destinationsManager.refreshSimulators();
     },
   });
 }
@@ -38,12 +40,13 @@ export async function startSimulatorCommand(execution: CommandExecution, item?: 
 /**
  * Command to stop simulator from the simulator tree view in the sidebar
  */
-export async function stopSimulatorCommand(execution: CommandExecution, item?: iOSSimulatorDestinationTreeItem) {
+export async function stopSimulatorCommand(context: ExtensionContext, item?: iOSSimulatorDestinationTreeItem) {
+  context.updateProgressStatus("Searching for simulator to stop");
   let simulatorId: string;
   if (item) {
     simulatorId = item.simulator.udid;
   } else {
-    const simulator = await askSimulator(execution.context, {
+    const simulator = await askSimulator(context, {
       title: "Select simulator to stop",
       state: "Booted",
       error: "No available simulators to stop",
@@ -51,7 +54,8 @@ export async function stopSimulatorCommand(execution: CommandExecution, item?: i
     simulatorId = simulator.udid;
   }
 
-  await runTask(execution.context, {
+  context.updateProgressStatus("Stopping simulator");
+  await runTask(context, {
     name: "Stop Simulator",
     lock: "sweetpad.simulators",
     terminateLocked: true,
@@ -61,7 +65,7 @@ export async function stopSimulatorCommand(execution: CommandExecution, item?: i
         args: ["simctl", "shutdown", simulatorId],
       });
 
-      await execution.context.destinationsManager.refreshSimulators();
+      await context.destinationsManager.refreshSimulators();
     },
   });
 }
@@ -69,8 +73,9 @@ export async function stopSimulatorCommand(execution: CommandExecution, item?: i
 /**
  * Command to delete simulator from top of the simulator tree view in the sidebar
  */
-export async function openSimulatorCommand(execution: CommandExecution) {
-  await runTask(execution.context, {
+export async function openSimulatorCommand(context: ExtensionContext) {
+  context.updateProgressStatus("Opening Simulator.app");
+  await runTask(context, {
     name: "Open Simulator",
     error: "Could not open simulator app",
     lock: "sweetpad.simulators",
@@ -91,8 +96,9 @@ export async function openSimulatorCommand(execution: CommandExecution) {
  * This is useful when you have a lot of simulators and you want to free up some space.
  * Also in some cases it can help to issues with starting simulators.
  */
-export async function removeSimulatorCacheCommand(execution: CommandExecution) {
-  await runTask(execution.context, {
+export async function removeSimulatorCacheCommand(context: ExtensionContext) {
+  context.updateProgressStatus("Removing Simulator cache");
+  await runTask(context, {
     name: "Remove Simulator Cache",
     error: "Error removing simulator cache",
     lock: "sweetpad.build",

--- a/src/system/commands.ts
+++ b/src/system/commands.ts
@@ -1,9 +1,10 @@
 import * as vscode from "vscode";
-import type { CommandExecution } from "../common/commands";
+import type { ExtensionContext } from "../common/commands";
 import { commonLogger } from "../common/logger";
 
-export async function resetSweetpadCache(execution: CommandExecution) {
-  execution.context.resetWorkspaceState();
+export async function resetSweetpadCache(context: ExtensionContext) {
+  context.updateProgressStatus("Resetting SweetPad cache");
+  context.resetWorkspaceState();
   vscode.window.showInformationMessage("SweetPad cache has been reset");
 }
 
@@ -16,7 +17,7 @@ async function createIssue(options: { title: string; body: string; labels: strin
   vscode.env.openExternal(vscode.Uri.parse(url.toString()));
 }
 
-export async function createIssueGenericCommand(execution: CommandExecution) {
+export async function createIssueGenericCommand(context: ExtensionContext) {
   await createIssue({
     title: "SweetPad issue",
     body: "Please describe your issue here",
@@ -39,4 +40,8 @@ export async function testErrorReportingCommand() {
     contextKey: "Context value",
   });
   throw new Error("This is a test error");
+}
+
+export async function openTerminalPanel() {
+  vscode.window.terminals.at(-1)?.show();
 }

--- a/src/system/status-bar.ts
+++ b/src/system/status-bar.ts
@@ -1,0 +1,110 @@
+import * as vscode from "vscode";
+import type { ExtensionContext } from "../common/commands";
+import { getWorkspaceConfig } from "../common/config";
+
+const DEFAULT_SCOPE_ID = "__DEFAULT_SCOPE_ID";
+
+/**
+ * Status bar item for showing what currently sweetpad is doing
+ *
+ * Usually, it's enough to call `update` method with the text you want to show
+ * and if it in the context of a command, it will be automatically removed when
+ * the command is finished. Otherwise, you need to call `remove` method to remove it
+ * from the status bar manually.
+ */
+export class ProgressStatusBar {
+  _context: ExtensionContext | undefined = undefined;
+  statusBar: vscode.StatusBarItem;
+  enabled = true;
+
+  messageMapping: Map<string, string> = new Map();
+
+  constructor() {
+    // Status bar ID allows to separate the different status bar items from the same extension
+    const statusBarId = "sweetpad.system.progressStatusBar";
+    this.statusBar = vscode.window.createStatusBarItem(statusBarId, vscode.StatusBarAlignment.Left, 0);
+    this.statusBar.command = "sweetpad.system.openTerminalPanel";
+    this.statusBar.name = "SweetPad: Command Status";
+  }
+
+  get context(): ExtensionContext {
+    if (!this._context) {
+      throw new Error("Context is not set");
+    }
+    return this._context;
+  }
+
+  set context(context: ExtensionContext) {
+    this._context = context;
+
+    this.updateConfig();
+
+    // Every time a command or task is finished we remove message of the current scope
+    // and update the status bar accordingly
+    context.on("executionScopeClosed", () => {
+      const scopeId = this.context.getExecutionScopeId() ?? DEFAULT_SCOPE_ID;
+      this.messageMapping.delete(scopeId);
+      this.displayBar();
+    });
+
+    context.on("workspaceConfigChanged", () => {
+      this.updateConfig();
+    });
+  }
+
+  updateText(text: string) {
+    const scopeId = this.context.getExecutionScopeId() ?? DEFAULT_SCOPE_ID;
+    this.messageMapping.set(scopeId, text);
+    this.displayBar();
+  }
+
+  updateConfig() {
+    const enabled = getWorkspaceConfig("system.showProgressStatusBar") ?? true;
+    if (this.enabled === enabled) {
+      return; // nothing changed, no need to update
+    }
+
+    this.enabled = enabled;
+    if (enabled) {
+      // user enabled the status bar, show it if there are any messages
+      this.displayBar();
+    } else {
+      // user disabled the status bar, hide it despite the messages
+      this.statusBar.hide();
+    }
+  }
+
+  displayBar() {
+    if (!this.enabled) {
+      return;
+    }
+
+    // No messages to show, hide the status bar for now
+    if (this.messageMapping.size === 0) {
+      this.statusBar.hide();
+      return;
+    }
+
+    this.statusBar.show();
+    // In simplest case, when we have only one message, we can show it directly in the status bar
+    if (this.messageMapping.size === 1) {
+      const text = this.messageMapping.values().next().value;
+      this.statusBar.text = `$(gear~spin) ${text}...`;
+      this.statusBar.tooltip = "Click to open terminal";
+      return;
+    }
+
+    // In cases when we have multiple parallel commands running, we can show the status bar
+    // with the number of commands running and a tooltip with the list of commands
+    // that are running. Not idea, but better than nothing.
+    this.statusBar.text = `$(gear~spin) ${this.messageMapping.size} commands running...`;
+    const tooltip = new vscode.MarkdownString(
+      `Active commands:\n${Array.from(this.messageMapping.values())
+        .map((text) => `- ${text}...`)
+        .join("\n")}\n`,
+    );
+    tooltip.isTrusted = true;
+    this.statusBar.tooltip = tooltip;
+    return;
+  }
+}

--- a/src/system/status-bar.ts
+++ b/src/system/status-bar.ts
@@ -27,6 +27,11 @@ export class ProgressStatusBar {
     this.statusBar.name = "SweetPad: Command Status";
   }
 
+  dispose() {
+    this.statusBar.dispose();
+    this.messageMapping.clear();
+  }
+
   get context(): ExtensionContext {
     if (!this._context) {
       throw new Error("Context is not set");
@@ -41,8 +46,8 @@ export class ProgressStatusBar {
 
     // Every time a command or task is finished we remove message of the current scope
     // and update the status bar accordingly
-    context.on("executionScopeClosed", () => {
-      const scopeId = this.context.getExecutionScopeId() ?? DEFAULT_SCOPE_ID;
+    context.on("executionScopeClosed", (scope) => {
+      const scopeId = scope.id ?? DEFAULT_SCOPE_ID;
       this.messageMapping.delete(scopeId);
       this.displayBar();
     });

--- a/src/testing/commands.ts
+++ b/src/testing/commands.ts
@@ -27,7 +27,7 @@ export async function testWithoutBuildingCommand(
 ): Promise<void> {
   const request = new vscode.TestRunRequest(items, [], undefined, undefined);
   const tokenSource = new vscode.CancellationTokenSource();
-  execution.context.testingManager.runTestsWithoutBuilding(request, tokenSource.token);
+  await execution.context.testingManager.runTestsWithoutBuilding(request, tokenSource.token, execution);
 }
 
 export async function selectXcodeSchemeForTestingCommand(execution: CommandExecution, item?: BuildTreeItem) {

--- a/src/testing/manager.ts
+++ b/src/testing/manager.ts
@@ -726,13 +726,21 @@ export class TestingManager {
    * Run selected tests without building the project
    * This is faster but you may need to build manually before running tests
    */
-  async runTestsWithoutBuilding(request: vscode.TestRunRequest, token: vscode.CancellationToken) {
+  async runTestsWithoutBuilding(
+    request: vscode.TestRunRequest, 
+    token: vscode.CancellationToken, 
+    execution?: CommandExecution
+  ) {
     const run = this.controller.createTestRun(request);
     try {
-      const { scheme, destination, xcworkspace } = await this.askTestingConfigurations();
+      const { scheme, destination, xcworkspace } = await this.askTestingConfigurations(execution);
 
       // todo: add check if project is already built
 
+      if (execution) {
+        execution.setStatusText("Testing…");
+      }
+      
       await this.runTests({
         run: run,
         request: request,

--- a/src/testing/utils.ts
+++ b/src/testing/utils.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { askConfigurationBase } from "../common/askers";
 import { type XcodeBuildSettings, getSchemes, getTargets } from "../common/cli/scripts";
-import { CommandExecution, ExtensionContext } from "../common/commands";
+import type { ExtensionContext } from "../common/commands";
 import { getWorkspaceConfig } from "../common/config";
 import { type QuickPickItem, showQuickPick } from "../common/quick-pick";
 import type { DestinationPlatform } from "../destination/constants";
@@ -184,24 +184,19 @@ export async function selectDestinationForTesting(
  * Ask user to select scheme to build
  */
 export async function askSchemeForTesting(
-  execution: ExtensionContext | CommandExecution,
+  context: ExtensionContext,
   options: {
     title?: string;
     xcworkspace: string;
     ignoreCache?: boolean;
   },
 ): Promise<string> {
-  const context = execution instanceof CommandExecution ? execution.context : execution;
-
-  if (execution instanceof CommandExecution) {
-    execution.setStatusText("Retrieving scheme…");
-  }
-
   const cachedScheme = context.buildManager.getDefaultSchemeForTesting();
   if (cachedScheme && !options.ignoreCache) {
     return cachedScheme;
   }
 
+  context.updateProgressStatus("Searching for scheme");
   const schemes = await getSchemes({
     xcworkspace: options.xcworkspace,
   });

--- a/src/tools/commands.ts
+++ b/src/tools/commands.ts
@@ -1,16 +1,17 @@
 import * as vscode from "vscode";
-import type { CommandExecution } from "../common/commands.js";
+import type { ExtensionContext } from "../common/commands.js";
 import { runTask } from "../common/tasks.js";
 import type { ToolTreeItem } from "./tree.js";
 import { askTool } from "./utils.js";
 
 /**
- * Comamnd to install tool from the tool tree view in the sidebar using brew
+ * Command to install tool from the tool tree view in the sidebar using brew
  */
-export async function installToolCommand(execution: CommandExecution, item?: ToolTreeItem) {
+export async function installToolCommand(context: ExtensionContext, item?: ToolTreeItem) {
   const tool = item?.tool ?? (await askTool({ title: "Select tool to install" }));
 
-  await runTask(execution.context, {
+  context.updateProgressStatus("Installing tool");
+  await runTask(context, {
     name: "Install Tool",
     error: "Error installing tool",
     terminateLocked: false,
@@ -26,7 +27,7 @@ export async function installToolCommand(execution: CommandExecution, item?: Too
         },
       });
 
-      execution.context.toolsManager.refresh();
+      context.toolsManager.refresh();
     },
   });
 }
@@ -34,7 +35,7 @@ export async function installToolCommand(execution: CommandExecution, item?: Too
 /**
  * Command to open documentation in the browser from the tool tree view in the sidebar
  */
-export async function openDocumentationCommand(execution: CommandExecution, item?: ToolTreeItem) {
+export async function openDocumentationCommand(context: ExtensionContext, item?: ToolTreeItem) {
   const tool = item?.tool ?? (await askTool({ title: "Select tool to open documentation" }));
   await vscode.env.openExternal(vscode.Uri.parse(tool.documentation));
 }

--- a/src/tuist/command.ts
+++ b/src/tuist/command.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { restartSwiftLSP } from "../build/utils";
 import { getIsTuistInstalled, tuistClean, tuistEdit, tuistGenerate, tuistInstall } from "../common/cli/scripts";
+import type { ExtensionContext } from "../common/commands";
 import { ExtensionError } from "../common/errors";
 
 async function tuistCheckInstalled() {
@@ -10,7 +11,8 @@ async function tuistCheckInstalled() {
   }
 }
 
-export async function tuistGenerateCommand() {
+export async function tuistGenerateCommand(context: ExtensionContext) {
+  context.updateProgressStatus("Running 'tuist generate'");
   await tuistCheckInstalled();
 
   const raw = await tuistGenerate();
@@ -24,7 +26,8 @@ export async function tuistGenerateCommand() {
   vscode.window.showInformationMessage("The Xcode project was successfully generated using Tuist.");
 }
 
-export async function tuistInstallCommand() {
+export async function tuistInstallCommand(context: ExtensionContext) {
+  context.updateProgressStatus("Running 'tuist install'");
   await tuistCheckInstalled();
 
   await tuistInstall();
@@ -34,7 +37,8 @@ export async function tuistInstallCommand() {
   vscode.window.showInformationMessage("The Swift Package was successfully installed using Tuist.");
 }
 
-export async function tuistCleanCommand() {
+export async function tuistCleanCommand(context: ExtensionContext) {
+  context.updateProgressStatus("Running 'tuist clean'");
   await tuistCheckInstalled();
 
   await tuistClean();
@@ -42,7 +46,8 @@ export async function tuistCleanCommand() {
   vscode.window.showInformationMessage("Tuist cleaned.");
 }
 
-export async function tuistEditComnmand() {
+export async function tuistEditComnmand(context: ExtensionContext) {
+  context.updateProgressStatus("Running 'tuist edit'");
   await tuistCheckInstalled();
 
   await tuistEdit();

--- a/src/tuist/watcher.ts
+++ b/src/tuist/watcher.ts
@@ -70,7 +70,7 @@ class TuistGenWatcher {
 
     this.throttle = setTimeout(() => {
       this.throttle = null;
-      tuistGenerateCommand()
+      tuistGenerateCommand(this.extension)
         .then(() => {
           commonLogger.log("tuist project was successfully generated", {
             workspacePath: this.workspacePath,

--- a/src/xcodegen/commands.ts
+++ b/src/xcodegen/commands.ts
@@ -1,13 +1,16 @@
 import * as vscode from "vscode";
 import { restartSwiftLSP } from "../build/utils";
 import { generateXcodeGen, getIsXcodeGenInstalled } from "../common/cli/scripts";
+import type { ExtensionContext } from "../common/commands";
 import { ExtensionError } from "../common/errors";
 
-export async function xcodgenGenerateCommand() {
+export async function xcodgenGenerateCommand(context: ExtensionContext): Promise<void> {
   const isServerInstalled = await getIsXcodeGenInstalled();
   if (!isServerInstalled) {
     throw new ExtensionError("XcodeGen is not installed");
   }
+
+  context.updateProgressStatus("Running XcodeGen");
   await generateXcodeGen();
 
   // Restart LSP to catch changes

--- a/src/xcodegen/watcher.ts
+++ b/src/xcodegen/watcher.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
-import { Disposable } from "vscode";
 import * as vscode from "vscode";
+import { Disposable } from "vscode";
 import { getWorkspacePath } from "../build/utils";
 import type { ExtensionContext } from "../common/commands";
 import { getWorkspaceConfig } from "../common/config";
@@ -63,7 +63,7 @@ class XcodeGenWatcher {
 
     this.throttle = setTimeout(() => {
       this.throttle = null;
-      xcodgenGenerateCommand()
+      xcodgenGenerateCommand(this.extension)
         .then(() => {
           commonLogger.log("XcodeGen project was successfully generated", {
             workspacePath: this.workspacePath,


### PR DESCRIPTION
The main goal of these changes is to better communicate the current state of sweetpad and especially builds to the user, which can be hard to understand right now. The changes here are twofold:

1) Each command create a statusBarItem to inform the user about the current task and progress of the command
2) A new option was added to disable auto reveal of the terminal when running build commands

Two very common scenarios where this PR improves the workflow are:

a) The user runs a build for the first time and we need to fetch the schemes and destinations, which can take considerable time on larger projects. So far, it appeared to the user as if the command doesn't do anything, since this is done silently in the background. Now, the user will get proper progress reports in the status bar
b) You Launch the app and want to know if the pipeline is still building, installing or already running. So far you had to check terminal output, now this can be seen easily on the vs code status bar

The auto-reveal option was added for users (such as me) who do not regularly require to inspect the app logs. For example, a lot of times my workflow is just changing code, then launching the app to check my changes. I do not require the terminal at all here. The new option to prevent auto-reveal of the terminal + the information I get from the statusbar are now enough to support such workflows.

Disclaimer: I am neither very familiar with TypeScript nor the VS Code API. I'm happy for any suggestions for this PR. I mainly wrote this for myself but I think this can really benefit others as well.