### PR TITLE
feat: add "Switch Git Worktree" command for parallel development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
       "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -1884,6 +1885,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1905,6 +1907,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -1941,6 +1944,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -2471,6 +2475,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
       "integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3202,6 +3207,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3533,6 +3539,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001629",
         "electron-to-chromium": "^1.4.796",
@@ -4988,6 +4995,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7919,6 +7927,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
       "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -1885,7 +1884,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1907,7 +1905,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -1944,7 +1941,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -2475,7 +2471,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.30.0.tgz",
       "integrity": "sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3207,7 +3202,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3539,7 +3533,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001629",
         "electron-to-chromium": "^1.4.796",
@@ -4995,7 +4988,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7927,7 +7919,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -446,6 +446,11 @@
         "icon": "$(debug-stop)"
       },
       {
+        "command": "sweetpad.build.switchWorktree",
+        "title": "SweetPad: Switch Git Worktree",
+        "icon": "$(git-branch)"
+      },
+      {
         "command": "sweetpad.simulators.refresh",
         "title": "SweetPad: Refresh simulators list",
         "icon": "$(sweetpad-refresh)"

--- a/src/build/commands.ts
+++ b/src/build/commands.ts
@@ -410,7 +410,7 @@ export async function switchWorktreeCommand(context: ExtensionContext) {
       continue;
     }
 
-    const isCurrent = currentWorkspace === xcworkspace;
+    const isCurrent = currentWorkspace !== undefined && path.resolve(currentWorkspace) === path.resolve(xcworkspace);
     const dirName = path.basename(wt.path);
 
     items.push({
@@ -431,15 +431,8 @@ export async function switchWorktreeCommand(context: ExtensionContext) {
     items,
   });
 
-  const workspacePath = getWorkspacePath();
-  const isMainWorkspace = selected.context.worktreePath === workspacePath;
-
-  if (isMainWorkspace) {
-    const relative = getWorkspaceRelativePath(selected.context.xcworkspace);
-    await updateWorkspaceConfig("build.xcodeWorkspacePath", relative);
-  } else {
-    await updateWorkspaceConfig("build.xcodeWorkspacePath", selected.context.xcworkspace);
-  }
+  const relative = getWorkspaceRelativePath(selected.context.xcworkspace);
+  await updateWorkspaceConfig("build.xcodeWorkspacePath", relative);
 
   context.updateWorkspaceState("build.xcodeWorkspacePath", undefined);
   context.buildManager.refreshSchemes();

--- a/src/build/commands.ts
+++ b/src/build/commands.ts
@@ -14,12 +14,14 @@ import { updateWorkspaceConfig } from "../common/config";
 import { ExecBaseError, ExtensionError } from "../common/errors";
 import { exec } from "../common/exec";
 import { getWorkspaceRelativePath, isFileExists, removeDirectory } from "../common/files";
-import { showInputBox } from "../common/quick-pick";
+import { showInputBox, showQuickPick } from "../common/quick-pick";
 import { runTask } from "../common/tasks";
 import {
   askSchemeForBuild,
   askXcodeWorkspacePath,
+  detectGitWorktrees,
   detectXcodeWorkspacesPaths,
+  findXcodeWorkspaceInDirectory,
   getCurrentXcodeWorkspacePath,
   getWorkspacePath,
   prepareStoragePath,
@@ -381,4 +383,67 @@ export async function refreshSchemesCommand(context: ExtensionContext): Promise<
 
 export async function stopSchemeCommand(context: ExtensionContext, item?: BuildTreeItem) {
   return context.buildManager.stopSchemeCommand(item);
+}
+
+/**
+ * Switch the Xcode workspace to a different git worktree.
+ * Detects worktrees via `git worktree list`, finds Xcode projects in each,
+ * and lets the user pick which one to build from.
+ */
+export async function switchWorktreeCommand(context: ExtensionContext) {
+  context.updateProgressStatus("Detecting git worktrees");
+
+  const worktrees = await detectGitWorktrees();
+  if (worktrees.length <= 1) {
+    vscode.window.showInformationMessage("No additional git worktrees found. Create one with `git worktree add`.");
+    return;
+  }
+
+  const currentWorkspace = getCurrentXcodeWorkspacePath(context);
+
+  type WorktreePickContext = { worktreePath: string; xcworkspace: string };
+  const items: { label: string; description: string; detail?: string; context: WorktreePickContext }[] = [];
+
+  for (const wt of worktrees) {
+    const xcworkspace = await findXcodeWorkspaceInDirectory(wt.path);
+    if (!xcworkspace) {
+      continue;
+    }
+
+    const isCurrent = currentWorkspace === xcworkspace;
+    const dirName = path.basename(wt.path);
+
+    items.push({
+      label: `${isCurrent ? "$(check) " : ""}${dirName}`,
+      description: wt.branch,
+      detail: wt.path,
+      context: { worktreePath: wt.path, xcworkspace },
+    });
+  }
+
+  if (items.length === 0) {
+    vscode.window.showWarningMessage("No Xcode projects found in any git worktree.");
+    return;
+  }
+
+  const selected = await showQuickPick<WorktreePickContext>({
+    title: "Select git worktree to build from",
+    items,
+  });
+
+  const workspacePath = getWorkspacePath();
+  const isMainWorkspace = selected.context.worktreePath === workspacePath;
+
+  if (isMainWorkspace) {
+    const relative = getWorkspaceRelativePath(selected.context.xcworkspace);
+    await updateWorkspaceConfig("build.xcodeWorkspacePath", relative);
+  } else {
+    await updateWorkspaceConfig("build.xcodeWorkspacePath", selected.context.xcworkspace);
+  }
+
+  context.updateWorkspaceState("build.xcodeWorkspacePath", undefined);
+  context.buildManager.refreshSchemes();
+
+  const dirName = path.basename(selected.context.worktreePath);
+  vscode.window.showInformationMessage(`SweetPad now builds from: ${dirName} (${selected.description ?? ""})`);
 }

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -743,3 +743,69 @@ export function getSwiftPMDirectory(xcworkspace: string): string {
   }
   throw new ExtensionError("Not a SPM package");
 }
+
+export type GitWorktree = {
+  path: string;
+  branch: string;
+  isBare: boolean;
+};
+
+/**
+ * Detect git worktrees by running `git worktree list --porcelain`.
+ * Returns an array of worktrees with their paths and branch names.
+ */
+export async function detectGitWorktrees(): Promise<GitWorktree[]> {
+  const { exec: execWorktree } = await import("../common/exec.js");
+  let output: string;
+  try {
+    output = await execWorktree({
+      command: "git",
+      args: ["worktree", "list", "--porcelain"],
+    });
+  } catch {
+    commonLogger.warn("Failed to list git worktrees — git may not be available or this is not a git repo");
+    return [];
+  }
+
+  const worktrees: GitWorktree[] = [];
+  const blocks = output.trim().split("\n\n");
+
+  for (const block of blocks) {
+    const lines = block.trim().split("\n");
+    let worktreePath = "";
+    let branch = "";
+    let isBare = false;
+
+    for (const line of lines) {
+      if (line.startsWith("worktree ")) {
+        worktreePath = line.substring("worktree ".length);
+      } else if (line.startsWith("branch ")) {
+        const refPath = line.substring("branch ".length);
+        branch = refPath.replace("refs/heads/", "");
+      } else if (line === "bare") {
+        isBare = true;
+      } else if (line === "detached") {
+        branch = "(detached HEAD)";
+      }
+    }
+
+    if (worktreePath && !isBare) {
+      worktrees.push({ path: worktreePath, branch, isBare });
+    }
+  }
+
+  return worktrees;
+}
+
+/**
+ * Find Xcode workspace/project files inside a given directory (non-recursive, up to 4 levels).
+ * Returns the first .xcworkspace path found, or undefined.
+ */
+export async function findXcodeWorkspaceInDirectory(directory: string): Promise<string | undefined> {
+  const paths = await findFilesRecursive({
+    directory,
+    depth: 4,
+    matcher: (file) => file.name.endsWith(".xcworkspace"),
+  });
+  return paths.length > 0 ? paths[0] : undefined;
+}

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { execa } from "execa";
 import * as vscode from "vscode";
 import { type QuickPickItem, showQuickPick } from "../common/quick-pick";
 
@@ -747,21 +748,34 @@ export function getSwiftPMDirectory(xcworkspace: string): string {
 export type GitWorktree = {
   path: string;
   branch: string;
-  isBare: boolean;
 };
 
 /**
  * Detect git worktrees by running `git worktree list --porcelain`.
  * Returns an array of worktrees with their paths and branch names.
+ *
+ * Example output of `git worktree list --porcelain`:
+ *
+ *   worktree /Users/user/project
+ *   HEAD abc1234
+ *   branch refs/heads/main
+ *
+ *   worktree /Users/user/project-feature
+ *   HEAD def5678
+ *   branch refs/heads/feature/login
+ *
+ *   worktree /Users/user/project-detached
+ *   HEAD 9876543
+ *   detached
  */
 export async function detectGitWorktrees(): Promise<GitWorktree[]> {
-  const { exec: execWorktree } = await import("../common/exec.js");
   let output: string;
   try {
-    output = await execWorktree({
-      command: "git",
-      args: ["worktree", "list", "--porcelain"],
+    // Use execa directly to avoid circular dependency with common/exec.ts
+    const result = await execa("git", ["worktree", "list", "--porcelain"], {
+      cwd: getWorkspacePath(),
     });
+    output = result.stdout;
   } catch {
     commonLogger.warn("Failed to list git worktrees — git may not be available or this is not a git repo");
     return [];
@@ -790,7 +804,7 @@ export async function detectGitWorktrees(): Promise<GitWorktree[]> {
     }
 
     if (worktreePath && !isBare) {
-      worktrees.push({ path: worktreePath, branch, isBare });
+      worktrees.push({ path: worktreePath, branch });
     }
   }
 
@@ -798,14 +812,16 @@ export async function detectGitWorktrees(): Promise<GitWorktree[]> {
 }
 
 /**
- * Find Xcode workspace/project files inside a given directory (non-recursive, up to 4 levels).
- * Returns the first .xcworkspace path found, or undefined.
+ * Find Xcode workspace/project or SPM package files inside a given directory (up to 4 levels).
+ * Returns the first .xcworkspace or Package.swift path found, or undefined.
  */
 export async function findXcodeWorkspaceInDirectory(directory: string): Promise<string | undefined> {
   const paths = await findFilesRecursive({
     directory,
     depth: 4,
-    matcher: (file) => file.name.endsWith(".xcworkspace"),
+    ignore: ["Pods", "DerivedData", ".build", "node_modules"],
+    maxResults: 1,
+    matcher: (file) => file.name.endsWith(".xcworkspace") || file.name === "Package.swift",
   });
   return paths.length > 0 ? paths[0] : undefined;
 }

--- a/src/common/files.ts
+++ b/src/common/files.ts
@@ -30,6 +30,7 @@ export async function findFilesRecursive(options: {
   matcher: (file: Dirent) => boolean;
   ignore?: string[];
   depth?: number;
+  maxResults?: number;
 }): Promise<string[]> {
   const ignore = options.ignore ?? [];
   const depth = options.depth ?? 0;
@@ -42,6 +43,9 @@ export async function findFilesRecursive(options: {
 
     if (options.matcher(file)) {
       matchedFiles.push(fullPath);
+      if (options.maxResults && matchedFiles.length >= options.maxResults) {
+        return matchedFiles;
+      }
     }
 
     if (file.isDirectory() && !ignore.includes(file.name) && depth > 0) {
@@ -50,8 +54,12 @@ export async function findFilesRecursive(options: {
         matcher: options.matcher,
         ignore: options.ignore,
         depth: depth - 1,
+        maxResults: options.maxResults ? options.maxResults - matchedFiles.length : undefined,
       });
       matchedFiles.push(...subFiles);
+      if (options.maxResults && matchedFiles.length >= options.maxResults) {
+        return matchedFiles;
+      }
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import {
   selectXcodeSchemeForBuildCommand,
   selectXcodeWorkspaceCommand,
   stopSchemeCommand,
+  switchWorktreeCommand,
   testCommand,
 } from "./build/commands.js";
 import { BuildManager } from "./build/manager.js";
@@ -163,6 +164,7 @@ export function activate(context: vscode.ExtensionContext) {
   d(command("sweetpad.build.selectConfiguration", selectConfigurationForBuildCommand));
   d(command("sweetpad.build.diagnoseSetup", diagnoseBuildSetupCommand));
   d(command("sweetpad.build.stop", stopSchemeCommand));
+  d(command("sweetpad.build.switchWorktree", switchWorktreeCommand));
 
   // Testing
   d(command("sweetpad.testing.buildForTesting", buildForTestingCommand));


### PR DESCRIPTION
## Summary

Adds a new command **"SweetPad: Switch Git Worktree"** (`sweetpad.build.switchWorktree`) that lets users quickly switch which git worktree SweetPad builds from — without opening separate VS Code windows.

This enables parallel development workflows where multiple AI agents (via tools like Conductor, Cursor Cloud, Claude Code) or developers work on different feature branches simultaneously using git worktrees.

**Related issue:** #217

## How it works

1. Runs `git worktree list --porcelain` to detect all worktrees
2. Scans each worktree for `.xcworkspace` files (up to 4 levels deep)
3. Shows a Quick Pick with worktree name, branch, and path
4. Marks the currently active worktree with a checkmark
5. Updates `sweetpad.build.xcodeWorkspacePath` — relative path for the main workspace, absolute for other worktrees (both already supported by `getCurrentXcodeWorkspacePath`)
6. Refreshes schemes after switching

## Changes

- `src/build/utils.ts`: Added `detectGitWorktrees()` and `findXcodeWorkspaceInDirectory()` utilities
- `src/build/commands.ts`: Added `switchWorktreeCommand()` 
- `src/extension.ts`: Registered `sweetpad.build.switchWorktree` command
- `package.json`: Added command metadata with `$(git-branch)` icon

## Why this matters

Parallel AI agent development with git worktrees is becoming a standard workflow. Tools like Conductor, Cursor Cloud, and Claude Code create worktrees for concurrent work on different features. Currently, users must either open separate VS Code windows per worktree or manually edit `.vscode/settings.json` to switch build targets. This command makes it a one-click operation.

## Test plan

- [ ] Open a repo with multiple git worktrees
- [ ] Run `Cmd+Shift+P` → "SweetPad: Switch Git Worktree"
- [ ] Verify worktrees are listed with correct branch names
- [ ] Select a non-main worktree
- [ ] Verify schemes refresh and builds use the selected worktree's code
- [ ] Switch back to main workspace and verify relative path is restored
- [ ] Test in a repo with no worktrees — should show info message
- [ ] Test in a non-git directory — should handle gracefully

Made with [Cursor](https://cursor.com)