### PR TITLE
Use correct device type for visionOS, fixes visionOS destination selection

### DIFF
--- a/src/common/xcode/devicectl.ts
+++ b/src/common/xcode/devicectl.ts
@@ -47,7 +47,7 @@ type DeviceCtlDeviceProperties = {
   rootFileSystemIsWritable: boolean;
 };
 
-export type DeviceCtlDeviceType = "iPhone" | "iPad" | "appleWatch" | "appleTV" | "appleVision";
+export type DeviceCtlDeviceType = "iPhone" | "iPad" | "appleWatch" | "appleTV" | "appleVision" | "realityDevice";
 
 type DeviceCtlHardwareProperties = {
   cpuType: DeviceCtlCpuType;

--- a/src/devices/manager.ts
+++ b/src/devices/manager.ts
@@ -47,7 +47,7 @@ export class DevicesManager {
         if (deviceType === "iPhone" || deviceType === "iPad") {
           return new iOSDeviceDestination(device);
         }
-        if (deviceType === "appleVision") {
+        if (deviceType === "appleVision" || deviceType === "realityDevice") {
           return new visionOSDeviceDestination(device);
         }
         if (deviceType === "appleTV") {


### PR DESCRIPTION
Resolves #79

I dug into this a bit and found a fix - the device manager was not matching against the correct device type.  My Vision Pro lists its device type as `"realityDevice"`, not `"appleVision"`.

After building the extension and manually installing the VSIX, I can confirm this works end-to-end :)