### PR TITLE
Allow getDestinationByUserInput to return none

### DIFF
--- a/src/build/provider.ts
+++ b/src/build/provider.ts
@@ -83,7 +83,7 @@ class ActionDispatcher {
   private async getDestinationByUserInput(
     context: ExtensionContext,
     options: { definition: TaskDefinition },
-  ): Promise<Destination> {
+  ): Promise<Destination | undefined> {
     // For simulators and devices, we try to find destination by ID
     // ex: "00000000-0000-0000-0000-000000000000"
     // ex: "platform=iOS Simulator,id=00000000-0000-0000-0000-000000000000"
@@ -116,15 +116,7 @@ class ActionDispatcher {
       }
     });
 
-    if (destination) {
-      return destination;
-    }
-
-    throw new ExtensionError("Destination not found", {
-      context: {
-        destinationId: udidRaw,
-      },
-    });
+    return destination;
   }
 
   private async getDestination(options: {


### PR DESCRIPTION
- Fixes an issue introduced by cdce2ca pushed to #162: when no macOS `destination` is set in `options.definition` in `getDestinationByUserInput`, it will throw an error failing build instead of returning `undefined` and proceeding to `destination` check that's already set in VS Code