### PR TITLE
feat: add configurable xcode-build-server path support

### DIFF
--- a/package.json
+++ b/package.json
@@ -897,6 +897,14 @@
           "default": true,
           "description": "Watch if default scheme is changed and regenerate the build server config"
         },
+        "sweetpad.xcodebuildserver.path": {
+          "type": "string",
+          "default": null,
+          "description": "Path to custom xcodebuildserver executable.",
+          "examples": [
+            "/opt/homebrew/bin/xcode-build-server"
+          ]
+        },
         "sweetpad.build.autoRefreshSchemes": {
           "type": "boolean",
           "default": true,

--- a/src/common/cli/scripts.ts
+++ b/src/common/cli/scripts.ts
@@ -308,13 +308,23 @@ export async function getIsXcbeautifyInstalled() {
 }
 
 /**
+ * Get the xcode-build-server command path from config or default
+ */
+function getXcodeBuildServerCommand(): string {
+  const customPath = getWorkspaceConfig("xcodebuildserver.path");
+  return customPath || "xcode-build-server";
+}
+
+/**
  * Find if xcode-build-server is installed
  */
 export async function getIsXcodeBuildServerInstalled() {
+  const command = getXcodeBuildServerCommand();
+
   try {
     await exec({
       command: "which",
-      args: ["xcode-build-server"],
+      args: [command],
     });
     return true;
   } catch (e) {
@@ -486,8 +496,10 @@ export async function getBuildConfigurations(options: { xcworkspace: string }): 
  * Generate xcode-build-server config
  */
 export async function generateBuildServerConfig(options: { xcworkspace: string; scheme: string }) {
+  const command = getXcodeBuildServerCommand();
+
   await exec({
-    command: "xcode-build-server",
+    command: command,
     args: ["config", "-workspace", options.xcworkspace, "-scheme", options.scheme],
   });
 }

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -25,6 +25,7 @@ type Config = {
   "system.customXcodeWorkspaceParser": boolean;
   "xcodegen.autogenerate": boolean;
   "xcodebuildserver.autogenerate": boolean;
+  "xcodebuildserver.path": string;
   "tuist.autogenerate": boolean;
   "tuist.generate.env": { [key: string]: string | null };
   "testing.configuration": string;


### PR DESCRIPTION
- Add sweetpad.xcodebuildserver.path configuration option
- Allow users to specify custom xcode-build-server executable path
- Update scripts to use configured path instead of hardcoded command
- Fallback to default 'xcode-build-server' if no custom path is set