### PR TITLE
refactor: optimize destination retrieval by avoiding unnecessary build settings extraction

### DIFF
--- a/src/build/commands.ts
+++ b/src/build/commands.ts
@@ -7,7 +7,6 @@ import {
   type XcodeScheme,
   generateBuildServerConfig,
   getBuildConfigurations,
-  getBuildSettingsToAskDestination,
   getBuildSettingsToLaunch,
   getIsXcbeautifyInstalled,
   getIsXcodeBuildServerInstalled,
@@ -643,16 +642,13 @@ async function commonBuildCommand(
   context.updateProgressStatus("Searching for configuration");
   const configuration = await askConfiguration(context, { xcworkspace: xcworkspace });
 
-  context.updateProgressStatus("Extracting build settings");
-  const buildSettings = await getBuildSettingsToAskDestination({
+  context.updateProgressStatus("Searching for destination");
+  const destination = await askDestinationToRunOn(context, {
     scheme: scheme,
     configuration: configuration,
     sdk: undefined,
     xcworkspace: xcworkspace,
   });
-
-  context.updateProgressStatus("Searching for destination");
-  const destination = await askDestinationToRunOn(context, buildSettings);
   const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 
   const sdk = destination.platform;
@@ -712,16 +708,13 @@ async function commonLaunchCommand(
   context.updateProgressStatus("Searching for configuration");
   const configuration = await askConfiguration(context, { xcworkspace: xcworkspace });
 
-  context.updateProgressStatus("Extracting build settings");
-  const buildSettings = await getBuildSettingsToAskDestination({
+  context.updateProgressStatus("Searching for destination");
+  const destination = await askDestinationToRunOn(context, {
     scheme: scheme,
     configuration: configuration,
     sdk: undefined,
     xcworkspace: xcworkspace,
   });
-
-  context.updateProgressStatus("Searching for destination");
-  const destination = await askDestinationToRunOn(context, buildSettings);
 
   const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 
@@ -832,16 +825,13 @@ async function commonRunCommand(
   context.updateProgressStatus("Searching for configuration");
   const configuration = await askConfiguration(context, { xcworkspace: xcworkspace });
 
-  context.updateProgressStatus("Extracting build settings");
-  const buildSettings = await getBuildSettingsToAskDestination({
+  context.updateProgressStatus("Searching for destination");
+  const destination = await askDestinationToRunOn(context, {
     scheme: scheme,
     configuration: configuration,
     sdk: undefined,
     xcworkspace: xcworkspace,
   });
-
-  context.updateProgressStatus("Searching for destination");
-  const destination = await askDestinationToRunOn(context, buildSettings);
 
   const sdk = destination.platform;
 
@@ -917,16 +907,13 @@ export async function cleanCommand(context: ExtensionContext, item?: BuildTreeIt
   context.updateProgressStatus("Searching for configuration");
   const configuration = await askConfiguration(context, { xcworkspace: xcworkspace });
 
-  context.updateProgressStatus("Extracting build settings");
-  const buildSettings = await getBuildSettingsToAskDestination({
+  context.updateProgressStatus("Searching for destination");
+  const destination = await askDestinationToRunOn(context, {
     scheme: scheme,
     configuration: configuration,
     sdk: undefined,
     xcworkspace: xcworkspace,
   });
-
-  context.updateProgressStatus("Searching for destination");
-  const destination = await askDestinationToRunOn(context, buildSettings);
   const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 
   const sdk = destination.platform;
@@ -963,16 +950,13 @@ export async function testCommand(context: ExtensionContext, item?: BuildTreeIte
   context.updateProgressStatus("Searching for configuration");
   const configuration = await askConfiguration(context, { xcworkspace: xcworkspace });
 
-  context.updateProgressStatus("Extracting build settings");
-  const buildSettings = await getBuildSettingsToAskDestination({
+  context.updateProgressStatus("Searching for destination");
+  const destination = await askDestinationToRunOn(context, {
     scheme: scheme,
     configuration: configuration,
     sdk: undefined,
     xcworkspace: xcworkspace,
   });
-
-  context.updateProgressStatus("Searching for destination");
-  const destination = await askDestinationToRunOn(context, buildSettings);
   const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 
   const sdk = destination.platform;

--- a/src/build/provider.ts
+++ b/src/build/provider.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
-import { type XcodeBuildSettings, getBuildSettingsToAskDestination } from "../common/cli/scripts";
 import { type ExtensionContext, TaskExecutionScope } from "../common/commands";
 import { getWorkspaceConfig } from "../common/config";
 import { errorReporting } from "../common/error-reporting";
+import { ExtensionError } from "../common/errors";
 import {
   type TaskTerminal,
   TaskTerminalV1,
@@ -22,13 +22,7 @@ import {
   runOniOSSimulator,
 } from "./commands";
 import { DEFAULT_BUILD_PROBLEM_MATCHERS } from "./constants";
-import {
-  askConfiguration,
-  askDestinationToRunOn,
-  askSchemeForBuild,
-  askXcodeWorkspacePath,
-  getDestinationById,
-} from "./utils";
+import { askConfiguration, askDestinationToRunOn, askSchemeForBuild, askXcodeWorkspacePath } from "./utils";
 
 interface TaskDefinition extends vscode.TaskDefinition {
   type: string;
@@ -86,68 +80,75 @@ class ActionDispatcher {
     }
   }
 
-  private async getDestination(options: {
-    definition: TaskDefinition;
-    buildSettings: XcodeBuildSettings | null;
-  }): Promise<Destination> {
-    // First try to get destination from task definition
-    const destinationId: string | undefined =
-      // ex: "00000000-0000-0000-0000-000000000000"
+  private async getDestinationByUserInput(
+    context: ExtensionContext,
+    options: { definition: TaskDefinition },
+  ): Promise<Destination> {
+    // For simulators and devices, we try to find destination by ID
+    // ex: "00000000-0000-0000-0000-000000000000"
+    // ex: "platform=iOS Simulator,id=00000000-0000-0000-0000-000000000000"
+    const udidRaw: string | undefined =
       options.definition.destinationId ??
-      // ex: "00000000-0000-0000-0000-000000000000"
       options.definition.simulator ??
-      // ex: "platform=iOS Simulator,id=00000000-0000-0000-0000-000000000000"
       options.definition.destination?.match(/id=(.+)/)?.[1];
 
-    // If user has provided the ID of the destination, then use it directly
-    if (destinationId) {
-      return await getDestinationById(this.context, { destinationId: destinationId });
+    const udidLower = udidRaw?.trim()?.toLowerCase();
+
+    // For macOS, we just check if the destination string contains "macos"
+    const isMacOS = options.definition.destination?.toLowerCase().includes("macos") ?? false;
+
+    const destinations = await context.destinationsManager.getDestinations();
+    const destination = destinations.find((destination) => {
+      switch (destination.type) {
+        case "iOSSimulator":
+        case "watchOSSimulator":
+        case "visionOSSimulator":
+        case "tvOSSimulator":
+        case "iOSDevice":
+        case "watchOSDevice":
+        case "visionOSDevice":
+        case "tvOSDevice":
+          return destination.udid.toLowerCase() === udidLower;
+        case "macOS":
+          return isMacOS;
+        default:
+          assertUnreachable(destination);
+      }
+    });
+
+    if (destination) {
+      return destination;
     }
 
-    // If not in task definition, try to get from workspace state
-    const selectedDestination = this.context.destinationsManager.getSelectedXcodeDestinationForBuild();
-    if (selectedDestination) {
-      return await getDestinationById(this.context, { destinationId: selectedDestination.id });
-    }
-
-    // If no destination found in either place, and no build settings, throw error
-    if (options.buildSettings === null) {
-      throw new Error("Build settings are required to determine the destination");
-    }
-
-    // Otherwise, ask the user to select the destination (it will be cached for the next time)
-    const destination = await askDestinationToRunOn(this.context, options.buildSettings);
-    return destination;
+    throw new ExtensionError("Destination not found", {
+      context: {
+        destinationId: udidRaw,
+      },
+    });
   }
 
-  private async getDestinationFromDefinition(options: {
+  private async getDestination(options: {
     definition: TaskDefinition;
     scheme: string;
     configuration: string;
     xcworkspace: string;
   }): Promise<Destination> {
-    // Try to get destination from task definition first
-    try {
-      return await this.getDestination({
-        definition: options.definition,
-        buildSettings: null,
-      });
-    } catch (error) {
-      // If we can't get destination from definition, we need to get build settings
-      this.context.updateProgressStatus("Extracting build settings");
-      const buildSettings = await getBuildSettingsToAskDestination({
-        scheme: options.scheme,
-        configuration: options.configuration,
-        sdk: undefined,
-        xcworkspace: options.xcworkspace,
-      });
-
-      this.context.updateProgressStatus("Searching for destination");
-      return await this.getDestination({
-        definition: options.definition,
-        buildSettings: buildSettings,
-      });
+    // If user has provided the ID of the destination, then use it directly
+    const inputDestination = await this.getDestinationByUserInput(this.context, {
+      definition: options.definition,
+    });
+    if (inputDestination) {
+      return inputDestination;
     }
+
+    // If not in task definition, then ask user to select destination (or get from cache)
+    const destination = await askDestinationToRunOn(this.context, {
+      scheme: options.scheme,
+      configuration: options.configuration,
+      sdk: undefined,
+      xcworkspace: options.xcworkspace,
+    });
+    return destination;
   }
 
   private async launchCallback(terminal: TaskTerminal, definition: TaskDefinition) {
@@ -181,11 +182,11 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
-    const destination = await this.getDestinationFromDefinition({
-      definition,
-      scheme,
-      configuration,
-      xcworkspace,
+    const destination = await this.getDestination({
+      definition: definition,
+      scheme: scheme,
+      configuration: configuration,
+      xcworkspace: xcworkspace,
     });
 
     const destinationRaw = definition.destination ?? getXcodeBuildDestinationString({ destination: destination });
@@ -284,11 +285,11 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
-    const destination = await this.getDestinationFromDefinition({
-      definition,
-      scheme,
-      configuration,
-      xcworkspace,
+    const destination = await this.getDestination({
+      definition: definition,
+      scheme: scheme,
+      configuration: configuration,
+      xcworkspace: xcworkspace,
     });
 
     const destinationRaw = definition.destination ?? getXcodeBuildDestinationString({ destination: destination });
@@ -338,11 +339,11 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
-    const destination = await this.getDestinationFromDefinition({
-      definition,
-      scheme,
-      configuration,
-      xcworkspace,
+    const destination = await this.getDestination({
+      definition: definition,
+      scheme: scheme,
+      configuration: configuration,
+      xcworkspace: xcworkspace,
     });
 
     const sdk = destination.platform;
@@ -416,11 +417,11 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
-    const destination = await this.getDestinationFromDefinition({
-      definition,
-      scheme,
-      configuration,
-      xcworkspace,
+    const destination = await this.getDestination({
+      definition: definition,
+      scheme: scheme,
+      configuration: configuration,
+      xcworkspace: xcworkspace,
     });
 
     const destinationRaw = definition.destination ?? getXcodeBuildDestinationString({ destination: destination });
@@ -456,11 +457,11 @@ class ActionDispatcher {
         xcworkspace: xcworkspace,
       }));
 
-    const destination = await this.getDestinationFromDefinition({
-      definition,
-      scheme,
-      configuration,
-      xcworkspace,
+    const destination = await this.getDestination({
+      definition: definition,
+      scheme: scheme,
+      configuration: configuration,
+      xcworkspace: xcworkspace,
     });
 
     const destinationRaw = definition.destination ?? getXcodeBuildDestinationString({ destination: destination });


### PR DESCRIPTION
# Improve Destination Retrieval Logic

## Description
This PR refactors the destination retrieval logic in the Xcode build task provider to make it more efficient and reliable. The main goal is to avoid unnecessary build settings extraction when a destination is already specified in the task definition or workspace state.
The original implementation took significant time on each build for large projects when calling `xcodebuild`

## Changes
- Refactored `getDestination` method to prioritize sources in the following order:
  1. Task definition (`destinationId`, `simulator`, or `destination` string)
  2. Workspace state (selected destination)
  3. User prompt (only if no destination is found in previous sources)
- Added new helper method `getDestinationFromDefinition` to streamline destination retrieval
- Removed redundant build settings extraction when destination is already known

## How to Test
1. **Task Definition Destination**
   - Create a task with `destinationId` in the definition
   - Verify the build uses the specified destination without prompting
   - Test with different destination formats (ID, simulator, raw destination string)

2. **Workspace State Destination**
   - Select a destination in the workspace
   - Run a build task without destination specification
   - Verify it uses the selected destination without prompting

3. **User Prompt Fallback**
   - Clear any selected destination
   - Run a build task without destination specification
   - Verify it prompts for destination selection
   - Confirm the selected destination is used for the build

4. **Error Handling**
   - Test with invalid destination IDs
   - Verify appropriate error messages are shown
   - Confirm the build process fails gracefully

5. **Performance**
   - Compare build times with and without destination specification
   - Verify no unnecessary build settings extraction occurs when destination is known