### PR TITLE
feat: stream os_log from physical iOS devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -981,6 +981,30 @@
             "subsystem BEGINSWITH \"${bundleId}\"",
             "process == \"${processName}\""
           ]
+        },
+        "sweetpad.build.deviceLogStreamBackend": {
+          "type": "string",
+          "enum": ["off", "osActivityDtMode", "pymobiledevice3"],
+          "default": "off",
+          "enumDescriptions": [
+            "Do not stream os_log from physical devices (default).",
+            "Inject OS_ACTIVITY_DT_MODE=enable so os_log mirrors to stderr via devicectl --console. Zero external dependencies, requires Xcode 16+. Undocumented Apple behavior, may break on future iOS versions. Mirrors main-executable logs only; dynamically-loaded framework logs may be missing.",
+            "Spawn `pymobiledevice3 syslog live` to stream structured os_log (subsystem, category, level). Requires `pip install pymobiledevice3` and, on iOS 17+, a running tunnel (`sudo pymobiledevice3 remote tunneld`)."
+          ],
+          "description": "Backend for streaming os_log/Logger output from physical iOS devices during debug sessions."
+        },
+        "sweetpad.build.pymobiledevice3Path": {
+          "type": "string",
+          "default": "pymobiledevice3",
+          "description": "Path to the pymobiledevice3 binary. Leave as 'pymobiledevice3' to resolve via PATH. Only used when build.deviceLogStreamBackend is 'pymobiledevice3'."
+        },
+        "sweetpad.build.pymobiledevice3ExtraArgs": {
+          "type": "array",
+          "items": {
+            "type": ["string", "null"]
+          },
+          "default": [],
+          "description": "Extra CLI arguments appended to 'pymobiledevice3 syslog live'. By default SweetPad injects '--process-name <EXECUTABLE_NAME>' and '--match <CFBundleIdentifier>' to cut framework noise. Include '--match <regex>' or '--process-name <name>' here to override either preset with your own value, or pass null (e.g. [\"--match\", null]) to disable SweetPad's preset without adding a replacement. Only used when build.deviceLogStreamBackend is 'pymobiledevice3'."
         }
       }
     },

--- a/src/build/manager-integration.spec.ts
+++ b/src/build/manager-integration.spec.ts
@@ -99,6 +99,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
         appPath: "/path/to/TestApp.app",
         bundleIdentifier: "com.example.testapp",
         appName: "TestApp",
+        executableName: "TestApp",
       };
       (require("../common/cli/scripts").getBuildSettingsToLaunch as jest.Mock).mockResolvedValue(mockBuildSettings);
     });

--- a/src/build/manager.ts
+++ b/src/build/manager.ts
@@ -21,6 +21,7 @@ import { commonLogger } from "../common/logger";
 import { type Command, type TaskTerminal, runTask } from "../common/tasks";
 import { assertUnreachable } from "../common/types";
 import * as iosDeploy from "../common/xcode/ios-deploy";
+import { getDeviceLaunchEnvExtras, resolveDeviceLogBackend } from "../debugger/device-log-backend";
 import { getLogStreamManager } from "../debugger/log-stream";
 import type { DeviceDestination } from "../devices/types";
 import type { SimulatorDestination } from "../simulators/types";
