### PR TITLE
fix: emit watch markers in debugging-run for macOS and simulators

### DIFF
--- a/src/build/provider.ts
+++ b/src/build/provider.ts
@@ -346,7 +346,7 @@ class ActionDispatcher {
         scheme: scheme,
         configuration: configuration,
         xcworkspace: xcworkspace,
-        watchMarker: false,
+        watchMarker: true,
         launchArgs: launchArgs,
         launchEnv: launchEnv,
       });
@@ -362,7 +362,7 @@ class ActionDispatcher {
         sdk: sdk,
         configuration: configuration,
         xcworkspace: xcworkspace,
-        watchMarker: false,
+        watchMarker: true,
         launchArgs: launchArgs,
         launchEnv: launchEnv,
         debug: options.debug,


### PR DESCRIPTION
commonRunCallback set watchMarker: false for macOS and simulators while the device branch and all commonLaunchCallback branches already set it to true. Without markers the $sweetpad-watch problem matcher never flips the background task to active, so sweetpad: debugging-run used as a preLaunchTask hangs and the debugger never attaches. Closes #222.