### PR TITLE
feat: opt-out flags for buildServer.json regen and Swift LSP restarts

### DIFF
--- a/package.json
+++ b/package.json
@@ -934,7 +934,8 @@
         "sweetpad.xcodebuildserver.autogenerate": {
           "type": "boolean",
           "default": true,
-          "description": "Watch if default scheme is changed and regenerate the build server config"
+          "description": "Watch if default scheme is changed and regenerate the build server config",
+          "markdownDeprecationMessage": "Use `#sweetpad.build.autoGenerateBuildServerConfig#` instead. This setting is still honored as a fallback when the new one is unset."
         },
         "sweetpad.xcodebuildserver.path": {
           "type": "string",
@@ -955,6 +956,16 @@
           "minimum": 100,
           "maximum": 5000,
           "description": "Delay in milliseconds before auto-refreshing schemes after detecting file changes"
+        },
+        "sweetpad.build.autoGenerateBuildServerConfig": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically (re)generate `buildServer.json` via xcode-build-server on build and on scheme change. Disable when using a custom build server (e.g. one based on Swift Build) so SweetPad does not overwrite your config."
+        },
+        "sweetpad.build.autoRestartSwiftLSP": {
+          "type": "boolean",
+          "default": true,
+          "description": "Restart the Swift language server after every build and after `tuist generate` / `tuist install` / `xcodegen generate`. Disable when using a build server that does not require LSP restarts (e.g. one with background indexing). Has no effect on the explicit 'SweetPad: Generate Build Server Config' command, which always restarts."
         },
         "sweetpad.build.logStreamEnabled": {
           "type": "boolean",

--- a/src/build/commands.ts
+++ b/src/build/commands.ts
@@ -150,7 +150,8 @@ export async function generateBuildServerConfigCommand(context: ExtensionContext
     xcworkspace: xcworkspace,
     scheme: scheme,
   });
-  await restartSwiftLSP();
+  // User explicitly invoked this command — always restart, regardless of build.autoRestartSwiftLSP.
+  await restartSwiftLSP({ force: true });
 
   vscode.window.showInformationMessage("buildServer.json generated in workspace root", "Open").then((selected) => {
     if (selected === "Open") {

--- a/src/build/manager.ts
+++ b/src/build/manager.ts
@@ -36,6 +36,7 @@ import {
   detectWorkspaceType,
   ensureAppPathExists,
   generateBuildServerConfigOnBuild,
+  isAutoGenerateBuildServerConfigEnabled,
   getCurrentXcodeWorkspacePath,
   getSwiftPMDirectory,
   getWorkspacePath,
@@ -181,8 +182,7 @@ export class BuildManager {
       return;
     }
 
-    const isEnabled = getWorkspaceConfig("xcodebuildserver.autogenerate") ?? true;
-    if (!isEnabled) {
+    if (!isAutoGenerateBuildServerConfigEnabled()) {
       return;
     }
 

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -333,14 +333,26 @@ export async function askConfiguration(
 }
 
 /**
+ * Whether SweetPad should auto-(re)generate `buildServer.json` via xcode-build-server.
+ * Reads the current `build.autoGenerateBuildServerConfig` key, falling back to the
+ * deprecated `xcodebuildserver.autogenerate` when the new key is unset. Defaults to true.
+ */
+export function isAutoGenerateBuildServerConfigEnabled(): boolean {
+  const current = getWorkspaceConfig("build.autoGenerateBuildServerConfig");
+  if (current !== undefined) {
+    return current;
+  }
+  return getWorkspaceConfig("xcodebuildserver.autogenerate") ?? true;
+}
+
+/**
  * Check if buildServer.json needs to be regenerated and regenerate it if needed
  */
 export async function generateBuildServerConfigOnBuild(options: {
   scheme: string;
   xcworkspace: string;
 }): Promise<void> {
-  const isEnabled = getWorkspaceConfig("xcodebuildserver.autogenerate") ?? true;
-  if (!isEnabled) {
+  if (!isAutoGenerateBuildServerConfigEnabled()) {
     return;
   }
 
@@ -468,7 +480,22 @@ export async function selectXcodeWorkspace(options: { autoselect: boolean }): Pr
   return selected.context.path;
 }
 
-export async function restartSwiftLSP() {
+/**
+ * Restart the Swift language server.
+ *
+ * Honors `sweetpad.build.autoRestartSwiftLSP` (default true). Pass `{ force: true }` from
+ * explicitly user-invoked commands (e.g. "Generate Build Server Config") that should
+ * always restart regardless of the setting.
+ */
+export async function restartSwiftLSP(options?: { force?: boolean }) {
+  if (!options?.force) {
+    const isEnabled = getWorkspaceConfig("build.autoRestartSwiftLSP") ?? true;
+    if (!isEnabled) {
+      commonLogger.debug("Skipping Swift LSP restart (build.autoRestartSwiftLSP is false)");
+      return;
+    }
+  }
+
   // Restart SourceKit Language Server
   try {
     await vscode.commands.executeCommand("swift.restartLSPServer");

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -20,6 +20,8 @@ type Config = {
   "build.bringSimulatorToForeground": boolean;
   "build.autoRefreshSchemes": boolean;
   "build.autoRefreshSchemesDelay": number;
+  "build.autoGenerateBuildServerConfig": boolean;
+  "build.autoRestartSwiftLSP": boolean;
   "build.logStreamEnabled": boolean;
   "build.logStreamPredicate": string;
   "system.taskExecutor": "v1" | "v2";


### PR DESCRIPTION
Adds two opt-out flags so a custom build server can fully replace
xcode-build-server: `sweetpad.build.autoGenerateBuildServerConfig`
gates buildServer.json regeneration (deprecates and falls back to
`sweetpad.xcodebuildserver.autogenerate`), and
`sweetpad.build.autoRestartSwiftLSP` gates the Swift LSP restart after
every build and after tuist/xcodegen generation. The explicit
"Generate Build Server Config" command always restarts.

Closes #205.