### PR TITLE
Focus Simulator after booting

### DIFF
--- a/package.json
+++ b/package.json
@@ -822,6 +822,11 @@
           "default": false,
           "description": "Use Rosetta Destination."
         },
+        "sweetpad.build.bringSimulatorToForeground": {
+          "type": "boolean",
+          "default": true,
+          "description": "Bring Simulator to foreground on launch"
+        },
         "sweetpad.testing.configuration": {
           "type": "string",
           "default": null,

--- a/src/build/commands.ts
+++ b/src/build/commands.ts
@@ -145,9 +145,11 @@ export async function runOniOSSimulator(
 
   // Open simulator
   context.updateProgressStatus("Launching Simulator.app");
+  const bringToForeground = getWorkspaceConfig("build.bringSimulatorToForeground") ?? true;
+  const openArgs = bringToForeground ? ["-a", "Simulator"] : ["-g", "-a", "Simulator"];
   await terminal.execute({
     command: "open",
-    args: ["-a", "Simulator"],
+    args: openArgs,
   });
 
   // Install app

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -15,6 +15,7 @@ type Config = {
   "build.launchArgs": string[];
   "build.launchEnv": { [key: string]: string };
   "build.rosettaDestination": boolean;
+  "build.bringSimulatorToForeground": boolean;
   "build.autoRefreshSchemes": boolean;
   "build.autoRefreshSchemesDelay": number;
   "system.taskExecutor": "v1" | "v2";


### PR DESCRIPTION
From the man page of `open`, the `-g` flag does:

> `-g  Do not bring the application to the foreground.`

If the user clicks "Play" to launch their app in Sweetpad, they probably want to see the results immediately in the Simulator. It's poor UX to have an extra few clicks to find the Simulator app in the dock or cmd-tab'ing thru the list of open apps. In fact, the demo gif in the README doesn't have this flag at all

If you feel it's better to have this as a configurable setting, please guide me where and how to do so :)