### PR TITLE
Add support for range formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -711,6 +711,23 @@
           ],
           "description": "Command or path to formatter executable. Use ${file} as a placeholder for the file path. Placeholder ${file} is supported only as a separate item in the array."
         },
+        "sweetpad.format.selectionArgs": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "default": null,
+          "examples": [
+            [
+              "--linerange",
+              "${startLine}, ${endLine}"
+            ]
+          ],
+          "description": "Custom arguments to pass to the formatter for selection formatting. Use ${startLine} and ${endLine} as placeholders for the start and end line numbers of the selected code. Use ${startOffset} and ${endOffset} as placeholders for the start and end offset of the selected code. If this is not provided for custom formatters, the entire document will always be reformatted."
+        },
         "sweetpad.build.xcbeautifyEnabled": {
           "type": "boolean",
           "default": true,

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 type Config = {
   "format.path": string;
   "format.args": string[] | null;
+  "format.selectionArgs": string[] | null;
   "build.xcbeautifyEnabled": boolean;
   "build.xcodeWorkspacePath": string;
   "build.derivedDataPath": string;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,7 +36,7 @@ import { DestinationStatusBar } from "./destination/status-bar.js";
 import { DestinationsTreeProvider } from "./destination/tree.js";
 import { DevicesManager } from "./devices/manager.js";
 import { formatCommand, showLogsCommand } from "./format/commands.js";
-import { SwiftFormattingProvider, registerFormatProvider } from "./format/formatter.js";
+import { SwiftFormattingProvider, registerFormatProvider, registerRangeFormatProvider } from "./format/formatter.js";
 import { createFormatStatusItem } from "./format/status.js";
 import {
   openSimulatorCommand,
@@ -181,6 +181,7 @@ export function activate(context: vscode.ExtensionContext) {
   // Format
   d(createFormatStatusItem());
   d(registerFormatProvider(formatter));
+  d(registerRangeFormatProvider(formatter));
   d(command("sweetpad.format.run", formatCommand));
   d(command("sweetpad.format.showLogs", showLogsCommand));
 

--- a/src/format/formatter.ts
+++ b/src/format/formatter.ts
@@ -14,7 +14,16 @@ export function registerFormatProvider(formatter: SwiftFormattingProvider): vsco
   return vscode.languages.registerDocumentFormattingEditProvider("swift", formatter);
 }
 
-export class SwiftFormattingProvider implements vscode.DocumentFormattingEditProvider {
+/**
+ * Register swiftpad as range formatter for Swift documents, enabling the
+ * "Format Selection" command for swift files.
+ */
+export function registerRangeFormatProvider(formatter: SwiftFormattingProvider): vscode.Disposable {
+  return vscode.languages.registerDocumentRangeFormattingEditProvider("swift", formatter);
+}
+
+export class SwiftFormattingProvider implements vscode.DocumentFormattingEditProvider, vscode.DocumentRangeFormattingEditProvider {
+  
   private isBundledSwiftFormat: boolean | undefined = undefined;
 
   provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
@@ -22,6 +31,16 @@ export class SwiftFormattingProvider implements vscode.DocumentFormattingEditPro
     void this.formatDocument(document);
     // we edit directly in the file, so no edits are returned
     return [];
+  }
+
+  provideDocumentRangeFormattingEdits(document: vscode.TextDocument, range: vscode.Range, options: vscode.FormattingOptions, token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
+    void this.formatDocument(document, [range])
+    return []
+  }
+
+  provideDocumentRangesFormattingEdits(document: vscode.TextDocument, ranges: vscode.Range[], options: vscode.FormattingOptions, token: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
+    void this.formatDocument(document, ranges)
+    return []
   }
 
   /**
@@ -50,7 +69,7 @@ export class SwiftFormattingProvider implements vscode.DocumentFormattingEditPro
   /**
    * Get formatter command parameters from workspace configuration.
    */
-  async getFormatterCommand(filename: string): Promise<{
+  async getFormatterCommand(filename: string, offsets: { start: number, end: number }[]): Promise<{
     command: string;
     args: string[];
   }> {
@@ -65,6 +84,11 @@ export class SwiftFormattingProvider implements vscode.DocumentFormattingEditPro
       // user should specify format.args in the workspace settings.
       args = ["--in-place", filename];
     }
+
+    offsets.forEach(offset => {
+      args.push("--offsets")
+      args.push(`${offset.start}:${offset.end}`)
+    })
 
     const path = getWorkspaceConfig("format.path");
     if (path) {
@@ -84,13 +108,22 @@ export class SwiftFormattingProvider implements vscode.DocumentFormattingEditPro
   /**
    * Format given document using swift-format executable.
    */
-  async formatDocument(document: vscode.TextDocument) {
+  async formatDocument(document: vscode.TextDocument, ranges?: vscode.Range[]) {
     if (document.languageId !== "swift") {
       return;
     }
 
+    var offsets: { start: number, end: number }[] = [];
+    if (ranges) {
+      ranges.forEach(range => {
+        const rangeStartOffset = document.offsetAt(range.start);
+        const rangeEndOffset = document.offsetAt(range.end);
+        offsets.push({ start: rangeStartOffset, end: rangeEndOffset });
+      });
+    }
+
     const filename = document.fileName;
-    const { command, args } = await this.getFormatterCommand(filename);
+    const { command, args } = await this.getFormatterCommand(filename, offsets);
 
     const timer = new Timer();
     try {


### PR DESCRIPTION
A small PR that uses the `--offsets` parameter introduced in swift-format 6 to add support for the "Format Selection" command in Swift files out of the box.

I got used to this command a lot in XCode (using Ctrl+I) so I was really missing this ;-) 

In case the user has a version smaller than swift-format 6 (which I think would be anything below XCode 16), "Format Selection" will simply do nothing. If we want to improve it we could add some sort of version check here, but it's not 100% straightforward since `swift-format --version` will not always return something sensible (on my machine it just returns "main" for the xcode-integrated version). But I think it should be okay, most users will have XCode 16 now.