### PR TITLE
fix: refresh progress status before devicectl launch await

### DIFF
--- a/src/build/manager.ts
+++ b/src/build/manager.ts
@@ -741,6 +741,7 @@ export class BuildManager {
         ...option.launchArgs,
       ].filter((arg) => arg !== null); // Filter out null arguments
 
+      context.updateProgressStatus(`Running "${option.scheme}" on "${option.destination.name}"`);
       await terminal.execute({
         command: "xcrun",
         args: launchArgs,


### PR DESCRIPTION
When running on an iOS 17+ device, the status bar stayed on
"Extracting Xcode version" for the whole time the app was running.
Cause: `xcrun devicectl ... --console` blocks for the app's lifetime
(it streams stdout/stderr and only writes the JSON outcome on exit),
and we never refreshed the status between extracting the Xcode version
and awaiting that call.

Fix: reset the progress status to `Running "<scheme>" on "<dest>"`
(the same wording used before install) right before the blocking await.
The await itself is intentional — dropping it would race the
`readJsonFile` outcome check below.

Closes #220.