### PR TITLE
Don't bring simulator to foreground after build

### DIFF
--- a/src/build/commands.ts
+++ b/src/build/commands.ts
@@ -128,7 +128,7 @@ export async function runOniOSSimulator(
   context.updateProgressStatus("Launching Simulator.app");
   await terminal.execute({
     command: "open",
-    args: ["-a", "Simulator"],
+    args: ["-g", "-a", "Simulator"],
   });
 
   // Get simulator with fresh state


### PR DESCRIPTION
This PR ensures the simulator is not brought to the foreground when launching after a build.

This improves workflows a lot since it reduces interruptions, e.g. if you chat with a colleague while your build is running. Right now when the build finishes the focus always changes to the simulator, interrupting your typing. Not anymore.

I thought about adding a user setting for this behaviour, but honestly I think it's just better now and also inline with Xcode's behaviour. Hope you see it the same way :-) But I can add a setting if required of course.