### PR TITLE
Fix typo in debugging-launch task name for vscode launch config

### DIFF
--- a/src/debugger/provider.ts
+++ b/src/debugger/provider.ts
@@ -13,7 +13,7 @@ const ATTACH_CONFIG: vscode.DebugConfiguration = {
   type: "sweetpad-lldb",
   request: "attach",
   name: "SweetPad: Build and Run (Wait for debugger)",
-  preLaunchTask: "sweetpad: debuging-launch",
+  preLaunchTask: "sweetpad: debugging-launch",
 };
 
 class InitialDebugConfigurationProvider implements vscode.DebugConfigurationProvider {


### PR DESCRIPTION
When `launch.json` file is generated from Run and Debug panel (following [this instruction](https://sweetpad.hyzyla.dev/docs/debug/)), the task doesn't work out of the box because of a small typo in the `preLaunchTask` name. This PR fixes the task name.