### PR TITLE
fix: detect iOS 16 and earlier physical devices (#223)

### DIFF
--- a/src/build/manager-integration.spec.ts
+++ b/src/build/manager-integration.spec.ts
@@ -108,7 +108,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
 
       beforeEach(() => {
         const device = createMockDeviceWithOS("17.0");
-        modernDevice = new iOSDeviceDestination(device);
+        modernDevice = new iOSDeviceDestination({ devicectl: device });
       });
 
       it("uses devicectl for deployment", async () => {
@@ -195,7 +195,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
 
       beforeEach(() => {
         const device = createMockDeviceWithOS("16.7");
-        legacyDevice = new iOSDeviceDestination(device);
+        legacyDevice = new iOSDeviceDestination({ devicectl: device });
         (iosDeploy.isIosDeployInstalled as jest.Mock).mockResolvedValue(true);
       });
 
@@ -267,7 +267,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
     describe("error handling", () => {
       it("throws error when deviceId is missing", async () => {
         const device = createMockDevice();
-        const destination = new iOSDeviceDestination(device);
+        const destination = new iOSDeviceDestination({ devicectl: device });
         // Manually set properties to simulate missing deviceId
         Object.defineProperty(device, "identifier", { get: () => undefined });
         Object.defineProperty(device.hardwareProperties, "udid", { get: () => undefined });
@@ -287,7 +287,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
             osVersionNumber: "17.0",
           },
         });
-        const destination = new iOSDeviceDestination(device);
+        const destination = new iOSDeviceDestination({ devicectl: device });
         Object.defineProperty(device, "identifier", { get: () => undefined });
         Object.defineProperty(device.hardwareProperties, "udid", { get: () => undefined });
 
@@ -305,7 +305,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
         const device = createMockDeviceOfType("appleWatch");
         device.deviceProperties.osVersionNumber = "10.0";
         const destination = require("../devices/types").watchOSDeviceDestination;
-        const watchDevice = new destination(device);
+        const watchDevice = new destination({ devicectl: device });
 
         // Should use devicectl for watchOS 10+
         expect(watchDevice.supportsDevicectl).toBe(true);
@@ -315,7 +315,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
         const device = createMockDeviceOfType("appleTV");
         device.deviceProperties.osVersionNumber = "17.0";
         const destination = require("../devices/types").tvOSDeviceDestination;
-        const tvDevice = new destination(device);
+        const tvDevice = new destination({ devicectl: device });
 
         // Should use devicectl for tvOS 17+
         expect(tvDevice.supportsDevicectl).toBe(true);
@@ -325,7 +325,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
         const device = createMockDeviceOfType("appleVision");
         device.deviceProperties.osVersionNumber = "1.0";
         const destination = require("../devices/types").visionOSDeviceDestination;
-        const visionDevice = new destination(device);
+        const visionDevice = new destination({ devicectl: device });
 
         // Should use devicectl for visionOS 1+
         expect(visionDevice.supportsDevicectl).toBe(true);
@@ -336,7 +336,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
   describe("deployment method selection", () => {
     it("selects devicectl for iOS 17+ devices", async () => {
       const device = createMockDeviceWithOS("17.0");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(true);
       expect(destination.devicectlId).toBeDefined();
@@ -344,7 +344,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
 
     it("selects ios-deploy for iOS < 17 devices", async () => {
       const device = createMockDeviceWithOS("16.7");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(false);
       expect(destination.udid).toBeDefined();
@@ -352,14 +352,14 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
 
     it("selects devicectl for iOS 18+ devices", async () => {
       const device = createMockDeviceWithOS("18.0");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(true);
     });
 
     it("selects ios-deploy for iOS 15.x devices", async () => {
       const device = createMockDeviceWithOS("15.5");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(false);
     });
@@ -370,7 +370,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
       (getXcodeVersionInstalled as jest.Mock).mockResolvedValue({ major: 16, minor: 0, patch: 0 });
 
       const device = createMockDeviceWithOS("17.0");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       await buildManager.runOniOSDevice(mockTerminal, {
         scheme: "TestApp",
@@ -393,7 +393,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
       (getXcodeVersionInstalled as jest.Mock).mockResolvedValue({ major: 15, minor: 0, patch: 0 });
 
       const device = createMockDeviceWithOS("17.0");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       await buildManager.runOniOSDevice(mockTerminal, {
         scheme: "TestApp",

--- a/src/common/xcode/devicectl.ts
+++ b/src/common/xcode/devicectl.ts
@@ -49,15 +49,20 @@ type DeviceCtlDeviceProperties = {
 
 export type DeviceCtlDeviceType = "iPhone" | "iPad" | "appleWatch" | "appleTV" | "appleVision" | "realityDevice";
 
+/**
+ * All fields are optional because devicectl returns "hardwareProperties": {} for
+ * some iOS <= 16 devices connected via USB (see sweetpad-dev/sweetpad#223). Callers
+ * must handle missing deviceType / platform / udid.
+ */
 type DeviceCtlHardwareProperties = {
   cpuType?: DeviceCtlCpuType;
-  deviceType: DeviceCtlDeviceType;
+  deviceType?: DeviceCtlDeviceType;
   ecid?: number;
   hardwareModel?: string;
   internalStorageCapacity?: number;
   isProductionFused?: boolean;
   marketingName?: string;
-  platform: "iOS";
+  platform?: "iOS";
   productType?: string;
   reality?: "physical";
   serialNumber?: string;

--- a/src/common/xcode/xcdevice.spec.ts
+++ b/src/common/xcode/xcdevice.spec.ts
@@ -1,27 +1,17 @@
 /**
- * Unit tests for xcdevice fallback device listing
+ * Unit tests for listDevicesWithXcdevice.
  */
 
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { createMockContext } from "../../__mocks__/devices";
 import { exec } from "../exec";
-import {
-  createNameLookup,
-  createOsVersionLookup,
-  createUdidLookup,
-  getNameForDevice,
-  getOsVersionForDevice,
-  getUdidForDevice,
-  listDevicesWithXcdevice,
-} from "./xcdevice";
+import { listDevicesWithXcdevice } from "./xcdevice";
 
-// Mock the exec function
 jest.mock("../exec", () => ({
   exec: jest.fn(),
 }));
 
-// Mock logger to avoid output in tests
 jest.mock("../logger", () => ({
   commonLogger: {
     debug: jest.fn(),
@@ -29,385 +19,104 @@ jest.mock("../logger", () => ({
   },
 }));
 
-describe("xcdevice", () => {
-  describe("listDevicesWithXcdevice", () => {
-    const mockContext = createMockContext();
+const fixturesDir = path.join(__dirname, "../../../tests/xcdevice-data");
 
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
+function loadFixture(name: string): string {
+  return fs.readFileSync(path.join(fixturesDir, name), "utf8");
+}
 
-    it("returns iOS devices from xcdevice list output", async () => {
-      const mockData = fs.readFileSync(
-        path.join(__dirname, "../../../tests/xcdevice-data/xcdevice-ios-devices.json"),
-        "utf8",
-      );
-      (exec as jest.Mock).mockResolvedValue(mockData);
+describe("listDevicesWithXcdevice", () => {
+  const mockContext = createMockContext();
 
-      const devices = await listDevicesWithXcdevice(mockContext);
-
-      expect(devices).toHaveLength(3);
-      expect(devices[0].name).toBe("iPhone 14 Pro");
-      expect(devices[0].modelCode).toBe("iPhone15,2");
-      expect(devices[0].operatingSystemVersion).toBe("16.7.12");
-      expect(devices[0].platform).toBe("com.apple.platform.iphoneos");
-    });
-
-    it("filters to only iOS devices from mixed platforms", async () => {
-      const mockData = fs.readFileSync(
-        path.join(__dirname, "../../../tests/xcdevice-data/xcdevice-mixed-devices.json"),
-        "utf8",
-      );
-      (exec as jest.Mock).mockResolvedValue(mockData);
-
-      const devices = await listDevicesWithXcdevice(mockContext);
-
-      expect(devices).toHaveLength(2);
-      expect(devices.every((d) => d.platform === "com.apple.platform.iphoneos")).toBe(true);
-      expect(devices[0].name).toBe("iPhone 14 Pro");
-      expect(devices[1].name).toBe("iPhone 14 Plus");
-    });
-
-    it("returns empty array when no devices found", async () => {
-      const mockData = fs.readFileSync(
-        path.join(__dirname, "../../../tests/xcdevice-data/xcdevice-empty.json"),
-        "utf8",
-      );
-      (exec as jest.Mock).mockResolvedValue(mockData);
-
-      const devices = await listDevicesWithXcdevice(mockContext);
-
-      expect(devices).toEqual([]);
-    });
-
-    it("returns empty array and logs error for malformed JSON", async () => {
-      const mockData = fs.readFileSync(
-        path.join(__dirname, "../../../tests/xcdevice-data/xcdevice-malformed.json"),
-        "utf8",
-      );
-      (exec as jest.Mock).mockResolvedValue(mockData);
-
-      const devices = await listDevicesWithXcdevice(mockContext);
-
-      expect(devices).toEqual([]);
-    });
-
-    it("returns empty array when exec throws an error", async () => {
-      (exec as jest.Mock).mockRejectedValue(new Error("Command failed"));
-
-      const devices = await listDevicesWithXcdevice(mockContext);
-
-      expect(devices).toEqual([]);
-    });
-
-    it("returns empty array when xcdevice command not found", async () => {
-      const error: any = new Error("Command not found");
-      error.code = "ENOENT";
-      (exec as jest.Mock).mockRejectedValue(error);
-
-      const devices = await listDevicesWithXcdevice(mockContext);
-
-      expect(devices).toEqual([]);
-    });
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  describe("createOsVersionLookup", () => {
-    it("creates a map from modelCode to OS version", () => {
-      const devices = [
-        {
-          identifier: "udid1",
-          modelCode: "iPhone15,2",
-          name: "iPhone 14 Pro",
-          operatingSystemVersion: "16.7.12",
-          platform: "com.apple.platform.iphoneos",
-        },
-        {
-          identifier: "udid2",
-          modelCode: "iPhone14,8",
-          name: "iPhone 14 Plus",
-          operatingSystemVersion: "16.6.1",
-          platform: "com.apple.platform.iphoneos",
-        },
-      ];
+  it("returns iOS devices from xcdevice list output", async () => {
+    (exec as jest.Mock).mockResolvedValue(loadFixture("xcdevice-ios-devices.json"));
 
-      const lookup = createOsVersionLookup(devices);
+    const devices = await listDevicesWithXcdevice(mockContext);
 
-      expect(lookup.get("iPhone15,2")).toBe("16.7.12");
-      expect(lookup.get("iPhone14,8")).toBe("16.6.1");
-      expect(lookup.size).toBe(2);
-    });
-
-    it("handles devices with missing modelCode or OS version", () => {
-      const devices = [
-        {
-          identifier: "udid1",
-          modelCode: "iPhone15,2",
-          name: "iPhone 14 Pro",
-          operatingSystemVersion: "16.7.12",
-          platform: "com.apple.platform.iphoneos",
-        },
-        {
-          identifier: "udid2",
-          modelCode: "",
-          name: "Unknown",
-          operatingSystemVersion: "16.6.1",
-          platform: "com.apple.platform.iphoneos",
-        },
-        {
-          identifier: "udid3",
-          modelCode: "iPhone14,8",
-          name: "iPhone 14 Plus",
-          operatingSystemVersion: "",
-          platform: "com.apple.platform.iphoneos",
-        },
-      ];
-
-      const lookup = createOsVersionLookup(devices);
-
-      expect(lookup.get("iPhone15,2")).toBe("16.7.12");
-      expect(lookup.get("iPhone14,8")).toBeUndefined();
-      expect(lookup.get("")).toBeUndefined();
-      expect(lookup.size).toBe(1);
-    });
-
-    it("keeps first entry when multiple devices have same modelCode", () => {
-      const devices = [
-        {
-          identifier: "udid1",
-          modelCode: "iPhone15,2",
-          name: "iPhone 14 Pro 1",
-          operatingSystemVersion: "16.7.12",
-          platform: "com.apple.platform.iphoneos",
-        },
-        {
-          identifier: "udid2",
-          modelCode: "iPhone15,2",
-          name: "iPhone 14 Pro 2",
-          operatingSystemVersion: "16.7.13",
-          platform: "com.apple.platform.iphoneos",
-        },
-      ];
-
-      const lookup = createOsVersionLookup(devices);
-
-      expect(lookup.get("iPhone15,2")).toBe("16.7.12");
-      expect(lookup.size).toBe(1);
-    });
-
-    it("returns empty map for empty device list", () => {
-      const lookup = createOsVersionLookup([]);
-
-      expect(lookup.size).toBe(0);
-    });
+    expect(devices).toHaveLength(3);
+    expect(devices[0].name).toBe("iPhone 14 Pro");
+    expect(devices[0].modelCode).toBe("iPhone15,2");
   });
 
-  describe("createUdidLookup", () => {
-    it("creates a map from modelCode to UDID", () => {
-      const devices = [
-        {
-          identifier: "00008110-001234567890001E",
-          modelCode: "iPhone15,2",
-          name: "iPhone 14 Pro",
-          operatingSystemVersion: "16.7.12",
-          platform: "com.apple.platform.iphoneos",
-        },
-        {
-          identifier: "00008120-001234567890002E",
-          modelCode: "iPhone14,8",
-          name: "iPhone 14 Plus",
-          operatingSystemVersion: "16.6.1",
-          platform: "com.apple.platform.iphoneos",
-        },
-      ];
+  it("keeps devices from iphoneos, watchos, appletvos and xros platforms; drops simulators", async () => {
+    (exec as jest.Mock).mockResolvedValue(loadFixture("xcdevice-mixed-platforms.json"));
 
-      const lookup = createUdidLookup(devices);
+    const devices = await listDevicesWithXcdevice(mockContext);
 
-      expect(lookup.get("iPhone15,2")).toBe("00008110-001234567890001E");
-      expect(lookup.get("iPhone14,8")).toBe("00008120-001234567890002E");
-      expect(lookup.size).toBe(2);
-    });
-
-    it("handles devices with missing modelCode or identifier", () => {
-      const devices = [
-        {
-          identifier: "00008110-001234567890001E",
-          modelCode: "iPhone15,2",
-          name: "iPhone 14 Pro",
-          operatingSystemVersion: "16.7.12",
-          platform: "com.apple.platform.iphoneos",
-        },
-        {
-          identifier: "",
-          modelCode: "iPhone14,8",
-          name: "iPhone 14 Plus",
-          operatingSystemVersion: "16.6.1",
-          platform: "com.apple.platform.iphoneos",
-        },
-        {
-          identifier: "00008130-001234567890003E",
-          modelCode: "",
-          name: "Unknown",
-          operatingSystemVersion: "16.5",
-          platform: "com.apple.platform.iphoneos",
-        },
-      ];
-
-      const lookup = createUdidLookup(devices);
-
-      expect(lookup.get("iPhone15,2")).toBe("00008110-001234567890001E");
-      expect(lookup.get("iPhone14,8")).toBeUndefined();
-      expect(lookup.get("")).toBeUndefined();
-      expect(lookup.size).toBe(1);
-    });
-
-    it("returns empty map for empty device list", () => {
-      const lookup = createUdidLookup([]);
-
-      expect(lookup.size).toBe(0);
-    });
+    // Fixture has 4 real devices + 1 simulator; simulator must be filtered out.
+    expect(devices).toHaveLength(4);
+    const platforms = devices.map((d) => d.platform).sort();
+    expect(platforms).toEqual([
+      "com.apple.platform.appletvos",
+      "com.apple.platform.iphoneos",
+      "com.apple.platform.iphoneos",
+      "com.apple.platform.watchos",
+    ]);
   });
 
-  describe("getOsVersionForDevice", () => {
-    it("returns OS version for known productType", () => {
-      const lookup = new Map([
-        ["iPhone15,2", "16.7.12"],
-        ["iPhone14,8", "16.6.1"],
-      ]);
+  it("retains all supported physical-device platforms in mixed input", async () => {
+    (exec as jest.Mock).mockResolvedValue(loadFixture("xcdevice-mixed-devices.json"));
 
-      expect(getOsVersionForDevice(lookup, "iPhone15,2")).toBe("16.7.12");
-      expect(getOsVersionForDevice(lookup, "iPhone14,8")).toBe("16.6.1");
-    });
+    const devices = await listDevicesWithXcdevice(mockContext);
 
-    it("returns undefined for unknown productType", () => {
-      const lookup = new Map([["iPhone15,2", "16.7.12"]]);
-
-      expect(getOsVersionForDevice(lookup, "iPhone99,9")).toBeUndefined();
-    });
+    // Fixture has iphoneos × 2, watchos, appletvos, xros — all physical, all retained.
+    expect(devices).toHaveLength(5);
+    const platformSet = new Set(devices.map((d) => d.platform));
+    expect(platformSet).toEqual(
+      new Set([
+        "com.apple.platform.iphoneos",
+        "com.apple.platform.watchos",
+        "com.apple.platform.appletvos",
+        "com.apple.platform.xros",
+      ]),
+    );
   });
 
-  describe("getUdidForDevice", () => {
-    it("returns UDID for known productType", () => {
-      const lookup = new Map([
-        ["iPhone15,2", "00008110-001234567890001E"],
-        ["iPhone14,8", "00008120-001234567890002E"],
-      ]);
+  it("retains entries with available:false / error so callers can render them as unavailable", async () => {
+    (exec as jest.Mock).mockResolvedValue(loadFixture("xcdevice-unavailable.json"));
 
-      expect(getUdidForDevice(lookup, "iPhone15,2")).toBe("00008110-001234567890001E");
-      expect(getUdidForDevice(lookup, "iPhone14,8")).toBe("00008120-001234567890002E");
-    });
+    const devices = await listDevicesWithXcdevice(mockContext);
 
-    it("returns undefined for unknown productType", () => {
-      const lookup = new Map([["iPhone15,2", "00008110-001234567890001E"]]);
-
-      expect(getUdidForDevice(lookup, "iPhone99,9")).toBeUndefined();
-    });
+    expect(devices).toHaveLength(1);
+    expect(devices[0].available).toBe(false);
+    expect(devices[0].error?.code).toBe(-9);
   });
 
-  describe("createNameLookup", () => {
-    it("creates a map from modelCode to device name", () => {
-      const devices = [
-        {
-          identifier: "00008110-001234567890001E",
-          modelCode: "iPhone15,2",
-          name: "John's iPhone",
-          operatingSystemVersion: "16.7.12",
-          platform: "com.apple.platform.iphoneos",
-        },
-        {
-          identifier: "00008120-001234567890002E",
-          modelCode: "iPhone14,8",
-          name: "Sarah's iPhone",
-          operatingSystemVersion: "16.6.1",
-          platform: "com.apple.platform.iphoneos",
-        },
-      ];
+  it("returns empty array when no devices found", async () => {
+    (exec as jest.Mock).mockResolvedValue(loadFixture("xcdevice-empty.json"));
 
-      const lookup = createNameLookup(devices);
+    const devices = await listDevicesWithXcdevice(mockContext);
 
-      expect(lookup.get("iPhone15,2")).toBe("John's iPhone");
-      expect(lookup.get("iPhone14,8")).toBe("Sarah's iPhone");
-      expect(lookup.size).toBe(2);
-    });
-
-    it("handles devices with missing modelCode or name", () => {
-      const devices = [
-        {
-          identifier: "00008110-001234567890001E",
-          modelCode: "iPhone15,2",
-          name: "John's iPhone",
-          operatingSystemVersion: "16.7.12",
-          platform: "com.apple.platform.iphoneos",
-        },
-        {
-          identifier: "00008120-001234567890002E",
-          modelCode: "",
-          name: "Invalid Device",
-          operatingSystemVersion: "16.6.1",
-          platform: "com.apple.platform.iphoneos",
-        },
-        {
-          identifier: "00008130-001234567890003E",
-          modelCode: "iPhone14,8",
-          name: "",
-          operatingSystemVersion: "16.5",
-          platform: "com.apple.platform.iphoneos",
-        },
-      ];
-
-      const lookup = createNameLookup(devices);
-
-      expect(lookup.get("iPhone15,2")).toBe("John's iPhone");
-      expect(lookup.get("iPhone14,8")).toBeUndefined();
-      expect(lookup.get("")).toBeUndefined();
-      expect(lookup.size).toBe(1);
-    });
-
-    it("keeps first entry when multiple devices have same modelCode", () => {
-      const devices = [
-        {
-          identifier: "00008110-001234567890001E",
-          modelCode: "iPhone15,2",
-          name: "John's iPhone",
-          operatingSystemVersion: "16.7.12",
-          platform: "com.apple.platform.iphoneos",
-        },
-        {
-          identifier: "00008120-001234567890002E",
-          modelCode: "iPhone15,2",
-          name: "Jane's iPhone",
-          operatingSystemVersion: "16.7.13",
-          platform: "com.apple.platform.iphoneos",
-        },
-      ];
-
-      const lookup = createNameLookup(devices);
-
-      expect(lookup.get("iPhone15,2")).toBe("John's iPhone");
-      expect(lookup.size).toBe(1);
-    });
-
-    it("returns empty map for empty device list", () => {
-      const lookup = createNameLookup([]);
-
-      expect(lookup.size).toBe(0);
-    });
+    expect(devices).toEqual([]);
   });
 
-  describe("getNameForDevice", () => {
-    it("returns device name for known productType", () => {
-      const lookup = new Map([
-        ["iPhone15,2", "John's iPhone"],
-        ["iPhone14,8", "Sarah's iPhone"],
-      ]);
+  it("returns empty array and logs error for malformed JSON", async () => {
+    (exec as jest.Mock).mockResolvedValue(loadFixture("xcdevice-malformed.json"));
 
-      expect(getNameForDevice(lookup, "iPhone15,2")).toBe("John's iPhone");
-      expect(getNameForDevice(lookup, "iPhone14,8")).toBe("Sarah's iPhone");
-    });
+    const devices = await listDevicesWithXcdevice(mockContext);
 
-    it("returns undefined for unknown productType", () => {
-      const lookup = new Map([["iPhone15,2", "John's iPhone"]]);
+    expect(devices).toEqual([]);
+  });
 
-      expect(getNameForDevice(lookup, "iPhone99,9")).toBeUndefined();
-    });
+  it("returns empty array when exec throws", async () => {
+    (exec as jest.Mock).mockRejectedValue(new Error("Command failed"));
+
+    const devices = await listDevicesWithXcdevice(mockContext);
+
+    expect(devices).toEqual([]);
+  });
+
+  it("returns empty array when xcdevice command not found (ENOENT)", async () => {
+    const error: any = new Error("Command not found");
+    error.code = "ENOENT";
+    (exec as jest.Mock).mockRejectedValue(error);
+
+    const devices = await listDevicesWithXcdevice(mockContext);
+
+    expect(devices).toEqual([]);
   });
 });

--- a/src/common/xcode/xcdevice.ts
+++ b/src/common/xcode/xcdevice.ts
@@ -3,22 +3,62 @@ import { exec } from "../exec";
 import { commonLogger } from "../logger";
 
 /**
- * Represents a device from xcdevice list output
- * Note: xcdevice uses different field names than devicectl
+ * Represents a device from "xcrun xcdevice list" output.
+ *
+ * xcdevice returns physical devices (and simulators) across all Apple platforms.
+ * Fields come from Xcode's own device database and are more reliable than devicectl
+ * for iOS <= 16 devices, which devicectl either reports with empty hardwareProperties
+ * or omits entirely.
  */
 export type XcdeviceDevice = {
-  identifier: string; // Different from devicectl identifier - this is the UDID
-  modelCode: string; // Same as productType in devicectl (e.g., "iPhone10,6")
+  /** UDID in legacy format (e.g. "00008110-001234567890001E"). Same value as DeviceCtlDevice.hardwareProperties.udid when both sources report the device. */
+  identifier: string;
+  /** e.g. "iPhone15,2" — same as DeviceCtlDevice.hardwareProperties.productType. */
+  modelCode: string;
+  /** User-customized device name, or marketing name if never customized. */
   name: string;
-  operatingSystemVersion: string; // e.g., "16.7.12"
-  platform: "com.apple.platform.iphoneos" | string;
+  /** e.g. "16.7.12". May be an empty string for unavailable devices. */
+  operatingSystemVersion: string;
+  /** "com.apple.platform.iphoneos" | "com.apple.platform.watchos" | "com.apple.platform.appletvos" | "com.apple.platform.xros" | ... */
+  platform: string;
+  /** True for iOS/watchOS simulators. We filter these out. */
+  simulator?: boolean;
+  /** False when the device is not currently reachable/paired. Still listed, just with degraded info. */
+  available?: boolean;
+  /** Transport Xcode believes it would use. Note: Xcode 15+ lies here for iOS 17+ wireless devices. */
+  interface?: "usb" | "network" | string;
+  /** CPU architecture (e.g. "arm64e"). Not always present. */
+  architecture?: string;
+  /** Friendly model name (e.g. "iPhone 13 Pro"). Not always present. */
+  modelName?: string;
+  /** Present on unavailable entries. Common codes: -9 not paired, -10 locked, -14 dev-mode disabled. */
+  error?: {
+    code: number;
+    domain?: string;
+    failureReason?: string;
+    description?: string;
+  };
 };
 
 type XcdeviceListOutput = XcdeviceDevice[];
 
 /**
- * List devices using xcdevice command
- * This is a fallback for older devices that don't report OS version via devicectl
+ * Platform strings we accept as physical Apple devices. Anything else (simulators,
+ * macOS, driverkit, etc.) is filtered out.
+ */
+const SUPPORTED_PLATFORMS = new Set([
+  "com.apple.platform.iphoneos",
+  "com.apple.platform.watchos",
+  "com.apple.platform.appletvos",
+  "com.apple.platform.xros",
+]);
+
+/**
+ * List devices using "xcrun xcdevice list".
+ *
+ * Retains entries with "available: false" or an "error" payload — downstream code
+ * (DeviceDestinationBase.state) derives "unavailable" from those so the device still shows
+ * in the tree, just marked disconnected.
  */
 export async function listDevicesWithXcdevice(context: ExtensionContext): Promise<XcdeviceDevice[]> {
   try {
@@ -31,94 +71,14 @@ export async function listDevicesWithXcdevice(context: ExtensionContext): Promis
 
     const devices: XcdeviceListOutput = JSON.parse(stdout);
 
-    // Filter to only include iOS devices (not simulators)
     return devices.filter((device) => {
-      // Only include physical iOS devices
-      return device.platform === "com.apple.platform.iphoneos";
+      if (device.simulator === true) {
+        return false;
+      }
+      return SUPPORTED_PLATFORMS.has(device.platform);
     });
   } catch (error) {
     commonLogger.error("Failed to list devices with xcdevice", { error });
     return [];
   }
-}
-
-/**
- * Create a lookup map from modelCode to OS version
- * This allows us to match devices by productType/modelCode
- */
-export function createOsVersionLookup(devices: XcdeviceDevice[]): Map<string, string> {
-  const lookup = new Map<string, string>();
-
-  for (const device of devices) {
-    if (device.modelCode && device.operatingSystemVersion) {
-      // If multiple devices have the same modelCode, we keep the first one
-      // In practice, this shouldn't matter as they should have the same OS version
-      if (!lookup.has(device.modelCode)) {
-        lookup.set(device.modelCode, device.operatingSystemVersion);
-      }
-    }
-  }
-
-  return lookup;
-}
-
-/**
- * Get OS version for a device by its productType (modelCode in xcdevice)
- */
-export function getOsVersionForDevice(lookup: Map<string, string>, productType: string): string | undefined {
-  return lookup.get(productType);
-}
-
-/**
- * Create a lookup map from modelCode to UDID (identifier in xcdevice)
- * This provides the correct UDID format for xcodebuild for older devices
- */
-export function createUdidLookup(devices: XcdeviceDevice[]): Map<string, string> {
-  const lookup = new Map<string, string>();
-
-  for (const device of devices) {
-    if (device.modelCode && device.identifier) {
-      // If multiple devices have the same modelCode, we keep the first one
-      // In practice, this shouldn't matter as they should have the same UDID
-      if (!lookup.has(device.modelCode)) {
-        lookup.set(device.modelCode, device.identifier);
-      }
-    }
-  }
-
-  return lookup;
-}
-
-/**
- * Get UDID for a device by its productType (modelCode in xcdevice)
- */
-export function getUdidForDevice(lookup: Map<string, string>, productType: string): string | undefined {
-  return lookup.get(productType);
-}
-
-/**
- * Create a lookup map from modelCode to device name
- * This provides the user-customized name for older devices where devicectl returns marketing name
- */
-export function createNameLookup(devices: XcdeviceDevice[]): Map<string, string> {
-  const lookup = new Map<string, string>();
-
-  for (const device of devices) {
-    if (device.modelCode && device.name) {
-      // If multiple devices have the same modelCode, we keep the first one
-      // In practice, this shouldn't matter as they should have different names
-      if (!lookup.has(device.modelCode)) {
-        lookup.set(device.modelCode, device.name);
-      }
-    }
-  }
-
-  return lookup;
-}
-
-/**
- * Get device name for a device by its productType (modelCode in xcdevice)
- */
-export function getNameForDevice(lookup: Map<string, string>, productType: string): string | undefined {
-  return lookup.get(productType);
 }

--- a/src/devices/manager.spec.ts
+++ b/src/devices/manager.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for device manager with dual-source fetching
+ * Unit tests for DevicesManager with dual-source fetching + iOS <=16 recovery.
  */
 
 import * as fs from "node:fs";
@@ -9,7 +9,6 @@ import { listDevices } from "../common/xcode/devicectl";
 import { listDevicesWithXcdevice } from "../common/xcode/xcdevice";
 import { DevicesManager } from "./manager";
 
-// Mock dependencies
 jest.mock("../common/exec", () => ({
   exec: jest.fn(),
 }));
@@ -20,23 +19,11 @@ jest.mock("../common/xcode/devicectl", () => ({
 
 jest.mock("../common/xcode/xcdevice", () => ({
   listDevicesWithXcdevice: jest.fn(),
-  createNameLookup: jest.fn(),
-  createOsVersionLookup: jest.fn(),
-  createUdidLookup: jest.fn(),
-  getNameForDevice: jest.fn(),
-  getOsVersionForDevice: jest.fn(),
-  getUdidForDevice: jest.fn(),
 }));
 
-// Import mocked modules
-import {
-  createNameLookup,
-  createOsVersionLookup,
-  createUdidLookup,
-  getNameForDevice,
-  getOsVersionForDevice,
-  getUdidForDevice,
-} from "../common/xcode/xcdevice";
+function loadFixture(relativePath: string): any {
+  return JSON.parse(fs.readFileSync(path.join(__dirname, "../..", relativePath), "utf8"));
+}
 
 describe("DevicesManager", () => {
   let manager: DevicesManager;
@@ -51,238 +38,137 @@ describe("DevicesManager", () => {
 
   describe("refresh", () => {
     it("fetches devices from both devicectl and xcdevice in parallel", async () => {
-      const mockDevicectlData = JSON.parse(
-        fs.readFileSync(path.join(__dirname, "../../tests/devicectl-data/devicectl-ios-17-modern.json"), "utf8"),
-      );
-      const mockXcdeviceData = JSON.parse(
-        fs.readFileSync(path.join(__dirname, "../../tests/xcdevice-data/xcdevice-ios-devices.json"), "utf8"),
+      (listDevices as jest.Mock).mockResolvedValue(loadFixture("tests/devicectl-data/devicectl-ios-17-modern.json"));
+      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue(
+        loadFixture("tests/xcdevice-data/xcdevice-ios-devices.json"),
       );
 
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
-      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue(mockXcdeviceData);
-      (createNameLookup as jest.Mock).mockReturnValue(new Map());
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(new Map());
-
-      const devices = await manager.refresh();
+      await manager.refresh();
 
       expect(listDevices).toHaveBeenCalledWith(mockContext);
       expect(listDevicesWithXcdevice).toHaveBeenCalledWith(mockContext);
-      expect(createNameLookup).toHaveBeenCalledWith(mockXcdeviceData);
-      expect(createOsVersionLookup).toHaveBeenCalledWith(mockXcdeviceData);
-      expect(createUdidLookup).toHaveBeenCalledWith(mockXcdeviceData);
     });
 
-    it("merges OS version from xcdevice when missing from devicectl", async () => {
-      const mockDevicectlData = JSON.parse(
-        fs.readFileSync(
-          path.join(__dirname, "../../tests/devicectl-data/devicectl-ios-16-missing-fields.json"),
-          "utf8",
-        ),
-      );
-      const mockXcdeviceData = [
-        {
-          identifier: "00008110-000987654321003E",
-          modelCode: "iPhone14,5",
-          name: "iPhone 13",
-          operatingSystemVersion: "16.5.1",
-          platform: "com.apple.platform.iphoneos",
-        },
-      ];
-
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
-      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue(mockXcdeviceData);
-
-      const osVersionMap = new Map([["iPhone14,5", "16.5.1"]]);
-      const udidMap = new Map([["iPhone14,5", "00008110-000987654321003E"]]);
-
-      (createNameLookup as jest.Mock).mockReturnValue(new Map());
-      (createOsVersionLookup as jest.Mock).mockReturnValue(osVersionMap);
-      (createUdidLookup as jest.Mock).mockReturnValue(udidMap);
-      (getNameForDevice as jest.Mock).mockReturnValue(undefined);
-      (getOsVersionForDevice as jest.Mock).mockImplementation((map, productType) => map.get(productType));
-      (getUdidForDevice as jest.Mock).mockImplementation((map, productType) => map.get(productType));
+    it("wraps iOS 17+ devicectl device when xcdevice is empty", async () => {
+      (listDevices as jest.Mock).mockResolvedValue(loadFixture("tests/devicectl-data/devicectl-ios-17-modern.json"));
+      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
 
       const devices = await manager.refresh();
 
       expect(devices).toHaveLength(1);
-      expect(devices[0].osVersion).toBe("16.5.1");
-      expect(devices[0].udid).toBe("00008110-000987654321003E");
+      expect(devices[0].type).toBe("iOSDevice");
+      expect(devices[0].supportsDevicectl).toBe(true);
     });
 
-    it("merges UDID from xcdevice when missing from devicectl", async () => {
-      const mockDevicectlData = JSON.parse(
-        fs.readFileSync(
-          path.join(__dirname, "../../tests/devicectl-data/devicectl-ios-16-missing-fields.json"),
-          "utf8",
-        ),
-      );
-      const mockXcdeviceData = [
-        {
-          identifier: "00008110-000987654321003E",
-          modelCode: "iPhone14,5",
-          name: "John's iPhone",
-          operatingSystemVersion: "16.5.1",
-          platform: "com.apple.platform.iphoneos",
-        },
-      ];
-
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
-      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue(mockXcdeviceData);
-
-      const udidMap = new Map([["iPhone14,5", "00008110-000987654321003E"]]);
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(udidMap);
-      (getOsVersionForDevice as jest.Mock).mockReturnValue(undefined);
-      (getUdidForDevice as jest.Mock).mockImplementation((map, productType) => map.get(productType));
-
-      const devices = await manager.refresh();
-
-      expect(devices).toHaveLength(1);
-      expect(devices[0].udid).toBe("00008110-000987654321003E");
-    });
-
-    it("merges device name from xcdevice when devicectl returns marketing name", async () => {
-      const mockDevicectlData = JSON.parse(
-        fs.readFileSync(
-          path.join(__dirname, "../../tests/devicectl-data/devicectl-ios-16-missing-fields.json"),
-          "utf8",
-        ),
-      );
-      const mockXcdeviceData = [
-        {
-          identifier: "00008110-000987654321003E",
-          modelCode: "iPhone14,5",
-          name: "John's iPhone",
-          operatingSystemVersion: "16.5.1",
-          platform: "com.apple.platform.iphoneos",
-        },
-      ];
-
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
-      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue(mockXcdeviceData);
-
-      const nameMap = new Map([["iPhone14,5", "John's iPhone"]]);
-      (createNameLookup as jest.Mock).mockReturnValue(nameMap);
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(new Map());
-      (getNameForDevice as jest.Mock).mockImplementation((map, productType) => map.get(productType));
-      (getOsVersionForDevice as jest.Mock).mockReturnValue(undefined);
-      (getUdidForDevice as jest.Mock).mockReturnValue(undefined);
-
-      const devices = await manager.refresh();
-
-      expect(devices).toHaveLength(1);
-      expect(devices[0].name).toBe("John's iPhone");
-    });
-
-    it("uses devicectl name when it differs from marketing name", async () => {
-      const mockDevicectlData = {
+    it("deduplicates when both sources report the same UDID", async () => {
+      const devicectlData = {
         result: {
           devices: [
             {
               capabilities: [],
-              connectionProperties: {
-                tunnelState: "connected",
-                pairingState: "paired",
-              },
-              deviceProperties: {
-                name: "John's iPhone 15 Pro",
-                osVersionNumber: "17.0",
-              },
+              connectionProperties: { tunnelState: "connected", pairingState: "paired" },
+              deviceProperties: { name: "John's iPhone", osVersionNumber: "17.0" },
               hardwareProperties: {
                 deviceType: "iPhone",
                 marketingName: "iPhone 15 Pro",
                 productType: "iPhone16,1",
-                udid: "00008110-000123456789001E",
+                udid: "00008110-DEDUP000001",
                 platform: "iOS",
               },
-              identifier: "urn:x-ios-devicectl:device-CS1234567-1234567890123456",
+              identifier: "urn:x-ios-devicectl:device-DEDUP",
               visibilityClass: "default",
             },
           ],
         },
       };
-      const mockXcdeviceData = [
+      const xcdeviceData = [
         {
-          identifier: "00008110-000987654321001E",
-          modelCode: "iPhone16,1",
-          name: "Different Name from xcdevice",
-          operatingSystemVersion: "17.0",
+          simulator: false,
+          available: true,
           platform: "com.apple.platform.iphoneos",
+          modelCode: "iPhone16,1",
+          identifier: "00008110-DEDUP000001",
+          operatingSystemVersion: "17.0",
+          name: "John's iPhone",
         },
       ];
 
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
-      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue(mockXcdeviceData);
-
-      const nameMap = new Map([["iPhone16,1", "Different Name from xcdevice"]]);
-      (createNameLookup as jest.Mock).mockReturnValue(nameMap);
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(new Map());
-      (getNameForDevice as jest.Mock).mockImplementation((map, productType) => map.get(productType));
-      (getOsVersionForDevice as jest.Mock).mockReturnValue(undefined);
-      (getUdidForDevice as jest.Mock).mockReturnValue(undefined);
+      (listDevices as jest.Mock).mockResolvedValue(devicectlData);
+      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue(xcdeviceData);
 
       const devices = await manager.refresh();
 
       expect(devices).toHaveLength(1);
-      // devicectl returns "John's iPhone 15 Pro" which differs from marketing name "iPhone 15 Pro"
-      // so we should use the devicectl name, not fall back to xcdevice
-      expect(devices[0].name).toBe("John's iPhone 15 Pro");
+      expect(devices[0].devicectlId).toBe("urn:x-ios-devicectl:device-DEDUP");
     });
 
-    it("applies safe defaults for missing data", async () => {
-      const mockDevicectlData = {
-        result: {
-          devices: [
-            {
-              capabilities: [],
-              connectionProperties: {
-                tunnelState: "connected",
-                pairingState: "paired",
-              },
-              deviceProperties: {},
-              hardwareProperties: {
-                deviceType: "iPhone",
-                platform: "iOS",
-              },
-              identifier: "urn:x-ios-devicectl:device-test",
-              visibilityClass: "default",
-            },
-          ],
-        },
-      };
-
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
-      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
-      (createNameLookup as jest.Mock).mockReturnValue(new Map());
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(new Map());
+    it("recovers iOS 16 Wi-Fi device when devicectl returns no devices", async () => {
+      (listDevices as jest.Mock).mockResolvedValue(loadFixture("tests/devicectl-data/devicectl-no-devices.json"));
+      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue(
+        loadFixture("tests/xcdevice-data/xcdevice-ios-16-wifi.json"),
+      );
 
       const devices = await manager.refresh();
 
       expect(devices).toHaveLength(1);
-      expect(devices[0].osVersion).toBe("Unknown");
-      // When productType is "Unknown", the name falls back to productType value
-      expect(devices[0].name).toBe("Unknown");
-      expect(devices[0].udid).toBe("urn:x-ios-devicectl:device-test");
+      expect(devices[0].type).toBe("iOSDevice");
+      expect(devices[0].name).toBe("My iPhone");
+      expect(devices[0].osVersion).toBe("16.4.1");
+      expect(devices[0].udid).toBe("00008110-000AABBCCDD11111");
+      expect(devices[0].devicectlId).toBeNull();
+      expect(devices[0].supportsDevicectl).toBe(false);
+      expect(devices[0].isConnected).toBe(true);
+    });
+
+    it("recovers iOS 16 USB device when devicectl returns empty hardwareProperties", async () => {
+      (listDevices as jest.Mock).mockResolvedValue(
+        loadFixture("tests/devicectl-data/devicectl-ios-16-usb-empty-hardware.json"),
+      );
+      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue(
+        loadFixture("tests/xcdevice-data/xcdevice-ios-16-usb-match.json"),
+      );
+
+      const devices = await manager.refresh();
+
+      expect(devices).toHaveLength(1);
+      expect(devices[0].type).toBe("iOSDevice");
+      expect(devices[0].name).toBe("Nixuge iPhone");
+      expect(devices[0].udid).toBe("00008110-000AABBCCDD22222");
+      expect(devices[0].supportsDevicectl).toBe(false);
+    });
+
+    it("shows an unavailable xcdevice entry as disconnected", async () => {
+      (listDevices as jest.Mock).mockResolvedValue(loadFixture("tests/devicectl-data/devicectl-no-devices.json"));
+      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue(
+        loadFixture("tests/xcdevice-data/xcdevice-unavailable.json"),
+      );
+
+      const devices = await manager.refresh();
+
+      expect(devices).toHaveLength(1);
+      expect(devices[0].isConnected).toBe(false);
+      expect(devices[0].state).toBe("unavailable");
+    });
+
+    it("drops devicectl entries with empty hardwareProperties and no xcdevice match", async () => {
+      (listDevices as jest.Mock).mockResolvedValue(
+        loadFixture("tests/devicectl-data/devicectl-ios-16-usb-empty-hardware.json"),
+      );
+      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
+
+      const devices = await manager.refresh();
+
+      expect(devices).toEqual([]);
     });
 
     it("filters devices without identifier", async () => {
-      const mockDevicectlData = {
+      const devicectlData = {
         result: {
           devices: [
             {
               capabilities: [],
-              connectionProperties: {
-                tunnelState: "connected",
-                pairingState: "paired",
-              },
-              deviceProperties: {
-                name: "Valid Device",
-                osVersionNumber: "17.0",
-              },
+              connectionProperties: { tunnelState: "connected", pairingState: "paired" },
+              deviceProperties: { name: "Valid Device", osVersionNumber: "17.0" },
               hardwareProperties: {
                 deviceType: "iPhone",
                 marketingName: "iPhone 15 Pro",
@@ -294,13 +180,8 @@ describe("DevicesManager", () => {
             },
             {
               capabilities: [],
-              connectionProperties: {
-                tunnelState: "connected",
-                pairingState: "paired",
-              },
-              deviceProperties: {
-                name: "Device Without Identifier",
-              },
+              connectionProperties: { tunnelState: "connected", pairingState: "paired" },
+              deviceProperties: { name: "Device Without Identifier" },
               hardwareProperties: {
                 deviceType: "iPhone",
                 marketingName: "Invalid Device",
@@ -313,11 +194,8 @@ describe("DevicesManager", () => {
         },
       };
 
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
+      (listDevices as jest.Mock).mockResolvedValue(devicectlData);
       (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
-      (createNameLookup as jest.Mock).mockReturnValue(new Map());
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(new Map());
 
       const devices = await manager.refresh();
 
@@ -325,87 +203,43 @@ describe("DevicesManager", () => {
       expect(devices[0].name).toBe("Valid Device");
     });
 
-    it("filters devices without deviceType", async () => {
-      const mockDevicectlData = {
-        result: {
-          devices: [
-            {
-              capabilities: [],
-              connectionProperties: {
-                tunnelState: "connected",
-                pairingState: "paired",
-              },
-              deviceProperties: {
-                name: "Valid Device",
-                osVersionNumber: "17.0",
-              },
-              hardwareProperties: {
-                deviceType: "iPhone",
-                marketingName: "iPhone 15 Pro",
-                productType: "iPhone16,1",
-                platform: "iOS",
-              },
-              identifier: "urn:x-ios-devicectl:device-valid",
-              visibilityClass: "default",
-            },
-            {
-              capabilities: [],
-              connectionProperties: {
-                tunnelState: "connected",
-                pairingState: "paired",
-              },
-              deviceProperties: {
-                name: "Device Without DeviceType",
-              },
-              hardwareProperties: {
-                marketingName: "Invalid Device",
-                productType: "iPhone99,9",
-                platform: "iOS",
-              },
-              identifier: "urn:x-ios-devicectl:device-invalid",
-              visibilityClass: "default",
-            },
-          ],
-        },
-      };
-
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
-      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
-      (createNameLookup as jest.Mock).mockReturnValue(new Map());
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(new Map());
-
-      const devices = await manager.refresh();
-
-      expect(devices).toHaveLength(1);
-      expect(devices[0].name).toBe("Valid Device");
-    });
-
-    it("creates correct device type instances", async () => {
-      const mockDevicectlData = JSON.parse(
-        fs.readFileSync(path.join(__dirname, "../../tests/devicectl-data/devicectl-multiple-devices.json"), "utf8"),
+    it("creates correct device type instances from mixed xcdevice platforms", async () => {
+      (listDevices as jest.Mock).mockResolvedValue(loadFixture("tests/devicectl-data/devicectl-no-devices.json"));
+      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue(
+        loadFixture("tests/xcdevice-data/xcdevice-mixed-platforms.json"),
       );
 
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
+      const devices = await manager.refresh();
+
+      const byType = devices.map((d) => d.type).sort();
+      // iPhone, iPad → both iOSDevice; watch, tv → watchOSDevice, tvOSDevice.
+      // Simulator entry filtered out by listDevicesWithXcdevice (mocked data includes
+      // a simulator but the mock is passed through — simulator filtering lives in
+      // listDevicesWithXcdevice, so here we expect all non-simulator entries.)
+      expect(byType).toEqual(["iOSDevice", "iOSDevice", "tvOSDevice", "watchOSDevice", "iOSDevice"].sort());
+    });
+
+    it("creates correct device type instances from devicectl fixtures", async () => {
+      (listDevices as jest.Mock).mockResolvedValue(loadFixture("tests/devicectl-data/devicectl-multiple-devices.json"));
       (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
-      (createNameLookup as jest.Mock).mockReturnValue(new Map());
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(new Map());
 
       const devices = await manager.refresh();
 
       expect(devices).toHaveLength(5);
-      expect(devices[0].type).toBe("iOSDevice");
-      expect(devices[1].type).toBe("iOSDevice");
-      expect(devices[2].type).toBe("watchOSDevice");
-      expect(devices[3].type).toBe("tvOSDevice");
-      expect(devices[4].type).toBe("visionOSDevice");
+      expect(devices.map((d) => d.type)).toEqual([
+        "iOSDevice",
+        "iOSDevice",
+        "watchOSDevice",
+        "tvOSDevice",
+        "visionOSDevice",
+      ]);
     });
 
     it("handles ENOENT error by setting failed to 'no-devicectl'", async () => {
       const error: any = new Error("devicectl not found");
       error.error = { code: "ENOENT" };
       (listDevices as jest.Mock).mockRejectedValue(error);
+      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
 
       const devices = await manager.refresh();
 
@@ -415,6 +249,7 @@ describe("DevicesManager", () => {
 
     it("handles other errors by setting failed to 'unknown'", async () => {
       (listDevices as jest.Mock).mockRejectedValue(new Error("Unknown error"));
+      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
 
       const devices = await manager.refresh();
 
@@ -423,110 +258,61 @@ describe("DevicesManager", () => {
     });
 
     it("caches device list after refresh", async () => {
-      const mockDevicectlData = JSON.parse(
-        fs.readFileSync(path.join(__dirname, "../../tests/devicectl-data/devicectl-ios-17-modern.json"), "utf8"),
-      );
-
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
+      (listDevices as jest.Mock).mockResolvedValue(loadFixture("tests/devicectl-data/devicectl-ios-17-modern.json"));
       (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
-      (createNameLookup as jest.Mock).mockReturnValue(new Map());
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(new Map());
 
       await manager.refresh();
-
-      // Second call should not trigger new fetch
-      const devices = await manager.getDevices();
+      await manager.getDevices();
 
       expect(listDevices).toHaveBeenCalledTimes(1);
-      expect(devices).toHaveLength(1);
     });
 
     it("emits updated event after refresh", async () => {
-      const mockDevicectlData = JSON.parse(
-        fs.readFileSync(path.join(__dirname, "../../tests/devicectl-data/devicectl-ios-17-modern.json"), "utf8"),
-      );
-
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
+      (listDevices as jest.Mock).mockResolvedValue(loadFixture("tests/devicectl-data/devicectl-ios-17-modern.json"));
       (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
-      (createNameLookup as jest.Mock).mockReturnValue(new Map());
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(new Map());
 
-      const updatedListener = jest.fn();
-      manager.on("updated", updatedListener);
+      const listener = jest.fn();
+      manager.on("updated", listener);
 
       await manager.refresh();
 
-      expect(updatedListener).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalled();
     });
   });
 
   describe("getDevices", () => {
-    it("returns cached devices without refresh", async () => {
-      const mockDevicectlData = JSON.parse(
-        fs.readFileSync(path.join(__dirname, "../../tests/devicectl-data/devicectl-ios-17-modern.json"), "utf8"),
-      );
-
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
+    beforeEach(() => {
+      (listDevices as jest.Mock).mockResolvedValue(loadFixture("tests/devicectl-data/devicectl-ios-17-modern.json"));
       (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
-      (createNameLookup as jest.Mock).mockReturnValue(new Map());
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(new Map());
+    });
 
+    it("returns cached devices without refresh", async () => {
       await manager.refresh();
-      const devices = await manager.getDevices();
-
+      await manager.getDevices();
       expect(listDevices).toHaveBeenCalledTimes(1);
-      expect(devices).toHaveLength(1);
     });
 
     it("forces refresh when options.refresh is true", async () => {
-      const mockDevicectlData = JSON.parse(
-        fs.readFileSync(path.join(__dirname, "../../tests/devicectl-data/devicectl-ios-17-modern.json"), "utf8"),
-      );
-
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
-      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
-      (createNameLookup as jest.Mock).mockReturnValue(new Map());
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(new Map());
-
       await manager.refresh();
       await manager.getDevices({ refresh: true });
-
       expect(listDevices).toHaveBeenCalledTimes(2);
     });
 
     it("fetches devices when cache is empty", async () => {
-      const mockDevicectlData = JSON.parse(
-        fs.readFileSync(path.join(__dirname, "../../tests/devicectl-data/devicectl-ios-17-modern.json"), "utf8"),
-      );
-
-      (listDevices as jest.Mock).mockResolvedValue(mockDevicectlData);
-      (listDevicesWithXcdevice as jest.Mock).mockResolvedValue([]);
-      (createNameLookup as jest.Mock).mockReturnValue(new Map());
-      (createOsVersionLookup as jest.Mock).mockReturnValue(new Map());
-      (createUdidLookup as jest.Mock).mockReturnValue(new Map());
-
-      const devices = await manager.getDevices();
-
+      await manager.getDevices();
       expect(listDevices).toHaveBeenCalledTimes(1);
-      expect(devices).toHaveLength(1);
     });
   });
 
   describe("context property", () => {
     it("throws error when context is not set", () => {
       const newManager = new DevicesManager();
-
       expect(() => newManager.context).toThrow("Context is not set");
     });
 
     it("returns context when set", () => {
       const newManager = new DevicesManager();
       newManager.context = mockContext;
-
       expect(newManager.context).toBe(mockContext);
     });
   });

--- a/src/devices/manager.ts
+++ b/src/devices/manager.ts
@@ -2,17 +2,11 @@ import events from "node:events";
 import type { ExtensionContext } from "../common/commands";
 import { checkUnreachable } from "../common/types";
 import { listDevices } from "../common/xcode/devicectl";
-import {
-  createNameLookup,
-  createOsVersionLookup,
-  createUdidLookup,
-  getNameForDevice,
-  getOsVersionForDevice,
-  getUdidForDevice,
-  listDevicesWithXcdevice,
-} from "../common/xcode/xcdevice";
+import { listDevicesWithXcdevice } from "../common/xcode/xcdevice";
+import { mergeDeviceSources, resolveDeviceType } from "./merge";
 import {
   type DeviceDestination,
+  type DeviceRaw,
   iOSDeviceDestination,
   tvOSDeviceDestination,
   visionOSDeviceDestination,
@@ -22,6 +16,28 @@ import {
 type DeviceManagerEventTypes = {
   updated: [];
 };
+
+function buildDeviceDestination(raw: DeviceRaw): DeviceDestination | null {
+  const deviceType = resolveDeviceType(raw);
+  if (!deviceType) {
+    return null;
+  }
+  switch (deviceType) {
+    case "appleWatch":
+      return new watchOSDeviceDestination(raw);
+    case "iPhone":
+    case "iPad":
+      return new iOSDeviceDestination(raw);
+    case "appleVision":
+    case "realityDevice":
+      return new visionOSDeviceDestination(raw);
+    case "appleTV":
+      return new tvOSDeviceDestination(raw);
+    default:
+      checkUnreachable(deviceType);
+      return null;
+  }
+}
 
 export class DevicesManager {
   private cache: DeviceDestination[] | undefined = undefined;
@@ -45,107 +61,43 @@ export class DevicesManager {
     return this._context;
   }
 
-  private async fetchDevices(): Promise<DeviceDestination[]> {
-    // Fetch devices from both sources in parallel
-    const [output, xcdeviceList] = await Promise.all([
+  private async fetchDevices(): Promise<{ devices: DeviceDestination[]; devicectlError: unknown }> {
+    // Run both sources in parallel; degrade rather than fail if one source errors.
+    // The iOS <= 16 recovery path relies on xcdevice — we must not drop xcdevice
+    // results just because devicectl (ENOENT on old Xcode, sandboxed env) blew up.
+    const [devicectlResult, xcdeviceResult] = await Promise.allSettled([
       listDevices(this.context),
       listDevicesWithXcdevice(this.context),
     ]);
 
-    // Create lookup maps from modelCode to OS version, UDID, and name for fallback
-    const osVersionLookup = createOsVersionLookup(xcdeviceList);
-    const udidLookup = createUdidLookup(xcdeviceList);
-    const nameLookup = createNameLookup(xcdeviceList);
+    const devicectlDevices =
+      devicectlResult.status === "fulfilled" ? devicectlResult.value.result.devices : [];
+    const xcdeviceList = xcdeviceResult.status === "fulfilled" ? xcdeviceResult.value : [];
 
-    return output.result.devices
-      .filter((device) => {
-        // Filter out devices without required fields
-        if (!device.identifier) {
-          return false;
-        }
-        if (!device.hardwareProperties?.deviceType) {
-          return false;
-        }
-        return true;
-      })
-      .map((device) => {
-        // Get OS version from devicectl or fallback to xcdevice
-        let osVersionNumber = device.deviceProperties.osVersionNumber;
-        if (!osVersionNumber && device.hardwareProperties.productType) {
-          const xcdeviceVersion = getOsVersionForDevice(osVersionLookup, device.hardwareProperties.productType);
-          if (xcdeviceVersion) {
-            osVersionNumber = xcdeviceVersion;
-          }
-        }
+    const merged = mergeDeviceSources(devicectlDevices, xcdeviceList);
+    const devices = merged.map(buildDeviceDestination).filter((d) => d !== null);
 
-        // Get UDID from devicectl or fallback to xcdevice (for older devices)
-        // xcdevice provides the correct UDID format for xcodebuild
-        let udid = device.hardwareProperties.udid;
-        if (!udid && device.hardwareProperties.productType) {
-          const xcdeviceUdid = getUdidForDevice(udidLookup, device.hardwareProperties.productType);
-          if (xcdeviceUdid) {
-            udid = xcdeviceUdid;
-          }
-        }
-
-        // Get device name from devicectl or fallback to xcdevice (for iOS < 17 devices)
-        // devicectl may return marketing name instead of user-customized name for older devices
-        let deviceName = device.deviceProperties.name;
-        if (
-          (!deviceName || deviceName === device.hardwareProperties.marketingName) &&
-          device.hardwareProperties.productType
-        ) {
-          const xcdeviceName = getNameForDevice(nameLookup, device.hardwareProperties.productType);
-          if (xcdeviceName) {
-            deviceName = xcdeviceName;
-          }
-        }
-
-        // Apply safe defaults for missing data
-        const safeDevice = {
-          ...device,
-          hardwareProperties: {
-            ...device.hardwareProperties,
-            udid: udid ?? device.identifier,
-            marketingName: device.hardwareProperties.marketingName,
-            productType: device.hardwareProperties.productType ?? "Unknown",
-          },
-          deviceProperties: {
-            ...device.deviceProperties,
-            name: deviceName,
-            osVersionNumber: osVersionNumber,
-          },
-        };
-
-        const deviceType = safeDevice.hardwareProperties.deviceType;
-        if (deviceType === "appleWatch") {
-          return new watchOSDeviceDestination(safeDevice);
-        }
-        if (deviceType === "iPhone" || deviceType === "iPad") {
-          return new iOSDeviceDestination(safeDevice);
-        }
-        if (deviceType === "appleVision" || deviceType === "realityDevice") {
-          return new visionOSDeviceDestination(safeDevice);
-        }
-        if (deviceType === "appleTV") {
-          return new tvOSDeviceDestination(safeDevice);
-        }
-        checkUnreachable(deviceType);
-        return null; // Unsupported device type
-      })
-      .filter((device) => device !== null);
+    return {
+      devices,
+      devicectlError: devicectlResult.status === "rejected" ? devicectlResult.reason : null,
+    };
   }
 
   async refresh(): Promise<DeviceDestination[]> {
     this.failed = null;
     try {
-      this.cache = await this.fetchDevices();
-    } catch (error: any) {
-      if (error?.error?.code === "ENOENT") {
-        this.failed = "no-devicectl";
-      } else {
-        this.failed = "unknown";
+      const { devices, devicectlError } = await this.fetchDevices();
+      this.cache = devices;
+      if (devicectlError) {
+        // Only surface devicectl failure when we have nothing to show — otherwise
+        // xcdevice recovered some devices and the user shouldn't see an error banner.
+        if (devices.length === 0) {
+          const code = (devicectlError as any)?.error?.code;
+          this.failed = code === "ENOENT" ? "no-devicectl" : "unknown";
+        }
       }
+    } catch (error) {
+      this.failed = "unknown";
       this.cache = [];
     }
     this.emitter.emit("updated");

--- a/src/devices/merge.spec.ts
+++ b/src/devices/merge.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for mergeDeviceSources and resolveDeviceType.
+ */
+
+import type { DeviceCtlDevice } from "../common/xcode/devicectl";
+import type { XcdeviceDevice } from "../common/xcode/xcdevice";
+import { mergeDeviceSources, resolveDeviceType } from "./merge";
+
+function makeDevicectl(overrides: Partial<DeviceCtlDevice> = {}): DeviceCtlDevice {
+  return {
+    capabilities: [],
+    connectionProperties: {
+      tunnelState: "connected",
+      pairingState: "paired",
+    },
+    deviceProperties: {
+      name: "iPhone 15 Pro",
+      osVersionNumber: "17.0",
+    },
+    hardwareProperties: {
+      deviceType: "iPhone",
+      marketingName: "iPhone 15 Pro",
+      productType: "iPhone16,1",
+      udid: "00008110-000DC0001",
+      platform: "iOS",
+    },
+    identifier: "urn:x-ios-devicectl:device-DC1",
+    visibilityClass: "default",
+    ...overrides,
+  };
+}
+
+function makeXcdevice(overrides: Partial<XcdeviceDevice> = {}): XcdeviceDevice {
+  return {
+    identifier: "00008110-000XC0001",
+    modelCode: "iPhone14,2",
+    name: "My iPhone",
+    operatingSystemVersion: "16.4.1",
+    platform: "com.apple.platform.iphoneos",
+    simulator: false,
+    available: true,
+    ...overrides,
+  };
+}
+
+describe("resolveDeviceType", () => {
+  it("prefers devicectl deviceType when present", () => {
+    expect(resolveDeviceType({ devicectl: makeDevicectl() })).toBe("iPhone");
+  });
+
+  it("infers iPhone from iphoneos platform + iPhone modelCode", () => {
+    expect(resolveDeviceType({ xcdevice: makeXcdevice({ modelCode: "iPhone14,2" }) })).toBe("iPhone");
+  });
+
+  it("infers iPad from iphoneos platform + iPad modelCode", () => {
+    expect(resolveDeviceType({ xcdevice: makeXcdevice({ modelCode: "iPad14,5" }) })).toBe("iPad");
+  });
+
+  it("infers appleWatch from watchos platform", () => {
+    expect(
+      resolveDeviceType({ xcdevice: makeXcdevice({ platform: "com.apple.platform.watchos", modelCode: "Watch6,1" }) }),
+    ).toBe("appleWatch");
+  });
+
+  it("infers appleTV from appletvos platform", () => {
+    expect(
+      resolveDeviceType({
+        xcdevice: makeXcdevice({ platform: "com.apple.platform.appletvos", modelCode: "AppleTV11,1" }),
+      }),
+    ).toBe("appleTV");
+  });
+
+  it("infers appleVision from xros platform", () => {
+    expect(
+      resolveDeviceType({
+        xcdevice: makeXcdevice({ platform: "com.apple.platform.xros", modelCode: "RealityDevice14,1" }),
+      }),
+    ).toBe("appleVision");
+  });
+
+  it("returns null when neither source can classify the device", () => {
+    const dc = makeDevicectl({
+      hardwareProperties: {} as any,
+    });
+    expect(resolveDeviceType({ devicectl: dc })).toBeNull();
+  });
+});
+
+describe("mergeDeviceSources", () => {
+  it("returns empty for empty inputs", () => {
+    expect(mergeDeviceSources([], [])).toEqual([]);
+  });
+
+  it("keeps a devicectl-only iOS 17 device", () => {
+    const result = mergeDeviceSources([makeDevicectl()], []);
+    expect(result).toHaveLength(1);
+    expect(result[0].devicectl).toBeDefined();
+    expect(result[0].xcdevice).toBeUndefined();
+  });
+
+  it("keeps an xcdevice-only iOS 16 device (Wi-Fi case)", () => {
+    const xc = makeXcdevice({ identifier: "00008110-0000IOS16WIFI" });
+    const result = mergeDeviceSources([], [xc]);
+    expect(result).toHaveLength(1);
+    expect(result[0].devicectl).toBeUndefined();
+    expect(result[0].xcdevice).toBe(xc);
+  });
+
+  it("deduplicates when both sources report the same UDID", () => {
+    const dc = makeDevicectl({
+      hardwareProperties: {
+        deviceType: "iPhone",
+        productType: "iPhone16,1",
+        udid: "00008110-MATCH",
+        platform: "iOS",
+      },
+    });
+    const xc = makeXcdevice({ identifier: "00008110-MATCH" });
+    const result = mergeDeviceSources([dc], [xc]);
+    expect(result).toHaveLength(1);
+    expect(result[0].devicectl).toBe(dc);
+    expect(result[0].xcdevice).toBe(xc);
+  });
+
+  it("matches UDID case-insensitively", () => {
+    const dc = makeDevicectl({
+      hardwareProperties: {
+        deviceType: "iPhone",
+        productType: "iPhone16,1",
+        udid: "00008110-abcdef",
+        platform: "iOS",
+      },
+    });
+    const xc = makeXcdevice({ identifier: "00008110-ABCDEF" });
+    const result = mergeDeviceSources([dc], [xc]);
+    expect(result).toHaveLength(1);
+    expect(result[0].xcdevice).toBe(xc);
+  });
+
+  it("drops devicectl entries with empty hardwareProperties and no xcdevice match", () => {
+    const dc = makeDevicectl({
+      deviceProperties: {},
+      hardwareProperties: {} as any,
+    });
+    expect(mergeDeviceSources([dc], [])).toEqual([]);
+  });
+
+  it("recovers an iOS 16 USB device via xcdevice when devicectl has empty hardwareProperties", () => {
+    const dc = makeDevicectl({
+      deviceProperties: {},
+      hardwareProperties: {} as any,
+      identifier: "urn:x-ios-devicectl:device-ORPHAN",
+    });
+    const xc = makeXcdevice({ identifier: "00008110-IOS16USB" });
+    const result = mergeDeviceSources([dc], [xc]);
+    expect(result).toHaveLength(1);
+    expect(result[0].devicectl).toBeUndefined();
+    expect(result[0].xcdevice).toBe(xc);
+  });
+
+  it("keeps both entries when UDIDs do not overlap", () => {
+    const dc = makeDevicectl();
+    const xc = makeXcdevice({ identifier: "00008110-DIFFERENT" });
+    const result = mergeDeviceSources([dc], [xc]);
+    expect(result).toHaveLength(2);
+  });
+});

--- a/src/devices/merge.ts
+++ b/src/devices/merge.ts
@@ -1,0 +1,125 @@
+import type { DeviceCtlDevice, DeviceCtlDeviceType } from "../common/xcode/devicectl";
+import type { XcdeviceDevice } from "../common/xcode/xcdevice";
+import type { DeviceRaw } from "./types";
+
+/**
+ * Determine the device type from whichever source has it. Returns null when neither
+ * source has enough information to classify the device — such records cannot be
+ * turned into a DeviceDestination and must be dropped.
+ */
+export function resolveDeviceType(raw: DeviceRaw): DeviceCtlDeviceType | null {
+  const dcType = raw.devicectl?.hardwareProperties?.deviceType;
+  if (dcType) {
+    return dcType;
+  }
+  if (raw.xcdevice) {
+    return inferDeviceTypeFromXcdevice(raw.xcdevice);
+  }
+  return null;
+}
+
+/**
+ * Infer deviceType from an xcdevice record.
+ *
+ * xcdevice only exposes "platform" (a broad bucket) and "modelCode" (the specific
+ * product identifier). For watchOS/tvOS/xrOS the platform alone is enough. For
+ * iphoneos we disambiguate iPhone vs iPad via the modelCode prefix since both
+ * share the same platform string.
+ *
+ * Returns null for unknown platforms so the caller can drop the record rather than
+ * silently misclassify a future platform as iPhone.
+ *
+ * Examples:
+ * - { platform: "com.apple.platform.iphoneos", modelCode: "iPhone14,2" } → "iPhone"
+ * - { platform: "com.apple.platform.iphoneos", modelCode: "iPad14,5" }   → "iPad"
+ * - { platform: "com.apple.platform.watchos",  modelCode: "Watch6,1" }   → "appleWatch"
+ * - { platform: "com.apple.platform.appletvos", modelCode: "AppleTV11,1" } → "appleTV"
+ * - { platform: "com.apple.platform.xros", modelCode: "RealityDevice14,1" } → "appleVision"
+ */
+function inferDeviceTypeFromXcdevice(xc: XcdeviceDevice): DeviceCtlDeviceType | null {
+  switch (xc.platform) {
+    case "com.apple.platform.watchos":
+      return "appleWatch";
+    case "com.apple.platform.appletvos":
+      return "appleTV";
+    case "com.apple.platform.xros":
+      return "appleVision";
+    case "com.apple.platform.iphoneos":
+      return xc.modelCode?.startsWith("iPad") ? "iPad" : "iPhone";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Merge devicectl and xcdevice outputs into a deduplicated list of source-record pairs.
+ *
+ * Scenario examples:
+ *
+ * - iOS 17 device, seen by both sources with matching UDID
+ *   → 1 record with both devicectl and xcdevice set.
+ *
+ * - iOS 17 device, only in devicectl (xcdevice empty)
+ *   → 1 record with just devicectl.
+ *
+ * - iOS 16 Wi-Fi device: devicectl list empty, xcdevice lists it
+ *   → 1 record with just xcdevice.
+ *
+ * - iOS 16 USB device: devicectl returns it with empty hardwareProperties (no UDID),
+ *   xcdevice also has it
+ *   → devicectl entry can't be paired (no UDID) and has no deviceType → dropped.
+ *     xcdevice entry stands alone → 1 record with just xcdevice.
+ *
+ * - Unpaired/locked device: xcdevice reports "available: false" / "error"
+ *   → 1 record with just xcdevice (DeviceDestination will render as unavailable).
+ */
+export function mergeDeviceSources(
+  devicectlDevices: DeviceCtlDevice[],
+  xcdeviceDevices: XcdeviceDevice[],
+): DeviceRaw[] {
+  const xcByUdid = new Map<string, XcdeviceDevice>();
+  for (const xc of xcdeviceDevices) {
+    if (xc.identifier && xc.identifier.length > 0) {
+      xcByUdid.set(xc.identifier.toLowerCase(), xc);
+    }
+  }
+
+  const consumedXcUdids = new Set<string>();
+  const result: DeviceRaw[] = [];
+
+  for (const dc of devicectlDevices) {
+    if (!dc.identifier) {
+      continue;
+    }
+
+    const dcUdid = dc.hardwareProperties?.udid?.toLowerCase();
+    const matchedXc = dcUdid ? xcByUdid.get(dcUdid) : undefined;
+
+    // Rule 1: pair devicectl + xcdevice when UDIDs match (case-insensitive,
+    // "devicectl.hardwareProperties.udid" ↔ "xcdevice.identifier").
+    if (matchedXc && dcUdid) {
+      consumedXcUdids.add(dcUdid);
+      result.push({ devicectl: dc, xcdevice: matchedXc });
+      continue;
+    }
+
+    // Rule 2: devicectl entries with no "deviceType" AND no xcdevice match are
+    // dropped — no way to pick a DeviceDestination subclass for them.
+    if (!dc.hardwareProperties?.deviceType) {
+      continue;
+    }
+    result.push({ devicectl: dc });
+  }
+
+  // Rule 3: xcdevice entries with no devicectl counterpart become standalone
+  // records — the iOS <= 16 recovery path.
+  for (const xc of xcdeviceDevices) {
+    const udid = xc.identifier?.toLowerCase();
+    if (!udid || consumedXcUdids.has(udid)) {
+      continue;
+    }
+    result.push({ xcdevice: xc });
+  }
+
+  return result;
+}

--- a/src/devices/types.spec.ts
+++ b/src/devices/types.spec.ts
@@ -21,7 +21,7 @@ describe("iOSDeviceDestination", () => {
   describe("type and platform", () => {
     it("has correct type and platform", () => {
       const device = createMockDevice();
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.type).toBe("iOSDevice");
       expect(destination.typeLabel).toBe("iOS Device");
@@ -37,14 +37,14 @@ describe("iOSDeviceDestination", () => {
           udid: "00008110-001234567890001E",
         },
       });
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.udid).toBe("00008110-001234567890001E");
     });
 
     it("falls back to identifier when udid is missing", () => {
       const device = createMockDeviceWithoutUDID();
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.udid).toBe(device.identifier);
     });
@@ -57,7 +57,7 @@ describe("iOSDeviceDestination", () => {
         },
         identifier: "fallback-identifier",
       });
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.udid).toBe("fallback-identifier");
     });
@@ -68,7 +68,7 @@ describe("iOSDeviceDestination", () => {
       const device = createMockDevice({
         identifier: "urn:x-ios-devicectl:device-test",
       });
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.devicectlId).toBe("urn:x-ios-devicectl:device-test");
     });
@@ -82,7 +82,7 @@ describe("iOSDeviceDestination", () => {
           osVersionNumber: "17.0",
         },
       });
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.name).toBe("My iPhone");
     });
@@ -97,7 +97,7 @@ describe("iOSDeviceDestination", () => {
           marketingName: "iPhone 14 Pro",
         },
       });
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.name).toBe("iPhone 14 Pro");
     });
@@ -113,7 +113,7 @@ describe("iOSDeviceDestination", () => {
           productType: "iPhone15,2",
         },
       });
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.name).toBe("iPhone15,2");
     });
@@ -129,7 +129,7 @@ describe("iOSDeviceDestination", () => {
           productType: undefined,
         },
       });
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.name).toBe("Unknown Device");
     });
@@ -138,14 +138,14 @@ describe("iOSDeviceDestination", () => {
   describe("osVersion property", () => {
     it("returns osVersionNumber when present", () => {
       const device = createMockDeviceWithOS("17.0");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.osVersion).toBe("17.0");
     });
 
     it("returns 'Unknown' when osVersionNumber is missing", () => {
       const device = createMockDeviceWithoutOS();
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.osVersion).toBe("Unknown");
     });
@@ -156,9 +156,25 @@ describe("iOSDeviceDestination", () => {
           osVersionNumber: undefined,
         },
       });
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.osVersion).toBe("Unknown");
+    });
+
+    it("strips build suffix from xcdevice operatingSystemVersion", () => {
+      const xc = {
+        identifier: "00008110-IOS16",
+        modelCode: "iPhone14,2",
+        name: "My iPhone",
+        operatingSystemVersion: "16.4.1 (20E252)",
+        platform: "com.apple.platform.iphoneos",
+        simulator: false,
+        available: true,
+      };
+      const destination = new iOSDeviceDestination({ xcdevice: xc });
+
+      expect(destination.osVersion).toBe("16.4.1");
+      expect(destination.label).toBe("My iPhone (16.4.1)");
     });
   });
 
@@ -170,7 +186,7 @@ describe("iOSDeviceDestination", () => {
           osVersionNumber: "17.0",
         },
       });
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.label).toBe("iPhone 14 Pro (17.0)");
     });
@@ -181,7 +197,7 @@ describe("iOSDeviceDestination", () => {
           name: "iPhone 14 Pro",
         },
       });
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.label).toBe("iPhone 14 Pro");
     });
@@ -190,35 +206,35 @@ describe("iOSDeviceDestination", () => {
   describe("supportsDevicectl property", () => {
     it("returns true for iOS 17.0", () => {
       const device = createMockDeviceWithOS("17.0");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(true);
     });
 
     it("returns true for iOS 18.0", () => {
       const device = createMockDeviceWithOS("18.0");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(true);
     });
 
     it("returns false for iOS 16.7", () => {
       const device = createMockDeviceWithOS("16.7");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(false);
     });
 
     it("returns false for iOS 15.0", () => {
       const device = createMockDeviceWithOS("15.0");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(false);
     });
 
     it("returns false when OS version is unknown", () => {
       const device = createMockDeviceWithoutOS();
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(false);
     });
@@ -227,14 +243,14 @@ describe("iOSDeviceDestination", () => {
   describe("icon property", () => {
     it("returns iPad icon when deviceType is iPad", () => {
       const device = createMockDeviceOfType("iPad");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.icon).toBe("sweetpad-device-ipad");
     });
 
     it("returns connected iPhone icon when deviceType is iPhone and connected", () => {
       const device = createMockDeviceOfType("iPhone");
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.icon).toBe("sweetpad-device-mobile");
     });
@@ -242,7 +258,7 @@ describe("iOSDeviceDestination", () => {
     it("returns disconnected iPhone icon when deviceType is iPhone and disconnected", () => {
       const device = createMockDeviceOfType("iPhone");
       device.connectionProperties.tunnelState = "disconnected";
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.icon).toBe("sweetpad-device-mobile-x");
     });
@@ -254,7 +270,7 @@ describe("iOSDeviceDestination", () => {
           deviceType: "iPhone",
         },
       });
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.icon).toBe("sweetpad-device-mobile");
     });
@@ -263,7 +279,7 @@ describe("iOSDeviceDestination", () => {
   describe("isConnected property", () => {
     it("returns true when tunnelState is connected", () => {
       const device = createMockDevice();
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.isConnected).toBe(true);
     });
@@ -271,7 +287,7 @@ describe("iOSDeviceDestination", () => {
     it("returns false when tunnelState is disconnected", () => {
       const device = createMockDevice();
       device.connectionProperties.tunnelState = "disconnected";
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.isConnected).toBe(false);
     });
@@ -279,16 +295,56 @@ describe("iOSDeviceDestination", () => {
     it("returns false when tunnelState is unavailable", () => {
       const device = createMockDevice();
       device.connectionProperties.tunnelState = "unavailable";
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.isConnected).toBe(false);
+    });
+  });
+
+  describe("state property with both sources", () => {
+    it("favors devicectl tunnelState over xcdevice availability when both are present", () => {
+      // devicectl says connected, xcdevice says unavailable (e.g. stale error from
+      // a previous lock). devicectl is authoritative for iOS 17+ so we trust it.
+      const device = createMockDevice();
+      device.connectionProperties.tunnelState = "connected";
+      const xc = {
+        identifier: "00008110-001234567890001E",
+        modelCode: "iPhone16,1",
+        name: "My iPhone",
+        operatingSystemVersion: "17.0",
+        platform: "com.apple.platform.iphoneos",
+        simulator: false,
+        available: false,
+        error: { code: -9 },
+      };
+      const destination = new iOSDeviceDestination({ devicectl: device, xcdevice: xc });
+
+      expect(destination.state).toBe("connected");
+      expect(destination.isConnected).toBe(true);
+    });
+
+    it("reports unavailable when devicectl tunnelState is unavailable even if xcdevice says available", () => {
+      const device = createMockDevice();
+      device.connectionProperties.tunnelState = "unavailable";
+      const xc = {
+        identifier: "00008110-001234567890001E",
+        modelCode: "iPhone16,1",
+        name: "My iPhone",
+        operatingSystemVersion: "17.0",
+        platform: "com.apple.platform.iphoneos",
+        simulator: false,
+        available: true,
+      };
+      const destination = new iOSDeviceDestination({ devicectl: device, xcdevice: xc });
+
+      expect(destination.state).toBe("unavailable");
     });
   });
 
   describe("id property", () => {
     it("returns id with iosdevice prefix and udid", () => {
       const device = createMockDevice();
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.id).toBe("iosdevice-00008110-001234567890001E");
     });
@@ -302,7 +358,7 @@ describe("iOSDeviceDestination", () => {
           osVersionNumber: "17.0",
         },
       });
-      const destination = new iOSDeviceDestination(device);
+      const destination = new iOSDeviceDestination({ devicectl: device });
 
       expect(destination.quickPickDetails).toBe("Type: iOS Device, Version: 17.0, ID: 00008110-001234567890001e");
     });
@@ -312,7 +368,7 @@ describe("iOSDeviceDestination", () => {
 describe("watchOSDeviceDestination", () => {
   it("has correct type and platform", () => {
     const device = createMockDeviceOfType("appleWatch");
-    const destination = new watchOSDeviceDestination(device);
+    const destination = new watchOSDeviceDestination({ devicectl: device });
 
     expect(destination.type).toBe("watchOSDevice");
     expect(destination.typeLabel).toBe("watchOS Device");
@@ -323,7 +379,7 @@ describe("watchOSDeviceDestination", () => {
     it("returns true for watchOS 10.0", () => {
       const device = createMockDeviceOfType("appleWatch");
       device.deviceProperties.osVersionNumber = "10.0";
-      const destination = new watchOSDeviceDestination(device);
+      const destination = new watchOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(true);
     });
@@ -331,7 +387,7 @@ describe("watchOSDeviceDestination", () => {
     it("returns false for watchOS 9.5", () => {
       const device = createMockDeviceOfType("appleWatch");
       device.deviceProperties.osVersionNumber = "9.5";
-      const destination = new watchOSDeviceDestination(device);
+      const destination = new watchOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(false);
     });
@@ -340,7 +396,7 @@ describe("watchOSDeviceDestination", () => {
   describe("icon property", () => {
     it("returns connected icon when connected", () => {
       const device = createMockDeviceOfType("appleWatch");
-      const destination = new watchOSDeviceDestination(device);
+      const destination = new watchOSDeviceDestination({ devicectl: device });
 
       expect(destination.icon).toBe("sweetpad-device-watch");
     });
@@ -348,7 +404,7 @@ describe("watchOSDeviceDestination", () => {
     it("returns disconnected icon when disconnected", () => {
       const device = createMockDeviceOfType("appleWatch");
       device.connectionProperties.tunnelState = "disconnected";
-      const destination = new watchOSDeviceDestination(device);
+      const destination = new watchOSDeviceDestination({ devicectl: device });
 
       expect(destination.icon).toBe("sweetpad-device-watch-pause");
     });
@@ -358,7 +414,7 @@ describe("watchOSDeviceDestination", () => {
 describe("tvOSDeviceDestination", () => {
   it("has correct type and platform", () => {
     const device = createMockDeviceOfType("appleTV");
-    const destination = new tvOSDeviceDestination(device);
+    const destination = new tvOSDeviceDestination({ devicectl: device });
 
     expect(destination.type).toBe("tvOSDevice");
     expect(destination.typeLabel).toBe("tvOS Device");
@@ -369,7 +425,7 @@ describe("tvOSDeviceDestination", () => {
     it("returns true for tvOS 17.0", () => {
       const device = createMockDeviceOfType("appleTV");
       device.deviceProperties.osVersionNumber = "17.0";
-      const destination = new tvOSDeviceDestination(device);
+      const destination = new tvOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(true);
     });
@@ -377,7 +433,7 @@ describe("tvOSDeviceDestination", () => {
     it("returns false for tvOS 16.5", () => {
       const device = createMockDeviceOfType("appleTV");
       device.deviceProperties.osVersionNumber = "16.5";
-      const destination = new tvOSDeviceDestination(device);
+      const destination = new tvOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(false);
     });
@@ -386,7 +442,7 @@ describe("tvOSDeviceDestination", () => {
   describe("icon property", () => {
     it("returns TV icon", () => {
       const device = createMockDeviceOfType("appleTV");
-      const destination = new tvOSDeviceDestination(device);
+      const destination = new tvOSDeviceDestination({ devicectl: device });
 
       expect(destination.icon).toBe("sweetpad-device-tv-old");
     });
@@ -396,7 +452,7 @@ describe("tvOSDeviceDestination", () => {
 describe("visionOSDeviceDestination", () => {
   it("has correct type and platform", () => {
     const device = createMockDeviceOfType("appleVision");
-    const destination = new visionOSDeviceDestination(device);
+    const destination = new visionOSDeviceDestination({ devicectl: device });
 
     expect(destination.type).toBe("visionOSDevice");
     expect(destination.typeLabel).toBe("visionOS Device");
@@ -407,7 +463,7 @@ describe("visionOSDeviceDestination", () => {
     it("returns true for visionOS 1.0", () => {
       const device = createMockDeviceOfType("appleVision");
       device.deviceProperties.osVersionNumber = "1.0";
-      const destination = new visionOSDeviceDestination(device);
+      const destination = new visionOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(true);
     });
@@ -415,7 +471,7 @@ describe("visionOSDeviceDestination", () => {
     it("returns true for visionOS 2.0", () => {
       const device = createMockDeviceOfType("appleVision");
       device.deviceProperties.osVersionNumber = "2.0";
-      const destination = new visionOSDeviceDestination(device);
+      const destination = new visionOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(true);
     });
@@ -423,7 +479,7 @@ describe("visionOSDeviceDestination", () => {
     it("returns false when OS version is unknown", () => {
       const device = createMockDeviceOfType("appleVision");
       device.deviceProperties.osVersionNumber = undefined;
-      const destination = new visionOSDeviceDestination(device);
+      const destination = new visionOSDeviceDestination({ devicectl: device });
 
       expect(destination.supportsDevicectl).toBe(false);
     });
@@ -432,7 +488,7 @@ describe("visionOSDeviceDestination", () => {
   describe("icon property", () => {
     it("returns vision icon", () => {
       const device = createMockDeviceOfType("appleVision");
-      const destination = new visionOSDeviceDestination(device);
+      const destination = new visionOSDeviceDestination({ devicectl: device });
 
       expect(destination.icon).toBe("sweetpad-cardboards");
     });
@@ -444,10 +500,10 @@ describe("Common device destination behavior", () => {
     it("all device types fall back to identifier when udid is missing", () => {
       const device = createMockDeviceWithoutUDID();
 
-      const iOSDest = new iOSDeviceDestination(device);
-      const watchOSDest = new watchOSDeviceDestination(device);
-      const tvOSDest = new tvOSDeviceDestination(device);
-      const visionOSDest = new visionOSDeviceDestination(device);
+      const iOSDest = new iOSDeviceDestination({ devicectl: device });
+      const watchOSDest = new watchOSDeviceDestination({ devicectl: device });
+      const tvOSDest = new tvOSDeviceDestination({ devicectl: device });
+      const visionOSDest = new visionOSDeviceDestination({ devicectl: device });
 
       expect(iOSDest.udid).toBe(device.identifier);
       expect(watchOSDest.udid).toBe(device.identifier);
@@ -460,12 +516,12 @@ describe("Common device destination behavior", () => {
     it("all device types fall back through name -> marketingName -> productType -> Unknown", () => {
       const device = createMockDeviceWithoutName();
 
-      const iOSDest = new iOSDeviceDestination(device);
+      const iOSDest = new iOSDeviceDestination({ devicectl: device });
       expect(iOSDest.name).toBe("iPhone15,2");
 
       device.hardwareProperties.marketingName = undefined;
       device.hardwareProperties.productType = undefined;
-      const iOSDest2 = new iOSDeviceDestination(device);
+      const iOSDest2 = new iOSDeviceDestination({ devicectl: device });
       expect(iOSDest2.name).toBe("Unknown Device");
     });
   });
@@ -474,10 +530,10 @@ describe("Common device destination behavior", () => {
     it("all device types return 'Unknown' when osVersionNumber is missing", () => {
       const device = createMockDeviceWithoutOS();
 
-      const iOSDest = new iOSDeviceDestination(device);
-      const watchOSDest = new watchOSDeviceDestination(device);
-      const tvOSDest = new tvOSDeviceDestination(device);
-      const visionOSDest = new visionOSDeviceDestination(device);
+      const iOSDest = new iOSDeviceDestination({ devicectl: device });
+      const watchOSDest = new watchOSDeviceDestination({ devicectl: device });
+      const tvOSDest = new tvOSDeviceDestination({ devicectl: device });
+      const visionOSDest = new visionOSDeviceDestination({ devicectl: device });
 
       expect(iOSDest.osVersion).toBe("Unknown");
       expect(watchOSDest.osVersion).toBe("Unknown");
@@ -494,10 +550,10 @@ describe("Common device destination behavior", () => {
         },
       });
 
-      const iOSDest = new iOSDeviceDestination(device);
-      const watchOSDest = new watchOSDeviceDestination(device);
-      const tvOSDest = new tvOSDeviceDestination(device);
-      const visionOSDest = new visionOSDeviceDestination(device);
+      const iOSDest = new iOSDeviceDestination({ devicectl: device });
+      const watchOSDest = new watchOSDeviceDestination({ devicectl: device });
+      const tvOSDest = new tvOSDeviceDestination({ devicectl: device });
+      const visionOSDest = new visionOSDeviceDestination({ devicectl: device });
 
       expect(iOSDest.label).toBe("Test Device");
       expect(watchOSDest.label).toBe("Test Device");

--- a/src/devices/types.ts
+++ b/src/devices/types.ts
@@ -1,324 +1,286 @@
-import type { DeviceCtlDevice } from "../common/xcode/devicectl";
+import type { DeviceCtlDevice, DeviceCtlDeviceType } from "../common/xcode/devicectl";
+import type { XcdeviceDevice } from "../common/xcode/xcdevice";
 import type { IDestination } from "../destination/types";
+import { resolveDeviceType } from "./merge";
 import { supportsDevicectl } from "./utils";
 
-export class iOSDeviceDestination implements IDestination {
+type DeviceState = "connected" | "disconnected" | "unavailable";
+
+/**
+ * Paired raw records for a single physical device. At least one of "devicectl" or
+ * "xcdevice" is always set — enforced by DeviceDestinationBase's constructor.
+ *
+ * The two fields come from different Apple CLIs:
+ *
+ * - "xcrun devicectl" — Apple's modern device-management CLI (iOS 17+ / CoreDevice).
+ *   Rich JSON, supports install/launch/process-info. Unreliable for iOS <= 16: USB
+ *   devices come back with empty "hardwareProperties"; Wi-Fi devices are omitted.
+ *
+ * - "xcrun xcdevice" — older inventory-only tool. Reports every paired device across
+ *   all supported platforms, including iOS <= 16 ones devicectl drops. Cannot install
+ *   or launch apps; deploy via "ios-deploy" instead.
+ */
+export type DeviceRaw = {
+  devicectl?: DeviceCtlDevice;
+  xcdevice?: XcdeviceDevice;
+};
+
+/**
+ * Shared data + fallback logic for physical Apple devices, regardless of platform.
+ *
+ * Why this exists: "xcrun devicectl" (used for iOS 17+) and "xcrun xcdevice" (used for
+ * iOS <= 16) return overlapping but differently shaped records. This base class holds
+ * both sources ("raw.devicectl" / "raw.xcdevice") and exposes unified getters so
+ * subclasses only need to supply platform-specific constants (type/typeLabel/platform/
+ * idPrefix/minDevicectlMajor) and platform-specific icon logic.
+ *
+ * At least one of "devicectl" or "xcdevice" must be set — the constructor throws otherwise.
+ * The raw records remain accessible via "this.raw.*" for the rare case where a consumer
+ * needs source-specific fields; prefer the unified getters.
+ */
+export abstract class DeviceDestinationBase {
+  public readonly raw: DeviceRaw;
+
+  /** Prefix used to build the destination id (e.g. "iosdevice"). */
+  protected abstract readonly idPrefix: string;
+
+  /** Minimum major OS version that supports devicectl on this platform. */
+  protected abstract readonly minDevicectlMajor: number;
+
+  /** Human-readable platform label shown in quick-pick details. */
+  abstract readonly typeLabel: string;
+
+  /** Platform-specific icon logic. */
+  abstract get icon(): string;
+
+  constructor(raw: DeviceRaw) {
+    if (!raw.devicectl && !raw.xcdevice) {
+      throw new Error("Device requires at least one of devicectl or xcdevice records");
+    }
+    this.raw = raw;
+  }
+
+  get id(): string {
+    return `${this.idPrefix}-${this.udid}`;
+  }
+
+  get label(): string {
+    const v = this.osVersion;
+    return v === "Unknown" ? this.name : `${this.name} (${v})`;
+  }
+
+  get quickPickDetails(): string {
+    return `Type: ${this.typeLabel}, Version: ${this.osVersion}, ID: ${this.udid.toLocaleLowerCase()}`;
+  }
+
+  get isConnected(): boolean {
+    return this.state === "connected";
+  }
+
+  /** True when "xcrun devicectl" reported this device. Gate devicectl-only operations on this. */
+  get hasDevicectl(): boolean {
+    return this.raw.devicectl !== undefined;
+  }
+
+  /** True when "xcrun xcdevice" reported this device. Mostly useful for tests/introspection. */
+  get hasXcdevice(): boolean {
+    return this.raw.xcdevice !== undefined;
+  }
+
+  /**
+   * The device's UDID in its long-standing hex form (e.g. "00008110-001234567890001E").
+   *
+   * Sometimes called "legacy" because Apple introduced a second identifier format
+   * alongside devicectl in Xcode 15 — a URN like "urn:x-ios-devicectl:device-CS1234567-..."
+   * (see "devicectlId"). The hex UDID predates that and is what most tooling still speaks:
+   * "xcodebuild -destination id=...", "ios-deploy --id", Instruments. Not deprecated —
+   * it remains the portable identifier for everything outside devicectl itself.
+   */
+  get udid(): string {
+    const dc = this.raw.devicectl;
+    const xc = this.raw.xcdevice;
+    return dc?.hardwareProperties?.udid ?? xc?.identifier ?? dc?.identifier ?? "unknown";
+  }
+
+  /**
+   * devicectl-internal identifier (URN form, e.g. "urn:x-ios-devicectl:device-CS1234567-...").
+   * Null when the device is only known to xcdevice — callers that need this must gate on
+   * "hasDevicectl" / "supportsDevicectl".
+   */
+  get devicectlId(): string | null {
+    return this.raw.devicectl?.identifier ?? null;
+  }
+
+  /**
+   * Human-readable device name shown to the user — the label in the destinations tree,
+   * the "Running ... on <name>" progress status, and the quick-pick details string.
+   * Prefers the user-customized name (e.g. "John's iPhone") over marketing names.
+   */
+  get name(): string {
+    const dc = this.raw.devicectl;
+    const xc = this.raw.xcdevice;
+    const dcName = dc?.deviceProperties?.name;
+    const marketing = dc?.hardwareProperties?.marketingName;
+
+    // devicectl sometimes returns the marketing name as the device name for iOS <17 —
+    // in that case prefer xcdevice's customized name.
+    // e.g. dcName="John's iPhone", marketing="iPhone 15 Pro" → "John's iPhone"
+    if (dcName && dcName !== marketing) {
+      return dcName;
+    }
+
+    // e.g. dcName="iPhone 13" (==marketing), xc.name="Nixuge iPhone" → "Nixuge iPhone"
+    if (xc?.name) {
+      return xc.name;
+    }
+
+    // e.g. dcName="iPhone 15 Pro", no xcdevice entry → "iPhone 15 Pro"
+    if (dcName) {
+      return dcName;
+    }
+
+    // e.g. dcName undefined but marketing="iPad Pro 12.9-inch" → "iPad Pro 12.9-inch"
+    if (marketing) {
+      return marketing;
+    }
+
+    // Last-resort fallback: raw model code like "iPhone14,2".
+    const modelCode = dc?.hardwareProperties?.productType ?? xc?.modelCode;
+    return modelCode ?? "Unknown Device";
+  }
+
+  /**
+   * OS version string shown in the destinations tree description and the quick-pick,
+   * and used by "supportsDevicectl" to decide devicectl vs ios-deploy routing.
+   *
+   * Always returned in plain form ("17.0", "16.4.1") regardless of source:
+   * - devicectl → plain version already ("17.0")
+   * - xcdevice  → "16.4.1 (20E252)" in the wild; the build suffix is stripped so
+   *   the label doesn't render nested parens ("My iPhone (16.4.1 (20E252))") and
+   *   so "supportsDevicectl"'s leading-digit parse is not fragile.
+   *
+   * Returns "Unknown" when neither source reports a version.
+   */
+  get osVersion(): string {
+    const dcVersion = this.raw.devicectl?.deviceProperties?.osVersionNumber;
+    if (dcVersion) {
+      return dcVersion;
+    }
+    const xcVersion = this.raw.xcdevice?.operatingSystemVersion;
+    if (!xcVersion || xcVersion.length === 0) {
+      return "Unknown";
+    }
+    // "16.4.1 (20E252)" → "16.4.1"; leave plain strings untouched.
+    const spaceIdx = xcVersion.indexOf(" ");
+    return spaceIdx === -1 ? xcVersion : xcVersion.slice(0, spaceIdx);
+  }
+
+  /**
+   * iPhone / iPad / appleWatch / appleTV / appleVision / realityDevice.
+   *
+   * devicectl reports this directly. For xcdevice-only devices, the subclass picked
+   * by the merge layer narrows this — e.g. iOSDeviceDestination only ever wraps
+   * iphoneos-platform xcdevice entries, so inference boils down to iPhone vs iPad.
+   */
+  get deviceType(): DeviceCtlDeviceType {
+    // buildDeviceDestination already drops records resolveDeviceType can't classify,
+    // so any instance that reaches this point has a resolvable type. Throw on the
+    // impossible path rather than silently defaulting to iPhone.
+    const t = resolveDeviceType(this.raw);
+    if (!t) {
+      throw new Error("DeviceDestinationBase.deviceType: unclassifiable raw record");
+    }
+    return t;
+  }
+
+  /**
+   * Connection/availability state used by "isConnected" and the icon variant.
+   *
+   * - "connected"    → device reachable; deploys will succeed.
+   * - "disconnected" → devicectl tunnelState=disconnected (cable pulled, etc.).
+   * - "unavailable"  → devicectl tunnelState=unavailable, OR xcdevice says
+   *                    available=false / returned an error (not paired, locked,
+   *                    developer mode off).
+   */
+  get state(): DeviceState {
+    // e.g. devicectl.connectionProperties.tunnelState="connected" → "connected"
+    const dc = this.raw.devicectl;
+    if (dc) {
+      return dc.connectionProperties.tunnelState;
+    }
+    const xc = this.raw.xcdevice;
+    if (!xc) {
+      // unreachable: constructor guarantees at least one source
+      return "unavailable";
+    }
+    // e.g. xcdevice { available: false, error: { code: -9 } } → "unavailable"
+    if (xc.error || xc.available === false) {
+      return "unavailable";
+    }
+    // e.g. xcdevice { available: true } → "connected"
+    return "connected";
+  }
+
+  get supportsDevicectl(): boolean {
+    if (!this.hasDevicectl) {
+      return false;
+    }
+    const v = this.osVersion === "Unknown" ? undefined : this.osVersion;
+    return supportsDevicectl(v, this.minDevicectlMajor);
+  }
+}
+
+export class iOSDeviceDestination extends DeviceDestinationBase implements IDestination {
   type = "iOSDevice" as const;
   typeLabel = "iOS Device";
   platform = "iphoneos" as const;
-
-  constructor(public device: DeviceCtlDevice) {
-    this.device = device;
-  }
-
-  get id(): string {
-    return `iosdevice-${this.udid}`;
-  }
-
-  get label(): string {
-    // iPhone 12 Pro Max (14.5)
-    const osVersion = this.osVersion;
-    if (osVersion === "Unknown") {
-      return this.name;
-    }
-    return `${this.name} (${osVersion})`;
-  }
-
-  get quickPickDetails(): string {
-    return `Type: ${this.typeLabel}, Version: ${this.osVersion}, ID: ${this.udid.toLocaleLowerCase()}`;
-  }
-
-  get isConnected(): boolean {
-    return this.state === "connected";
-  }
+  protected readonly idPrefix = "iosdevice";
+  protected readonly minDevicectlMajor = 17;
 
   get icon(): string {
     if (this.deviceType === "iPad") {
-      if (this.isConnected) {
-        return "sweetpad-device-ipad";
-      }
-      return "sweetpad-device-ipad-x";
+      return this.isConnected ? "sweetpad-device-ipad" : "sweetpad-device-ipad-x";
     }
     if (this.deviceType === "iPhone") {
-      if (this.isConnected) {
-        return "sweetpad-device-mobile";
-      }
-      return "sweetpad-device-mobile-x";
+      return this.isConnected ? "sweetpad-device-mobile" : "sweetpad-device-mobile-x";
     }
     return "sweetpad-device-mobile";
   }
-
-  /**
-   * The legacy UDID format used by xcodebuild destination
-   * For older devices, this comes from xcdevice; for newer devices, from devicectl
-   */
-  get udid() {
-    return this.device.hardwareProperties.udid ?? this.device.identifier ?? "unknown";
-  }
-
-  /**
-   * The devicectl identifier used for devicectl commands
-   * This is always the identifier from devicectl list
-   */
-  get devicectlId() {
-    return this.device.identifier;
-  }
-
-  get name() {
-    return (
-      this.device.deviceProperties.name ??
-      this.device.hardwareProperties.marketingName ??
-      this.device.hardwareProperties.productType ??
-      "Unknown Device"
-    );
-  }
-
-  get osVersion() {
-    return this.device.deviceProperties.osVersionNumber ?? "Unknown";
-  }
-
-  get state(): "connected" | "disconnected" | "unavailable" {
-    return this.device.connectionProperties.tunnelState;
-  }
-
-  get deviceType() {
-    return this.device.hardwareProperties.deviceType;
-  }
-
-  /**
-   * Check if the device supports devicectl (iOS 17+)
-   * Older devices (iOS < 17) need to use ios-deploy instead
-   */
-  get supportsDevicectl(): boolean {
-    return supportsDevicectl(this.device.deviceProperties.osVersionNumber, 17);
-  }
 }
 
-export class watchOSDeviceDestination implements IDestination {
+export class watchOSDeviceDestination extends DeviceDestinationBase implements IDestination {
   type = "watchOSDevice" as const;
   typeLabel = "watchOS Device";
   platform = "watchos" as const;
-
-  constructor(public device: DeviceCtlDevice) {
-    this.device = device;
-  }
-
-  get id(): string {
-    return `watchosdevice-${this.udid}`;
-  }
+  protected readonly idPrefix = "watchosdevice";
+  protected readonly minDevicectlMajor = 10;
 
   get icon(): string {
-    if (this.isConnected) {
-      return "sweetpad-device-watch";
-    }
-    return "sweetpad-device-watch-pause";
-  }
-
-  /**
-   * The legacy UDID format used by xcodebuild destination
-   * For older devices, this comes from xcdevice; for newer devices, from devicectl
-   */
-  get udid() {
-    return this.device.hardwareProperties.udid ?? this.device.identifier ?? "unknown";
-  }
-
-  /**
-   * The devicectl identifier used for devicectl commands
-   * This is always the identifier from devicectl list
-   */
-  get devicectlId() {
-    return this.device.identifier;
-  }
-
-  get name() {
-    return (
-      this.device.deviceProperties.name ??
-      this.device.hardwareProperties.marketingName ??
-      this.device.hardwareProperties.productType ??
-      "Unknown Device"
-    );
-  }
-
-  get label(): string {
-    const osVersion = this.osVersion;
-    if (osVersion === "Unknown") {
-      return this.name;
-    }
-    return `${this.name} (${osVersion})`;
-  }
-
-  get osVersion() {
-    return this.device.deviceProperties.osVersionNumber ?? "Unknown";
-  }
-
-  get quickPickDetails(): string {
-    return `Type: ${this.typeLabel}, Version: ${this.osVersion}, ID: ${this.udid.toLocaleLowerCase()}`;
-  }
-
-  get state(): "connected" | "disconnected" | "unavailable" {
-    return this.device.connectionProperties.tunnelState;
-  }
-
-  get isConnected(): boolean {
-    return this.state === "connected";
-  }
-
-  /**
-   * Check if the device supports devicectl (watchOS 10+)
-   * Older devices (watchOS < 10) need to use alternative methods
-   */
-  get supportsDevicectl(): boolean {
-    return supportsDevicectl(this.device.deviceProperties.osVersionNumber, 10);
+    return this.isConnected ? "sweetpad-device-watch" : "sweetpad-device-watch-pause";
   }
 }
 
-export class tvOSDeviceDestination implements IDestination {
+export class tvOSDeviceDestination extends DeviceDestinationBase implements IDestination {
   type = "tvOSDevice" as const;
   typeLabel = "tvOS Device";
   platform = "appletvos" as const;
-
-  constructor(public device: DeviceCtlDevice) {
-    this.device = device;
-  }
-
-  get id(): string {
-    return `tvosdevice-${this.udid}`;
-  }
+  protected readonly idPrefix = "tvosdevice";
+  protected readonly minDevicectlMajor = 17;
 
   get icon(): string {
     return "sweetpad-device-tv-old";
   }
-
-  /**
-   * The legacy UDID format used by xcodebuild destination
-   * For older devices, this comes from xcdevice; for newer devices, from devicectl
-   */
-  get udid() {
-    return this.device.hardwareProperties.udid ?? this.device.identifier ?? "unknown";
-  }
-
-  /**
-   * The devicectl identifier used for devicectl commands
-   * This is always the identifier from devicectl list
-   */
-  get devicectlId() {
-    return this.device.identifier;
-  }
-
-  get name() {
-    return (
-      this.device.deviceProperties.name ??
-      this.device.hardwareProperties.marketingName ??
-      this.device.hardwareProperties.productType ??
-      "Unknown Device"
-    );
-  }
-
-  get label(): string {
-    const osVersion = this.osVersion;
-    if (osVersion === "Unknown") {
-      return this.name;
-    }
-    return `${this.name} (${osVersion})`;
-  }
-
-  get osVersion() {
-    return this.device.deviceProperties.osVersionNumber ?? "Unknown";
-  }
-
-  get quickPickDetails(): string {
-    return `Type: ${this.typeLabel}, Version: ${this.osVersion}, ID: ${this.udid.toLocaleLowerCase()}`;
-  }
-
-  get state(): "connected" | "disconnected" | "unavailable" {
-    return this.device.connectionProperties.tunnelState;
-  }
-
-  get isConnected(): boolean {
-    return this.state === "connected";
-  }
-
-  /**
-   * Check if the device supports devicectl (tvOS 17+)
-   * Older devices (tvOS < 17) need to use alternative methods
-   */
-  get supportsDevicectl(): boolean {
-    return supportsDevicectl(this.device.deviceProperties.osVersionNumber, 17);
-  }
 }
 
-export class visionOSDeviceDestination implements IDestination {
+export class visionOSDeviceDestination extends DeviceDestinationBase implements IDestination {
   type = "visionOSDevice" as const;
   typeLabel = "visionOS Device";
   platform = "xros" as const;
-
-  constructor(public device: DeviceCtlDevice) {
-    this.device = device;
-  }
-
-  get id(): string {
-    return `visionosdevice-${this.udid}`;
-  }
+  protected readonly idPrefix = "visionosdevice";
+  protected readonly minDevicectlMajor = 1;
 
   get icon(): string {
     return "sweetpad-cardboards";
-  }
-
-  /**
-   * The legacy UDID format used by xcodebuild destination
-   * For older devices, this comes from xcdevice; for newer devices, from devicectl
-   */
-  get udid() {
-    return this.device.hardwareProperties.udid ?? this.device.identifier ?? "unknown";
-  }
-
-  /**
-   * The devicectl identifier used for devicectl commands
-   * This is always the identifier from devicectl list
-   */
-  get devicectlId() {
-    return this.device.identifier;
-  }
-
-  get name() {
-    return (
-      this.device.deviceProperties.name ??
-      this.device.hardwareProperties.marketingName ??
-      this.device.hardwareProperties.productType ??
-      "Unknown Device"
-    );
-  }
-
-  get label(): string {
-    const osVersion = this.osVersion;
-    if (osVersion === "Unknown") {
-      return this.name;
-    }
-    return `${this.name} (${osVersion})`;
-  }
-
-  get osVersion() {
-    return this.device.deviceProperties.osVersionNumber ?? "Unknown";
-  }
-
-  get quickPickDetails(): string {
-    return `Type: ${this.typeLabel}, Version: ${this.osVersion}, ID: ${this.udid.toLocaleLowerCase()}`;
-  }
-
-  get state(): "connected" | "disconnected" | "unavailable" {
-    return this.device.connectionProperties.tunnelState;
-  }
-
-  get isConnected(): boolean {
-    return this.state === "connected";
-  }
-
-  /**
-   * Check if the device supports devicectl (visionOS 1+)
-   * All visionOS devices support devicectl as it's a newer platform
-   */
-  get supportsDevicectl(): boolean {
-    return supportsDevicectl(this.device.deviceProperties.osVersionNumber, 1);
   }
 }
 

--- a/tests/devicectl-data/devicectl-ios-16-usb-empty-hardware.json
+++ b/tests/devicectl-data/devicectl-ios-16-usb-empty-hardware.json
@@ -1,0 +1,17 @@
+{
+  "result": {
+    "devices": [
+      {
+        "capabilities": [],
+        "connectionProperties": {
+          "tunnelState": "unavailable",
+          "pairingState": "unsupported"
+        },
+        "deviceProperties": {},
+        "hardwareProperties": {},
+        "identifier": "urn:x-ios-devicectl:device-CS1600001-USB000000000000",
+        "visibilityClass": "default"
+      }
+    ]
+  }
+}

--- a/tests/devicectl-data/devicectl-no-devices.json
+++ b/tests/devicectl-data/devicectl-no-devices.json
@@ -1,0 +1,5 @@
+{
+  "result": {
+    "devices": []
+  }
+}

--- a/tests/xcdevice-data/xcdevice-ios-16-usb-match.json
+++ b/tests/xcdevice-data/xcdevice-ios-16-usb-match.json
@@ -1,0 +1,14 @@
+[
+  {
+    "simulator": false,
+    "operatingSystemVersion": "16.4.1 (20E252)",
+    "interface": "usb",
+    "available": true,
+    "platform": "com.apple.platform.iphoneos",
+    "modelCode": "iPhone14,2",
+    "identifier": "00008110-000AABBCCDD22222",
+    "architecture": "arm64e",
+    "modelName": "iPhone 13 Pro",
+    "name": "Nixuge iPhone"
+  }
+]

--- a/tests/xcdevice-data/xcdevice-ios-16-wifi.json
+++ b/tests/xcdevice-data/xcdevice-ios-16-wifi.json
@@ -1,0 +1,14 @@
+[
+  {
+    "simulator": false,
+    "operatingSystemVersion": "16.4.1 (20E252)",
+    "interface": "network",
+    "available": true,
+    "platform": "com.apple.platform.iphoneos",
+    "modelCode": "iPhone14,2",
+    "identifier": "00008110-000AABBCCDD11111",
+    "architecture": "arm64e",
+    "modelName": "iPhone 13 Pro",
+    "name": "My iPhone"
+  }
+]

--- a/tests/xcdevice-data/xcdevice-mixed-platforms.json
+++ b/tests/xcdevice-data/xcdevice-mixed-platforms.json
@@ -1,0 +1,55 @@
+[
+  {
+    "simulator": false,
+    "operatingSystemVersion": "16.7.12",
+    "interface": "usb",
+    "available": true,
+    "platform": "com.apple.platform.iphoneos",
+    "modelCode": "iPhone15,2",
+    "identifier": "00008110-000PHONE0000001",
+    "modelName": "iPhone 14 Pro",
+    "name": "iPhone"
+  },
+  {
+    "simulator": false,
+    "operatingSystemVersion": "16.5",
+    "interface": "usb",
+    "available": true,
+    "platform": "com.apple.platform.iphoneos",
+    "modelCode": "iPad14,5",
+    "identifier": "00008120-0000IPAD0000002",
+    "modelName": "iPad Pro 12.9-inch",
+    "name": "iPad"
+  },
+  {
+    "simulator": false,
+    "operatingSystemVersion": "10.0",
+    "interface": "usb",
+    "available": true,
+    "platform": "com.apple.platform.watchos",
+    "modelCode": "Watch6,1",
+    "identifier": "00003010-000WATCH0000003",
+    "modelName": "Apple Watch",
+    "name": "Watch"
+  },
+  {
+    "simulator": false,
+    "operatingSystemVersion": "17.0",
+    "interface": "network",
+    "available": true,
+    "platform": "com.apple.platform.appletvos",
+    "modelCode": "AppleTV11,1",
+    "identifier": "00004010-00000TV00000004",
+    "modelName": "Apple TV 4K",
+    "name": "Living Room"
+  },
+  {
+    "simulator": true,
+    "operatingSystemVersion": "17.0",
+    "platform": "com.apple.platform.iphoneos",
+    "modelCode": "iPhone15,2",
+    "identifier": "SIM000000-SIMULATORSKIP",
+    "modelName": "iPhone 14 Pro",
+    "name": "iPhone 14 Pro Simulator"
+  }
+]

--- a/tests/xcdevice-data/xcdevice-unavailable.json
+++ b/tests/xcdevice-data/xcdevice-unavailable.json
@@ -1,0 +1,18 @@
+[
+  {
+    "simulator": false,
+    "operatingSystemVersion": "",
+    "interface": "usb",
+    "available": false,
+    "platform": "com.apple.platform.iphoneos",
+    "modelCode": "iPhone10,6",
+    "identifier": "00008101-000UNAVAIL11111",
+    "modelName": "iPhone X",
+    "name": "iPhone",
+    "error": {
+      "code": -9,
+      "domain": "com.apple.platform.iphoneos",
+      "failureReason": "iPhone is not paired with your computer. To use iPhone with Xcode, unlock it and choose to trust this computer when prompted."
+    }
+  }
+]


### PR DESCRIPTION
Fixes #223. `xcrun devicectl` returns `"hardwareProperties": {}` for iOS <=16 devices connected via USB and omits Wi-Fi devices entirely, which left the device list empty for anyone on an older iPhone/iPad. This change fetches from both `devicectl` and `xcdevice` in parallel, merges records by UDID into a unified `DeviceRaw` carrying both sources, and falls back to `xcdevice` whenever `devicectl` can't classify an entry. `DeviceDestinationBase` now exposes unified getters (`udid`, `name`, `osVersion`, `state`, …) that read from whichever source has the data, so downstream deploy logic (devicectl for iOS 17+, ios-deploy for iOS <=16) keeps working unchanged. `DeviceCtlHardwareProperties` fields were also relaxed to optional to match real-world devicectl output. Covered by new unit tests in `src/devices/merge.spec.ts` plus fixture-based manager tests for the Wi-Fi and USB recovery paths.