### PR TITLE
feature: Add Tuist Test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -424,6 +424,11 @@
         "title": "SweetPad: Edit Tuist project (Open project in Xcode)",
         "icon": "$(file-code)"
       },
+            {
+        "command": "sweetpad.tuist.test",
+        "title": "SweetPad: Test Generated project using Tuist",
+        "icon": "$(file-code)"
+      },
       {
         "command": "sweetpad.build.openXcode",
         "title": "SweetPad: Open Xcode",

--- a/src/common/cli/scripts.ts
+++ b/src/common/cli/scripts.ts
@@ -583,6 +583,13 @@ export async function tuistEdit() {
   });
 }
 
+export async function tuistTest() {
+  await exec({
+    command: "tuist",
+    args: ["test"],
+  });
+}
+
 /**
  * Get the Xcode version installed on the system using xcodebuild
  *

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,7 +66,7 @@ import { TestingManager } from "./testing/manager.js";
 import { installToolCommand, openDocumentationCommand } from "./tools/commands.js";
 import { ToolsManager } from "./tools/manager.js";
 import { ToolTreeProvider } from "./tools/tree.js";
-import { tuistCleanCommand, tuistEditComnmand, tuistGenerateCommand, tuistInstallCommand } from "./tuist/command.js";
+import { tuistCleanCommand, tuistEditComnmand, tuistGenerateCommand, tuistInstallCommand, tuistTestComnmand } from "./tuist/command.js";
 import { createTuistWatcher } from "./tuist/watcher.js";
 import { xcodgenGenerateCommand } from "./xcodegen/commands.js";
 import { createXcodeGenWatcher } from "./xcodegen/watcher.js";
@@ -178,6 +178,7 @@ export function activate(context: vscode.ExtensionContext) {
   d(command("sweetpad.tuist.install", tuistInstallCommand));
   d(command("sweetpad.tuist.clean", tuistCleanCommand));
   d(command("sweetpad.tuist.edit", tuistEditComnmand));
+  d(command("sweetpad.tuist.test", tuistTestComnmand));
   d(createTuistWatcher(_context));
 
   // Scheme Auto-Refresh Watcher

--- a/src/tuist/command.ts
+++ b/src/tuist/command.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { restartSwiftLSP } from "../build/utils";
-import { getIsTuistInstalled, tuistClean, tuistEdit, tuistGenerate, tuistInstall } from "../common/cli/scripts";
+import { getIsTuistInstalled, tuistClean, tuistEdit, tuistGenerate, tuistInstall, tuistTest } from "../common/cli/scripts";
 import type { ExtensionContext } from "../common/commands";
 import { ExtensionError } from "../common/errors";
 
@@ -51,4 +51,11 @@ export async function tuistEditComnmand(context: ExtensionContext) {
   await tuistCheckInstalled();
 
   await tuistEdit();
+}
+
+export async function tuistTestComnmand(context: ExtensionContext) {
+  context.updateProgressStatus("Running 'tuist test'");
+  await tuistCheckInstalled();
+
+  await tuistTest();
 }


### PR DESCRIPTION
This PR adds `tuist test` command to run all test schemes using Tuist. This also allows us to use selective testing (locally) 

Since I'm not TS enthusiast and this is my first contribution to sweetpad, I tried to follow examples from old PRs and current implementation, feel free to suggest any fix or anyone can directly commit 👍 