### PR TITLE
Allow override of the default xcodebuild command

### DIFF
--- a/package.json
+++ b/package.json
@@ -753,6 +753,15 @@
           "required": false,
           "description": "Path to Xcode workspace. Can be absolute or relative to the workspace root."
         },
+        "sweetpad.build.xcodebuildCommand": {
+          "type": "string",
+          "default": null,
+          "description": "Custom xcodebuild command or path. Supports environment variable expansion via ${env:VAR_NAME} syntax.",
+          "examples": [
+            "/Applications/Xcode-beta.app/Contents/Developer/usr/bin/xcodebuild",
+            "${env:XCODEBUILD_PATH}"
+          ]
+        },
         "sweetpad.build.derivedDataPath": {
           "type": "string",
           "default": null,

--- a/src/build/manager.ts
+++ b/src/build/manager.ts
@@ -9,6 +9,7 @@ import {
   getIsXcbeautifyInstalled,
   getIsXcodeBuildServerInstalled,
   getSchemes,
+  getXcodeBuildCommand,
   getXcodeVersionInstalled,
 } from "../common/cli/scripts";
 import { BaseExecutionScope, type ExtensionContext } from "../common/commands";
@@ -923,7 +924,7 @@ export class BuildManager {
       scheme: options.scheme,
       callback: async (terminal) => {
         await terminal.execute({
-          command: "xcodebuild",
+          command: getXcodeBuildCommand(),
           args: ["-resolvePackageDependencies", "-scheme", options.scheme, "-workspace", options.xcworkspace],
         });
       },

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -9,6 +9,7 @@ import {
   getBuildSettingsToAskDestination,
   getIsXcodeBuildServerInstalled,
   getSchemes,
+  getXcodeBuildCommand,
   readXcodeBuildServerConfig,
 } from "../common/cli/scripts";
 import type { ExtensionContext } from "../common/commands";
@@ -479,7 +480,7 @@ export function isXcbeautifyEnabled() {
 export class XcodeCommandBuilder {
   NO_VALUE = "__NO_VALUE__";
 
-  private xcodebuild = "xcodebuild";
+  private xcodebuild = getXcodeBuildCommand();
   private parameters: {
     arg: string;
     value: string | "__NO_VALUE__";

--- a/src/common/cli/scripts.spec.ts
+++ b/src/common/cli/scripts.spec.ts
@@ -1,5 +1,83 @@
 import { ExtensionError } from "../errors";
-import { parseCliJsonOutput } from "./scripts";
+import { getXcodeBuildCommand, parseCliJsonOutput } from "./scripts";
+import * as vscode from "vscode";
+
+jest.mock("vscode");
+
+const mockGetConfiguration = vscode.workspace.getConfiguration as jest.Mock;
+
+describe("getXcodeBuildCommand", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns default 'xcodebuild' when no config is set", () => {
+    mockGetConfiguration.mockReturnValue({
+      get: jest.fn().mockReturnValue(undefined),
+    });
+    expect(getXcodeBuildCommand()).toBe("xcodebuild");
+  });
+
+  it("returns default 'xcodebuild' when config is null", () => {
+    mockGetConfiguration.mockReturnValue({
+      get: jest.fn().mockReturnValue(null),
+    });
+    expect(getXcodeBuildCommand()).toBe("xcodebuild");
+  });
+
+  it("returns default 'xcodebuild' when config is empty string", () => {
+    mockGetConfiguration.mockReturnValue({
+      get: jest.fn().mockReturnValue(""),
+    });
+    expect(getXcodeBuildCommand()).toBe("xcodebuild");
+  });
+
+  it("returns custom command when configured with absolute path", () => {
+    mockGetConfiguration.mockReturnValue({
+      get: jest.fn().mockReturnValue("/Applications/Xcode-beta.app/Contents/Developer/usr/bin/xcodebuild"),
+    });
+    expect(getXcodeBuildCommand()).toBe("/Applications/Xcode-beta.app/Contents/Developer/usr/bin/xcodebuild");
+  });
+
+  it("expands environment variable in config value", () => {
+    process.env.CUSTOM_XCODEBUILD = "/custom/path/to/xcodebuild";
+    mockGetConfiguration.mockReturnValue({
+      get: jest.fn().mockReturnValue("${env:CUSTOM_XCODEBUILD}"),
+    });
+    expect(getXcodeBuildCommand()).toBe("/custom/path/to/xcodebuild");
+  });
+
+  it("expands environment variable with additional path components", () => {
+    process.env.XCODE_PATH = "/Applications/Xcode-beta.app";
+    mockGetConfiguration.mockReturnValue({
+      get: jest.fn().mockReturnValue("${env:XCODE_PATH}/Contents/Developer/usr/bin/xcodebuild"),
+    });
+    expect(getXcodeBuildCommand()).toBe("/Applications/Xcode-beta.app/Contents/Developer/usr/bin/xcodebuild");
+  });
+
+  it("keeps original placeholder when environment variable is not set", () => {
+    delete process.env.NONEXISTENT_VAR;
+    mockGetConfiguration.mockReturnValue({
+      get: jest.fn().mockReturnValue("${env:NONEXISTENT_VAR}"),
+    });
+    expect(getXcodeBuildCommand()).toBe("${env:NONEXISTENT_VAR}");
+  });
+
+  it("expands empty environment variable to empty string", () => {
+    process.env.EMPTY_VAR = "";
+    mockGetConfiguration.mockReturnValue({
+      get: jest.fn().mockReturnValue("prefix${env:EMPTY_VAR}suffix"),
+    });
+    expect(getXcodeBuildCommand()).toBe("prefixsuffix");
+  });
+});
 
 describe("parseCliJsonOutput ", () => {
   it("simple", async () => {

--- a/src/common/cli/scripts.ts
+++ b/src/common/cli/scripts.ts
@@ -220,7 +220,7 @@ async function getBuildSettingsList(options: {
   }
 
   const stdout = await exec({
-    command: "xcodebuild",
+    command: getXcodeBuildCommand(),
     args: args,
   });
 
@@ -358,6 +358,14 @@ function getXcodeBuildServerCommand(): string {
 }
 
 /**
+ * Get the xcodebuild command from config or default
+ */
+export function getXcodeBuildCommand(): string {
+  const customCommand = getWorkspaceConfig("build.xcodebuildCommand");
+  return customCommand || "xcodebuild";
+}
+
+/**
  * Find if xcode-build-server is installed
  */
 export async function getIsXcodeBuildServerInstalled() {
@@ -377,7 +385,7 @@ export async function getIsXcodeBuildServerInstalled() {
 export const getBasicProjectInfo = cache(
   async (options: { xcworkspace: string | undefined }): Promise<XcodebuildListOutput> => {
     const stdout = await exec({
-      command: "xcodebuild",
+      command: getXcodeBuildCommand(),
       args: ["-list", "-json", ...(options?.xcworkspace ? ["-workspace", options?.xcworkspace] : [])],
     });
     const parsed = parseCliJsonOutput<any>(stdout);

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -6,6 +6,7 @@ type Config = {
   "format.selectionArgs": string[] | null;
   "build.xcbeautifyEnabled": boolean;
   "build.xcodeWorkspacePath": string;
+  "build.xcodebuildCommand": string;
   "build.derivedDataPath": string;
   "build.configuration": string;
   "build.arch": "x86_64" | "arm64";

--- a/src/testing/manager.ts
+++ b/src/testing/manager.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import * as vscode from "vscode";
 import { askXcodeWorkspacePath, getWorkspacePath, getXcodeBuildDestinationString } from "../build/utils.js";
-import { getBuildSettingsToAskDestination } from "../common/cli/scripts.js";
+import { getBuildSettingsToAskDestination, getXcodeBuildCommand } from "../common/cli/scripts.js";
 import type { ExtensionContext } from "../common/commands.js";
 import { errorReporting } from "../common/error-reporting.js";
 import { exec } from "../common/exec.js";
@@ -403,7 +403,7 @@ export class TestingManager {
       terminateLocked: true,
       callback: async (terminal) => {
         await terminal.execute({
-          command: "xcodebuild",
+          command: getXcodeBuildCommand(),
           args: [
             "build-for-testing",
             "-destination",
@@ -806,7 +806,7 @@ export class TestingManager {
         terminateLocked: true,
         callback: async (terminal) => {
           await terminal.execute({
-            command: "xcodebuild",
+            command: getXcodeBuildCommand(),
             args: [
               "test-without-building",
               "-workspace",
@@ -889,7 +889,7 @@ export class TestingManager {
       callback: async (terminal) => {
         try {
           await terminal.execute({
-            command: "xcodebuild",
+            command: getXcodeBuildCommand(),
             args: [
               "test-without-building",
               "-workspace",


### PR DESCRIPTION
This PR adds ability to provide path to custom `xcodebuild` command via `sweetpad.build.xcodebuildCommand`. 

This is common behaviour, for example, fastlane's scan has same [xcodebuild_command](https://github.com/fastlane/fastlane/blob/cb3e7aae706af6ff330838677562fe3584afc195/gym/lib/gym/options.rb#L298) for overriding the default xcodebuild command. 