### PR TITLE
Add buildServer.json Regeneration During Build/Run

### DIFF
--- a/src/common/cli/scripts.ts
+++ b/src/common/cli/scripts.ts
@@ -1,10 +1,11 @@
 import path from "node:path";
-import { prepareDerivedDataPath } from "../../build/utils";
+import { getWorkspacePath, prepareDerivedDataPath } from "../../build/utils";
 import type { DestinationPlatform } from "../../destination/constants";
 import { cache } from "../cache";
 import { getWorkspaceConfig } from "../config";
 import { ExtensionError } from "../errors";
 import { exec } from "../exec";
+import { readJsonFile } from "../files";
 import { uniqueFilter } from "../helpers";
 import { commonLogger } from "../logger";
 import { assertUnreachable } from "../types";
@@ -424,8 +425,23 @@ export async function generateBuildServerConfig(options: { xcworkspace: string; 
   });
 }
 
+export type XcodeBuildServerConfig = {
+  scheme: string;
+  workspace: string;
+  build_root: string;
+  // there might be more properties, like "kind", "args", "name", but we don't need them for now
+};
+
 /**
- * Is XcodeGen installed?s
+ * Read xcode-build-server config with proper types
+ */
+export async function readXcodeBuildServerConfig(): Promise<XcodeBuildServerConfig> {
+  const buildServerJsonPath = path.join(getWorkspacePath(), "buildServer.json");
+  return await readJsonFile<XcodeBuildServerConfig>(buildServerJsonPath);
+}
+
+/**
+ * Is XcodeGen installed?
  */
 export async function getIsXcodeGenInstalled() {
   try {


### PR DESCRIPTION
# Add buildServer.json Regeneration During Build/Run

## Description
Added functionality to automatically regenerate `buildServer.json` during build and run operations to ensure the configuration stays up-to-date with the latest project state.

## Changes
- Modified `checkAndRegenerateBuildServerConfig` to handle regeneration during build/run operations
- Updated build and run commands to trigger regeneration
- Added automatic regeneration when `buildServer.json` is missing or corrupted

## Testing
1. Run a build or run operation
2. Verify that `buildServer.json` is regenerated with the latest configuration
3. Check that the build/run operation completes successfully
4. Test with missing/corrupted `buildServer.json` to verify automatic regeneration