@@ -36,11 +37,11 @@ import {
   detectWorkspaceType,
   ensureAppPathExists,
   generateBuildServerConfigOnBuild,
-  isAutoGenerateBuildServerConfigEnabled,
   getCurrentXcodeWorkspacePath,
   getSwiftPMDirectory,
   getWorkspacePath,
   getXcodeBuildDestinationString,
+  isAutoGenerateBuildServerConfigEnabled,
   isXcbeautifyEnabled,
   prepareBundleDir,
   prepareDerivedDataPath,
@@ -688,15 +689,6 @@ export class BuildManager {
     // Install and launch app on device
     context.updateProgressStatus(`Installing "${scheme}" on "${destinationName}"`);
 
-    context.updateWorkspaceState("build.lastLaunchedApp", {
-      type: "device",
-      appPath: targetPath,
-      appName: buildSettings.appName,
-      bundleIdentifier: bundlerId,
-      destinationId: deviceId,
-      destinationType: destinationType,
-    });
-
     if (option.watchMarker) {
       writeWatchMarkers(terminal);
     }
@@ -722,6 +714,18 @@ export class BuildManager {
       context.updateProgressStatus("Extracting Xcode version");
       const xcodeVersion = await getXcodeVersionInstalled();
       const isConsoleOptionSupported = xcodeVersion.major >= 16;
+      const logBackend = resolveDeviceLogBackend();
+
+      context.updateWorkspaceState("build.lastLaunchedApp", {
+        type: "device",
+        appPath: targetPath,
+        appName: buildSettings.appName,
+        executableName: buildSettings.executableName,
+        bundleIdentifier: bundlerId,
+        destinationId: deviceId,
+        destinationType: destinationType,
+        logBackend: logBackend,
+      });
 
       // Prepare the launch arguments
       const launchArgs = [
@@ -745,9 +749,13 @@ export class BuildManager {
       await terminal.execute({
         command: "xcrun",
         args: launchArgs,
-        // Should be prefixed with `DEVICECTL_CHILD_` to pass to the child process
+        // Should be prefixed with `DEVICECTL_CHILD_` to pass to the child process.
+        // Merge backend-provided defaults first so user-provided launchEnv values win.
         env: Object.fromEntries(
-          Object.entries(option.launchEnv).map(([key, value]) => [`DEVICECTL_CHILD_${key}`, value]),
+          Object.entries({ ...getDeviceLaunchEnvExtras(logBackend), ...option.launchEnv }).map(([key, value]) => [
+            `DEVICECTL_CHILD_${key}`,
+            value,
+          ]),
         ),
         // Forward stdout/stderr to the log stream output channel
         onOutputLine: async (data) => {
@@ -788,9 +796,15 @@ export class BuildManager {
         throw new ExtensionError("ios-deploy is required for iOS < 17. Install it with: brew install ios-deploy");
       }
 
-      if (option.watchMarker) {
-        writeWatchMarkers(terminal);
-      }
+      context.updateWorkspaceState("build.lastLaunchedApp", {
+        type: "device",
+        appPath: targetPath,
+        appName: buildSettings.appName,
+        executableName: buildSettings.executableName,
+        bundleIdentifier: bundlerId,
+        destinationId: deviceId,
+        destinationType: destinationType,
+      });
 
       await iosDeploy.installAndLaunchApp(context, terminal, {
         deviceId: deviceId,

--- a/src/common/cli/scripts.ts
+++ b/src/common/cli/scripts.ts
@@ -165,6 +165,18 @@ export class XcodeBuildSettings {
     return `${this.targetName}.app`;
   }
 
+  get executableName() {
+    // On iOS this is CFBundleExecutable — the string that appears as the process name in
+    // os_log / syslog output. Usually matches PRODUCT_NAME but can diverge (e.g. spaces stripped).
+    if (this.settings.EXECUTABLE_NAME) {
+      return this.settings.EXECUTABLE_NAME;
+    }
+    if (this.settings.PRODUCT_NAME) {
+      return this.settings.PRODUCT_NAME;
+    }
+    return this.targetName;
+  }
+
   private get targetName() {
     // Example:
     // - "ControlRoom"

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -14,13 +14,17 @@ import { type ErrorMessageAction, ExtensionError, TaskError } from "./errors";
 import { commonLogger } from "./logger";
 import { QuickPickCancelledError } from "./quick-pick";
 
+export type DeviceLogBackend = "off" | "osActivityDtMode" | "pymobiledevice3";
+
 export type LastLaunchedAppDeviceContext = {
   type: "device";
   appPath: string; // Example: "/Users/username/Library/Developer/Xcode/DerivedData/MyApp-..."
   appName: string; // Example: "MyApp.app"
+  executableName?: string; // Example: "MyApp" — CFBundleExecutable, process name in os_log
   bundleIdentifier: string; // Example: "com.example.MyApp"
   destinationId: string; // Example: "00008030-001A0A3E0A68002E"
   destinationType: DestinationType; // Example: "iOS"
+  logBackend?: DeviceLogBackend;
 };
 
 export type LastLaunchedAppSimulatorContext = {

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -24,6 +24,9 @@ type Config = {
   "build.autoRestartSwiftLSP": boolean;
   "build.logStreamEnabled": boolean;
   "build.logStreamPredicate": string;
+  "build.deviceLogStreamBackend": "off" | "osActivityDtMode" | "pymobiledevice3";
+  "build.pymobiledevice3Path": string;
+  "build.pymobiledevice3ExtraArgs": (string | null)[];
   "system.taskExecutor": "v1" | "v2";
   "system.logLevel": "debug" | "info" | "warn" | "error";
   "system.enableSentry": boolean;

--- a/src/debugger/device-log-backend.spec.ts
+++ b/src/debugger/device-log-backend.spec.ts
@@ -1,0 +1,254 @@
+import { getWorkspaceConfig } from "../common/config";
+import {
+  buildPymobiledevice3Args,
+  formatCommandLine,
+  getDeviceLaunchEnvExtras,
+  resolveDeviceLogBackend,
+  shellQuote,
+} from "./device-log-backend";
+
+jest.mock("../common/config", () => ({
+  getWorkspaceConfig: jest.fn(),
+}));
+
+const mockedGetConfig = getWorkspaceConfig as jest.MockedFunction<typeof getWorkspaceConfig>;
+
+describe("resolveDeviceLogBackend", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("defaults to off when config is missing", () => {
+    mockedGetConfig.mockReturnValue(undefined);
+    expect(resolveDeviceLogBackend()).toBe("off");
+  });
+
+  it("returns explicit off", () => {
+    mockedGetConfig.mockReturnValue("off");
+    expect(resolveDeviceLogBackend()).toBe("off");
+  });
+
+  it("returns explicit osActivityDtMode", () => {
+    mockedGetConfig.mockReturnValue("osActivityDtMode");
+    expect(resolveDeviceLogBackend()).toBe("osActivityDtMode");
+  });
+
+  it("returns explicit pymobiledevice3", () => {
+    mockedGetConfig.mockReturnValue("pymobiledevice3");
+    expect(resolveDeviceLogBackend()).toBe("pymobiledevice3");
+  });
+});
+
+describe("getDeviceLaunchEnvExtras", () => {
+  it("returns OS_ACTIVITY_DT_MODE for osActivityDtMode", () => {
+    expect(getDeviceLaunchEnvExtras("osActivityDtMode")).toEqual({ OS_ACTIVITY_DT_MODE: "enable" });
+  });
+
+  it("returns empty for off", () => {
+    expect(getDeviceLaunchEnvExtras("off")).toEqual({});
+  });
+
+  it("returns empty for pymobiledevice3", () => {
+    expect(getDeviceLaunchEnvExtras("pymobiledevice3")).toEqual({});
+  });
+});
+
+describe("buildPymobiledevice3Args", () => {
+  const base = { processName: "pulse_2050", bundleIdentifier: "dev.tuist.pulse-2050" };
+
+  it("uses SweetPad defaults when extras are empty", () => {
+    const result = buildPymobiledevice3Args({ ...base, rawExtraArgs: [] });
+    expect(result).toEqual({
+      kind: "ok",
+      args: ["syslog", "live", "--label", "--process-name", "pulse_2050", "--match", "dev.tuist.pulse-2050"],
+      hasProcessNameOverride: false,
+      hasMatchOverride: false,
+    });
+  });
+
+  it("passes through unrelated extras in order", () => {
+    const result = buildPymobiledevice3Args({
+      ...base,
+      rawExtraArgs: ["--verbose", "--color"],
+    });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.args).toEqual([
+      "syslog",
+      "live",
+      "--label",
+      "--process-name",
+      "pulse_2050",
+      "--match",
+      "dev.tuist.pulse-2050",
+      "--verbose",
+      "--color",
+    ]);
+  });
+
+  it("replaces --process-name when overridden", () => {
+    const result = buildPymobiledevice3Args({
+      ...base,
+      rawExtraArgs: ["--process-name", "MyApp"],
+    });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.hasProcessNameOverride).toBe(true);
+    expect(result.args).toEqual([
+      "syslog",
+      "live",
+      "--label",
+      "--match",
+      "dev.tuist.pulse-2050",
+      "--process-name",
+      "MyApp",
+    ]);
+  });
+
+  it("replaces --match when overridden", () => {
+    const result = buildPymobiledevice3Args({
+      ...base,
+      rawExtraArgs: ["--match", "com.example.custom"],
+    });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.hasMatchOverride).toBe(true);
+    expect(result.args).toEqual([
+      "syslog",
+      "live",
+      "--label",
+      "--process-name",
+      "pulse_2050",
+      "--match",
+      "com.example.custom",
+    ]);
+  });
+
+  it("accepts short aliases -p and -m", () => {
+    const result = buildPymobiledevice3Args({
+      ...base,
+      rawExtraArgs: ["-p", "Other", "-m", "foo"],
+    });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.hasProcessNameOverride).toBe(true);
+    expect(result.hasMatchOverride).toBe(true);
+    expect(result.args).toEqual(["syslog", "live", "--label", "-p", "Other", "-m", "foo"]);
+  });
+
+  it("suppresses --match when value is null", () => {
+    const result = buildPymobiledevice3Args({
+      ...base,
+      rawExtraArgs: ["--match", null],
+    });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.hasMatchOverride).toBe(true);
+    expect(result.args).toEqual(["syslog", "live", "--label", "--process-name", "pulse_2050"]);
+  });
+
+  it("suppresses --process-name when value is null", () => {
+    const result = buildPymobiledevice3Args({
+      ...base,
+      rawExtraArgs: ["--process-name", null],
+    });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.hasProcessNameOverride).toBe(true);
+    expect(result.args).toEqual(["syslog", "live", "--label", "--match", "dev.tuist.pulse-2050"]);
+  });
+
+  it("suppresses both with null values", () => {
+    const result = buildPymobiledevice3Args({
+      ...base,
+      rawExtraArgs: ["--process-name", null, "--match", null],
+    });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.args).toEqual(["syslog", "live", "--label"]);
+  });
+
+  it("returns missingProcessName when process name is undefined and no override", () => {
+    const result = buildPymobiledevice3Args({
+      ...base,
+      processName: undefined,
+      rawExtraArgs: [],
+    });
+    expect(result).toEqual({ kind: "missingProcessName" });
+  });
+
+  it("accepts missing process name when overridden", () => {
+    const result = buildPymobiledevice3Args({
+      ...base,
+      processName: undefined,
+      rawExtraArgs: ["--process-name", "Explicit"],
+    });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.args).toEqual([
+      "syslog",
+      "live",
+      "--label",
+      "--match",
+      "dev.tuist.pulse-2050",
+      "--process-name",
+      "Explicit",
+    ]);
+  });
+
+  it("accepts missing process name when --process-name is null-suppressed", () => {
+    const result = buildPymobiledevice3Args({
+      ...base,
+      processName: undefined,
+      rawExtraArgs: ["--process-name", null],
+    });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.args).toEqual(["syslog", "live", "--label", "--match", "dev.tuist.pulse-2050"]);
+  });
+
+  it("drops trailing flag with no value", () => {
+    const result = buildPymobiledevice3Args({
+      ...base,
+      rawExtraArgs: ["--match"],
+    });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.hasMatchOverride).toBe(true);
+    expect(result.args).toEqual(["syslog", "live", "--label", "--process-name", "pulse_2050"]);
+  });
+
+  it("preserves extras declared after a null-suppressed flag", () => {
+    const result = buildPymobiledevice3Args({
+      ...base,
+      rawExtraArgs: ["--match", null, "--verbose"],
+    });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.args).toEqual(["syslog", "live", "--label", "--process-name", "pulse_2050", "--verbose"]);
+  });
+});
+
+describe("shellQuote", () => {
+  it("leaves bare identifiers unquoted", () => {
+    expect(shellQuote("pulse_2050")).toBe("pulse_2050");
+    expect(shellQuote("com.example.app")).toBe("com.example.app");
+    expect(shellQuote("/usr/bin/foo")).toBe("/usr/bin/foo");
+  });
+
+  it("single-quotes values with spaces", () => {
+    expect(shellQuote("hello world")).toBe("'hello world'");
+  });
+
+  it("single-quotes empty string", () => {
+    expect(shellQuote("")).toBe("''");
+  });
+
+  it("escapes embedded single quotes", () => {
+    expect(shellQuote("it's")).toBe("'it'\\''s'");
+  });
+
+  it("quotes shell metacharacters", () => {
+    expect(shellQuote("a|b")).toBe("'a|b'");
+    expect(shellQuote("$foo")).toBe("'$foo'");
+  });
+});
+
+describe("formatCommandLine", () => {
+  it("joins command and args with spaces", () => {
+    expect(formatCommandLine("pymobiledevice3", ["syslog", "live"])).toBe("pymobiledevice3 syslog live");
+  });
+
+  it("quotes args that need it", () => {
+    expect(formatCommandLine("pymobiledevice3", ["--match", "a b"])).toBe("pymobiledevice3 --match 'a b'");
+  });
+});

--- a/src/debugger/device-log-backend.ts
+++ b/src/debugger/device-log-backend.ts
@@ -1,0 +1,93 @@
+import type { DeviceLogBackend } from "../common/commands";
+import { getWorkspaceConfig } from "../common/config";
+
+export function resolveDeviceLogBackend(): DeviceLogBackend {
+  return getWorkspaceConfig("build.deviceLogStreamBackend") ?? "off";
+}
+
+export function getDeviceLaunchEnvExtras(backend: DeviceLogBackend): Record<string, string> {
+  if (backend === "osActivityDtMode") {
+    return { OS_ACTIVITY_DT_MODE: "enable" };
+  }
+  return {};
+}
+
+export type Pymobiledevice3ArgsInput = {
+  rawExtraArgs: (string | null)[];
+  processName: string | undefined;
+  bundleIdentifier: string;
+};
+
+export type Pymobiledevice3ArgsResult =
+  | {
+      kind: "ok";
+      args: string[];
+      hasProcessNameOverride: boolean;
+      hasMatchOverride: boolean;
+    }
+  | { kind: "missingProcessName" };
+
+/**
+ * Merge SweetPad's default `pymobiledevice3 syslog live` arguments with user-supplied extras.
+ *
+ * Rules:
+ * - `--process-name`/`-p` and `--match`/`-m` in extras fully replace SweetPad's defaults.
+ * - A null value after either flag suppresses SweetPad's default without adding a replacement.
+ * - Any other args are passed through in order.
+ * - If the process name is missing AND no override was provided, returns `missingProcessName`.
+ */
+export function buildPymobiledevice3Args(input: Pymobiledevice3ArgsInput): Pymobiledevice3ArgsResult {
+  const { rawExtraArgs, processName, bundleIdentifier } = input;
+
+  let hasProcessNameOverride = false;
+  let hasMatchOverride = false;
+  const cleanedExtra: string[] = [];
+
+  for (let i = 0; i < rawExtraArgs.length; i++) {
+    const arg = rawExtraArgs[i];
+    const isProcessName = arg === "--process-name" || arg === "-p";
+    const isMatch = arg === "--match" || arg === "-m";
+    if (isProcessName || isMatch) {
+      if (isProcessName) hasProcessNameOverride = true;
+      else hasMatchOverride = true;
+      const value = rawExtraArgs[i + 1];
+      if (typeof value === "string") {
+        cleanedExtra.push(arg as string, value);
+      }
+      i++;
+      continue;
+    }
+    if (typeof arg === "string") {
+      cleanedExtra.push(arg);
+    }
+  }
+
+  if (!processName && !hasProcessNameOverride) {
+    return { kind: "missingProcessName" };
+  }
+
+  const baseArgs: string[] = ["syslog", "live", "--label"];
+  if (!hasProcessNameOverride) {
+    baseArgs.push("--process-name", processName as string);
+  }
+  if (!hasMatchOverride) {
+    baseArgs.push("--match", bundleIdentifier);
+  }
+
+  return {
+    kind: "ok",
+    args: [...baseArgs, ...cleanedExtra],
+    hasProcessNameOverride,
+    hasMatchOverride,
+  };
+}
+
+export function formatCommandLine(command: string, args: string[]): string {
+  return [command, ...args].map(shellQuote).join(" ");
+}
+
+export function shellQuote(value: string): string {
+  if (value === "") return "''";
+  if (/^[A-Za-z0-9_\-.,:/=@%+]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/src/debugger/log-stream.ts
+++ b/src/debugger/log-stream.ts
@@ -1,8 +1,16 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import * as vscode from "vscode";
-import type { ExtensionContext, LastLaunchedAppContext } from "../common/commands";
+import type { ExtensionContext, LastLaunchedAppContext, LastLaunchedAppDeviceContext } from "../common/commands";
 import { getWorkspaceConfig } from "../common/config";
+import { exec } from "../common/exec";
 import { commonLogger } from "../common/logger";
+import { buildPymobiledevice3Args, formatCommandLine } from "./device-log-backend";
+
+type LogStreamSpec = {
+  command: string;
+  args: string[];
+  stderrPrefix: string;
+};
 
 /**
  * Builds the default predicate for filtering logs from the unified logging system.
@@ -129,19 +137,23 @@ export class LogStreamManager {
       ? customPredicate.replace(/\$\{bundleId\}/g, bundleIdentifier).replace(/\$\{processName\}/g, processName)
       : buildDefaultPredicate(bundleIdentifier, processName);
 
-    try {
-      this.spawnLogStreamProcess(launchContext, predicate);
-    } catch (error) {
-      commonLogger.error("Failed to start log stream", { error });
-    }
-
-    // Add separator between stdout and unified logging output
     const channel = this.getOutputChannel();
     channel.appendLine("");
     channel.appendLine("─".repeat(60));
-    channel.appendLine("[SweetPad] os_log / Logger / NSLog output:");
-    channel.appendLine(`[SweetPad] Predicate: ${predicate}`);
+    if (launchContext.type === "device") {
+      // Device backends don't use a `log stream` predicate. Each backend prints its own header below.
+      channel.appendLine("[SweetPad] Device log streaming:");
+    } else {
+      channel.appendLine("[SweetPad] os_log / Logger / NSLog output:");
+      channel.appendLine(`[SweetPad] Predicate: ${predicate}`);
+    }
     channel.appendLine("");
+
+    try {
+      await this.spawnLogStreamProcess(launchContext, predicate);
+    } catch (error) {
+      commonLogger.error("Failed to start log stream", { error });
+    }
 
     // Register handler to stop log stream when debug session ends
     this.sessionDisposable = vscode.debug.onDidTerminateDebugSession(() => {
@@ -155,63 +167,133 @@ export class LogStreamManager {
   /**
    * Spawn the log stream process based on the launch context type.
    */
-  private spawnLogStreamProcess(launchContext: LastLaunchedAppContext, predicate: string): void {
-    let command: string;
-    let args: string[];
-
-    switch (launchContext.type) {
-      case "simulator": {
-        // For simulators, use xcrun simctl spawn to run log stream inside the simulator
-        command = "xcrun";
-        args = [
-          "simctl",
-          "spawn",
-          launchContext.simulatorUdid,
-          "log",
-          "stream",
-          "--predicate",
-          predicate,
-          "--level",
-          "debug",
-          "--style",
-          "compact",
-        ];
-        break;
-      }
-      case "macos": {
-        // For macOS, run log stream directly
-        command = "log";
-        args = ["stream", "--predicate", predicate, "--level", "debug", "--style", "compact"];
-        break;
-      }
-      case "device": {
-        // For physical devices, log streaming via devicectl is not yet supported
-        // TODO: investigate devicectl device process log stream support
-        const channel = this.getOutputChannel();
-        channel.appendLine("[SweetPad] os_log streaming for physical devices is not yet supported.");
-        channel.appendLine("[SweetPad] Use Console.app or Xcode to view device logs.");
-        return;
-      }
+  private async spawnLogStreamProcess(launchContext: LastLaunchedAppContext, predicate: string): Promise<void> {
+    const channel = this.getOutputChannel();
+    const spec = await this.resolveLogStreamSpec(launchContext, predicate, channel);
+    if (!spec) {
+      return;
     }
 
-    commonLogger.debug("Starting log stream", { command, args });
-
-    const subprocess = spawn(command, args, {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
+    commonLogger.debug("Starting log stream", { command: spec.command, args: spec.args });
+    const subprocess = spawn(spec.command, spec.args, { stdio: ["ignore", "pipe", "pipe"] });
     this.logStreamProcess = subprocess;
+    this.attachSubprocessHandlers(subprocess, channel, spec.stderrPrefix);
+  }
 
-    const channel = this.getOutputChannel();
+  private async resolveLogStreamSpec(
+    launchContext: LastLaunchedAppContext,
+    predicate: string,
+    channel: vscode.OutputChannel,
+  ): Promise<LogStreamSpec | null> {
+    switch (launchContext.type) {
+      case "simulator":
+        return this.buildSimulatorSpec(launchContext.simulatorUdid, predicate);
+      case "macos":
+        return this.buildMacOSSpec(predicate);
+      case "device":
+        return this.resolveDeviceSpec(launchContext, channel);
+    }
+  }
 
+  private buildSimulatorSpec(simulatorUdid: string, predicate: string): LogStreamSpec {
+    return {
+      command: "xcrun",
+      args: [
+        "simctl",
+        "spawn",
+        simulatorUdid,
+        "log",
+        "stream",
+        "--predicate",
+        predicate,
+        "--level",
+        "debug",
+        "--style",
+        "compact",
+      ],
+      stderrPrefix: "[log stream stderr]",
+    };
+  }
+
+  private buildMacOSSpec(predicate: string): LogStreamSpec {
+    return {
+      command: "log",
+      args: ["stream", "--predicate", predicate, "--level", "debug", "--style", "compact"],
+      stderrPrefix: "[log stream stderr]",
+    };
+  }
+
+  private async resolveDeviceSpec(
+    launchContext: LastLaunchedAppDeviceContext,
+    channel: vscode.OutputChannel,
+  ): Promise<LogStreamSpec | null> {
+    const backend = launchContext.logBackend ?? "off";
+    switch (backend) {
+      case "osActivityDtMode":
+        channel.appendLine(
+          "[SweetPad] os_log/Logger output is being mirrored to stderr via OS_ACTIVITY_DT_MODE=enable.",
+        );
+        channel.appendLine("[SweetPad] Messages appear in the stdout/stderr stream above.");
+        channel.appendLine(
+          "[SweetPad] Caveat: mirrors main-executable logs only; dynamically-loaded framework logs may be missing.",
+        );
+        return null;
+      case "pymobiledevice3":
+        return await this.buildPymobiledevice3Spec(launchContext, channel);
+      default:
+        channel.appendLine("[SweetPad] Device os_log streaming is disabled (build.deviceLogStreamBackend=off).");
+        channel.appendLine("[SweetPad] Use Console.app or Xcode to view device logs.");
+        return null;
+    }
+  }
+
+  private async buildPymobiledevice3Spec(
+    launchContext: LastLaunchedAppDeviceContext,
+    channel: vscode.OutputChannel,
+  ): Promise<LogStreamSpec | null> {
+    const binaryPath = getWorkspaceConfig("build.pymobiledevice3Path") ?? "pymobiledevice3";
+    if (!(await isPymobiledevice3Available(binaryPath))) {
+      channel.appendLine(`[SweetPad] '${binaryPath}' not found on PATH.`);
+      channel.appendLine("[SweetPad] Install with: pip install pymobiledevice3");
+      channel.appendLine("[SweetPad] Or set 'sweetpad.build.pymobiledevice3Path' to an absolute path.");
+      return null;
+    }
+    const rawExtraArgs = getWorkspaceConfig("build.pymobiledevice3ExtraArgs") ?? [];
+    const result = buildPymobiledevice3Args({
+      rawExtraArgs,
+      processName: launchContext.executableName,
+      bundleIdentifier: launchContext.bundleIdentifier,
+    });
+    if (result.kind === "missingProcessName") {
+      channel.appendLine(
+        "[SweetPad] Could not determine the process name for log filtering (EXECUTABLE_NAME missing).",
+      );
+      channel.appendLine(
+        "[SweetPad] Set 'sweetpad.build.pymobiledevice3ExtraArgs' to include '--process-name <name>'.",
+      );
+      return null;
+    }
+    channel.appendLine(`[SweetPad] Extra args: ${JSON.stringify(rawExtraArgs)}`);
+    channel.appendLine(`[SweetPad] Command: ${formatCommandLine(binaryPath, result.args)}`);
+    channel.appendLine("[SweetPad] On iOS 17+, requires a running tunnel: sudo pymobiledevice3 remote tunneld");
+    return {
+      command: binaryPath,
+      args: result.args,
+      stderrPrefix: "[pymobiledevice3]",
+    };
+  }
+
+  private attachSubprocessHandlers(
+    subprocess: ChildProcess,
+    channel: vscode.OutputChannel,
+    stderrPrefix: string,
+  ): void {
     subprocess.stdout?.on("data", (data: Buffer) => {
       channel.append(data.toString());
     });
-
     subprocess.stderr?.on("data", (data: Buffer) => {
-      channel.append(`[log stream stderr] ${data.toString()}`);
+      channel.append(`${stderrPrefix} ${data.toString()}`);
     });
-
     subprocess.on("exit", (code: number | null, signal: string | null) => {
       if (code !== null && code !== 0) {
         channel.appendLine(`\n[SweetPad] Log stream exited with code ${code}`);
@@ -220,7 +302,6 @@ export class LogStreamManager {
       }
       this.logStreamProcess = undefined;
     });
-
     subprocess.on("error", (error: Error) => {
       commonLogger.error("Log stream process error", { error });
       channel.appendLine(`\n[SweetPad] Log stream error: ${error.message}`);
@@ -253,6 +334,15 @@ export class LogStreamManager {
       this.outputChannel.dispose();
       this.outputChannel = undefined;
     }
+  }
+}
+
+async function isPymobiledevice3Available(binaryPath: string): Promise<boolean> {
+  try {
+    await exec({ command: binaryPath, args: ["version"] });
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/src/devices/manager.ts
+++ b/src/devices/manager.ts
@@ -70,8 +70,7 @@ export class DevicesManager {
       listDevicesWithXcdevice(this.context),
     ]);
 
-    const devicectlDevices =
-      devicectlResult.status === "fulfilled" ? devicectlResult.value.result.devices : [];
+    const devicectlDevices = devicectlResult.status === "fulfilled" ? devicectlResult.value.result.devices : [];
     const xcdeviceList = xcdeviceResult.status === "fulfilled" ? xcdeviceResult.value : [];
 
     const merged = mergeDeviceSources(devicectlDevices, xcdeviceList);


### PR DESCRIPTION
Adds two opt-in backends for streaming `os_log`/`Logger` output from physical iOS devices during debug sessions, configured via `sweetpad.build.deviceLogStreamBackend`: `osActivityDtMode` (no deps, injects `OS_ACTIVITY_DT_MODE=enable` so logs mirror to `devicectl --console` stderr) and `pymobiledevice3` (spawns `pymobiledevice3 syslog live` for structured logs). Closes #229.