### PR TITLE
Structured local syslog filtering for pymobiledevice3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1011,7 +1011,24 @@
             ]
           },
           "default": [],
-          "description": "Extra CLI arguments appended to 'pymobiledevice3 syslog live'. By default SweetPad injects '--process-name <EXECUTABLE_NAME>' and '--regex <EXECUTABLE_NAME>\\\\{<EXECUTABLE_NAME>(\\\\.debug\\\\.dylib)?\\\\}\\[' to focus on the app's main image and optional debug dylib. Include '--regex <pattern>' or '--process-name <name>' here to override either preset with your own value, or pass null (e.g. [\"--regex\", null]) to disable SweetPad's preset without adding a replacement. Only used when build.deviceLogStreamBackend is 'pymobiledevice3'."
+          "description": "Extra CLI arguments appended to 'pymobiledevice3 syslog live'. Only used when build.deviceLogStreamBackend is 'pymobiledevice3'."
+        },
+        "sweetpad.build.pymobiledevice3DebugDylibOnly": {
+          "type": "boolean",
+          "default": true,
+          "description": "Only keep syslog entries from the .debug.dylib image, dropping noise from the main binary. Disable if not using ENABLE_DEBUG_DYLIB. Only used when build.deviceLogStreamBackend is 'pymobiledevice3'."
+        },
+        "sweetpad.build.pymobiledevice3SubsystemDenyList": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": ["com.apple.*"],
+          "description": "Glob patterns for subsystems to drop (e.g. 'com.apple.*'). Only used when build.deviceLogStreamBackend is 'pymobiledevice3'."
+        },
+        "sweetpad.build.pymobiledevice3SubsystemAllowList": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "When non-empty, only keep entries whose subsystem matches a pattern (e.g. 'com.myapp.*'). Only used when build.deviceLogStreamBackend is 'pymobiledevice3'."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1011,7 +1011,7 @@
             ]
           },
           "default": [],
-          "description": "Extra CLI arguments appended to 'pymobiledevice3 syslog live'. By default SweetPad injects '--process-name <EXECUTABLE_NAME>' and '--match <CFBundleIdentifier>' to cut framework noise. Include '--match <regex>' or '--process-name <name>' here to override either preset with your own value, or pass null (e.g. [\"--match\", null]) to disable SweetPad's preset without adding a replacement. Only used when build.deviceLogStreamBackend is 'pymobiledevice3'."
+          "description": "Extra CLI arguments appended to 'pymobiledevice3 syslog live'. By default SweetPad injects '--process-name <EXECUTABLE_NAME>' and '--regex <EXECUTABLE_NAME>\\\\{<EXECUTABLE_NAME>(\\\\.debug\\\\.dylib)?\\\\}\\[' to focus on the app's main image and optional debug dylib. Include '--regex <pattern>' or '--process-name <name>' here to override either preset with your own value, or pass null (e.g. [\"--regex\", null]) to disable SweetPad's preset without adding a replacement. Only used when build.deviceLogStreamBackend is 'pymobiledevice3'."
         }
       }
     },

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -27,6 +27,9 @@ type Config = {
   "build.deviceLogStreamBackend": "off" | "osActivityDtMode" | "pymobiledevice3";
   "build.pymobiledevice3Path": string;
   "build.pymobiledevice3ExtraArgs": (string | null)[];
+  "build.pymobiledevice3DebugDylibOnly": boolean;
+  "build.pymobiledevice3SubsystemDenyList": string[];
+  "build.pymobiledevice3SubsystemAllowList": string[];
   "system.taskExecutor": "v1" | "v2";
   "system.logLevel": "debug" | "info" | "warn" | "error";
   "system.enableSentry": boolean;

--- a/src/debugger/device-log-backend.spec.ts
+++ b/src/debugger/device-log-backend.spec.ts
@@ -1,8 +1,6 @@
 import { getWorkspaceConfig } from "../common/config";
 import {
-  buildDefaultPymobiledevice3Regex,
   buildPymobiledevice3Args,
-  escapeRegex,
   formatCommandLine,
   getDeviceLaunchEnvExtras,
   resolveDeviceLogBackend,
@@ -57,34 +55,31 @@ describe("getDeviceLaunchEnvExtras", () => {
 
 describe("buildPymobiledevice3Args", () => {
   const base = { processName: "pulse_2050" };
-  const defaultRegex = buildDefaultPymobiledevice3Regex(base.processName);
 
   it("uses SweetPad defaults when extras are empty", () => {
     const result = buildPymobiledevice3Args({ ...base, rawExtraArgs: [] });
     expect(result).toEqual({
       kind: "ok",
-      args: ["syslog", "live", "--label", "--process-name", "pulse_2050", "--regex", defaultRegex],
+      args: ["--no-color", "syslog", "live", "--label", "--process-name", "pulse_2050"],
       hasProcessNameOverride: false,
-      hasRegexOverride: false,
     });
   });
 
   it("passes through unrelated extras in order", () => {
     const result = buildPymobiledevice3Args({
       ...base,
-      rawExtraArgs: ["--verbose", "--color"],
+      rawExtraArgs: ["--verbose", "--image-offset"],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
     expect(result.args).toEqual([
+      "--no-color",
       "syslog",
       "live",
       "--label",
       "--process-name",
       "pulse_2050",
-      "--regex",
-      defaultRegex,
       "--verbose",
-      "--color",
+      "--image-offset",
     ]);
   });
 
@@ -95,54 +90,17 @@ describe("buildPymobiledevice3Args", () => {
     });
     if (result.kind !== "ok") throw new Error("expected ok");
     expect(result.hasProcessNameOverride).toBe(true);
-    expect(result.args).toEqual([
-      "syslog",
-      "live",
-      "--label",
-      "--regex",
-      buildDefaultPymobiledevice3Regex("MyApp"),
-      "--process-name",
-      "MyApp",
-    ]);
+    expect(result.args).toEqual(["--no-color", "syslog", "live", "--label", "--process-name", "MyApp"]);
   });
 
-  it("replaces --regex when overridden", () => {
+  it("accepts short alias -p", () => {
     const result = buildPymobiledevice3Args({
       ...base,
-      rawExtraArgs: ["--regex", "com.example.custom"],
-    });
-    if (result.kind !== "ok") throw new Error("expected ok");
-    expect(result.hasRegexOverride).toBe(true);
-    expect(result.args).toEqual([
-      "syslog",
-      "live",
-      "--label",
-      "--process-name",
-      "pulse_2050",
-      "--regex",
-      "com.example.custom",
-    ]);
-  });
-
-  it("accepts short aliases -p and -e", () => {
-    const result = buildPymobiledevice3Args({
-      ...base,
-      rawExtraArgs: ["-p", "Other", "-e", "foo"],
+      rawExtraArgs: ["-p", "Other"],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
     expect(result.hasProcessNameOverride).toBe(true);
-    expect(result.hasRegexOverride).toBe(true);
-    expect(result.args).toEqual(["syslog", "live", "--label", "-p", "Other", "-e", "foo"]);
-  });
-
-  it("suppresses --regex when value is null", () => {
-    const result = buildPymobiledevice3Args({
-      ...base,
-      rawExtraArgs: ["--regex", null],
-    });
-    if (result.kind !== "ok") throw new Error("expected ok");
-    expect(result.hasRegexOverride).toBe(true);
-    expect(result.args).toEqual(["syslog", "live", "--label", "--process-name", "pulse_2050"]);
+    expect(result.args).toEqual(["--no-color", "syslog", "live", "--label", "-p", "Other"]);
   });
 
   it("suppresses --process-name when value is null", () => {
@@ -152,16 +110,7 @@ describe("buildPymobiledevice3Args", () => {
     });
     if (result.kind !== "ok") throw new Error("expected ok");
     expect(result.hasProcessNameOverride).toBe(true);
-    expect(result.args).toEqual(["syslog", "live", "--label", "--regex", defaultRegex]);
-  });
-
-  it("suppresses both with null values", () => {
-    const result = buildPymobiledevice3Args({
-      ...base,
-      rawExtraArgs: ["--process-name", null, "--regex", null],
-    });
-    if (result.kind !== "ok") throw new Error("expected ok");
-    expect(result.args).toEqual(["syslog", "live", "--label"]);
+    expect(result.args).toEqual(["--no-color", "syslog", "live", "--label"]);
   });
 
   it("returns missingProcessName when process name is undefined and no override", () => {
@@ -180,15 +129,7 @@ describe("buildPymobiledevice3Args", () => {
       rawExtraArgs: ["--process-name", "Explicit"],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
-    expect(result.args).toEqual([
-      "syslog",
-      "live",
-      "--label",
-      "--regex",
-      buildDefaultPymobiledevice3Regex("Explicit"),
-      "--process-name",
-      "Explicit",
-    ]);
+    expect(result.args).toEqual(["--no-color", "syslog", "live", "--label", "--process-name", "Explicit"]);
   });
 
   it("accepts missing process name when --process-name is null-suppressed", () => {
@@ -198,55 +139,33 @@ describe("buildPymobiledevice3Args", () => {
       rawExtraArgs: ["--process-name", null],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
-    expect(result.args).toEqual(["syslog", "live", "--label"]);
+    expect(result.args).toEqual(["--no-color", "syslog", "live", "--label"]);
   });
 
-  it("escapes regex metacharacters in the default regex", () => {
-    const result = buildPymobiledevice3Args({
-      processName: "pulse_2050+beta",
-      rawExtraArgs: [],
-    });
-    if (result.kind !== "ok") throw new Error("expected ok");
-    expect(result.args).toEqual([
-      "syslog",
-      "live",
-      "--label",
-      "--process-name",
-      "pulse_2050+beta",
-      "--regex",
-      "pulse_2050\\+beta\\{pulse_2050\\+beta(\\.debug\\.dylib)?\\}\\[",
-    ]);
-  });
-
-  it("drops trailing flag with no value", () => {
+  it("drops trailing --process-name flag with no value", () => {
     const result = buildPymobiledevice3Args({
       ...base,
-      rawExtraArgs: ["--regex"],
+      rawExtraArgs: ["--process-name"],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
-    expect(result.hasRegexOverride).toBe(true);
-    expect(result.args).toEqual(["syslog", "live", "--label", "--process-name", "pulse_2050"]);
+    expect(result.hasProcessNameOverride).toBe(true);
+    expect(result.args).toEqual(["--no-color", "syslog", "live", "--label"]);
   });
 
   it("preserves extras declared after a null-suppressed flag", () => {
     const result = buildPymobiledevice3Args({
       ...base,
-      rawExtraArgs: ["--regex", null, "--verbose"],
+      rawExtraArgs: ["--process-name", null, "--verbose"],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
-    expect(result.args).toEqual(["syslog", "live", "--label", "--process-name", "pulse_2050", "--verbose"]);
+    expect(result.args).toEqual(["--no-color", "syslog", "live", "--label", "--verbose"]);
   });
-});
 
-describe("buildDefaultPymobiledevice3Regex", () => {
-  it("matches the main executable and optional debug dylib image name", () => {
-    expect(buildDefaultPymobiledevice3Regex("pulse_2050")).toBe("pulse_2050\\{pulse_2050(\\.debug\\.dylib)?\\}\\[");
-  });
-});
-
-describe("escapeRegex", () => {
-  it("escapes regex metacharacters", () => {
-    expect(escapeRegex("pulse_2050+beta")).toBe("pulse_2050\\+beta");
+  it("does not inject any server-side message filter (--match / --regex)", () => {
+    const result = buildPymobiledevice3Args({ ...base, rawExtraArgs: [] });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.args).not.toContain("--match");
+    expect(result.args).not.toContain("--regex");
   });
 });
 
@@ -281,12 +200,8 @@ describe("formatCommandLine", () => {
   });
 
   it("quotes args that need it", () => {
-    expect(formatCommandLine("pymobiledevice3", ["--match", "a b"])).toBe("pymobiledevice3 --match 'a b'");
-  });
-
-  it("quotes regex args with shell metacharacters", () => {
-    expect(formatCommandLine("pymobiledevice3", ["--regex", "pulse_2050\\{pulse_2050(\\.debug\\.dylib)?\\}\\["])).toBe(
-      "pymobiledevice3 --regex 'pulse_2050\\{pulse_2050(\\.debug\\.dylib)?\\}\\['",
+    expect(formatCommandLine("pymobiledevice3", ["--process-name", "a b"])).toBe(
+      "pymobiledevice3 --process-name 'a b'",
     );
   });
 });

--- a/src/debugger/device-log-backend.spec.ts
+++ b/src/debugger/device-log-backend.spec.ts
@@ -1,6 +1,8 @@
 import { getWorkspaceConfig } from "../common/config";
 import {
+  buildDefaultPymobiledevice3Regex,
   buildPymobiledevice3Args,
+  escapeRegex,
   formatCommandLine,
   getDeviceLaunchEnvExtras,
   resolveDeviceLogBackend,
@@ -54,15 +56,16 @@ describe("getDeviceLaunchEnvExtras", () => {
 });
 
 describe("buildPymobiledevice3Args", () => {
-  const base = { processName: "pulse_2050", bundleIdentifier: "dev.tuist.pulse-2050" };
+  const base = { processName: "pulse_2050" };
+  const defaultRegex = buildDefaultPymobiledevice3Regex(base.processName);
 
   it("uses SweetPad defaults when extras are empty", () => {
     const result = buildPymobiledevice3Args({ ...base, rawExtraArgs: [] });
     expect(result).toEqual({
       kind: "ok",
-      args: ["syslog", "live", "--label", "--process-name", "pulse_2050", "--match", "dev.tuist.pulse-2050"],
+      args: ["syslog", "live", "--label", "--process-name", "pulse_2050", "--regex", defaultRegex],
       hasProcessNameOverride: false,
-      hasMatchOverride: false,
+      hasRegexOverride: false,
     });
   });
 
@@ -78,8 +81,8 @@ describe("buildPymobiledevice3Args", () => {
       "--label",
       "--process-name",
       "pulse_2050",
-      "--match",
-      "dev.tuist.pulse-2050",
+      "--regex",
+      defaultRegex,
       "--verbose",
       "--color",
     ]);
@@ -96,49 +99,49 @@ describe("buildPymobiledevice3Args", () => {
       "syslog",
       "live",
       "--label",
-      "--match",
-      "dev.tuist.pulse-2050",
+      "--regex",
+      buildDefaultPymobiledevice3Regex("MyApp"),
       "--process-name",
       "MyApp",
     ]);
   });
 
-  it("replaces --match when overridden", () => {
+  it("replaces --regex when overridden", () => {
     const result = buildPymobiledevice3Args({
       ...base,
-      rawExtraArgs: ["--match", "com.example.custom"],
+      rawExtraArgs: ["--regex", "com.example.custom"],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
-    expect(result.hasMatchOverride).toBe(true);
+    expect(result.hasRegexOverride).toBe(true);
     expect(result.args).toEqual([
       "syslog",
       "live",
       "--label",
       "--process-name",
       "pulse_2050",
-      "--match",
+      "--regex",
       "com.example.custom",
     ]);
   });
 
-  it("accepts short aliases -p and -m", () => {
+  it("accepts short aliases -p and -e", () => {
     const result = buildPymobiledevice3Args({
       ...base,
-      rawExtraArgs: ["-p", "Other", "-m", "foo"],
+      rawExtraArgs: ["-p", "Other", "-e", "foo"],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
     expect(result.hasProcessNameOverride).toBe(true);
-    expect(result.hasMatchOverride).toBe(true);
-    expect(result.args).toEqual(["syslog", "live", "--label", "-p", "Other", "-m", "foo"]);
+    expect(result.hasRegexOverride).toBe(true);
+    expect(result.args).toEqual(["syslog", "live", "--label", "-p", "Other", "-e", "foo"]);
   });
 
-  it("suppresses --match when value is null", () => {
+  it("suppresses --regex when value is null", () => {
     const result = buildPymobiledevice3Args({
       ...base,
-      rawExtraArgs: ["--match", null],
+      rawExtraArgs: ["--regex", null],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
-    expect(result.hasMatchOverride).toBe(true);
+    expect(result.hasRegexOverride).toBe(true);
     expect(result.args).toEqual(["syslog", "live", "--label", "--process-name", "pulse_2050"]);
   });
 
@@ -149,13 +152,13 @@ describe("buildPymobiledevice3Args", () => {
     });
     if (result.kind !== "ok") throw new Error("expected ok");
     expect(result.hasProcessNameOverride).toBe(true);
-    expect(result.args).toEqual(["syslog", "live", "--label", "--match", "dev.tuist.pulse-2050"]);
+    expect(result.args).toEqual(["syslog", "live", "--label", "--regex", defaultRegex]);
   });
 
   it("suppresses both with null values", () => {
     const result = buildPymobiledevice3Args({
       ...base,
-      rawExtraArgs: ["--process-name", null, "--match", null],
+      rawExtraArgs: ["--process-name", null, "--regex", null],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
     expect(result.args).toEqual(["syslog", "live", "--label"]);
@@ -181,8 +184,8 @@ describe("buildPymobiledevice3Args", () => {
       "syslog",
       "live",
       "--label",
-      "--match",
-      "dev.tuist.pulse-2050",
+      "--regex",
+      buildDefaultPymobiledevice3Regex("Explicit"),
       "--process-name",
       "Explicit",
     ]);
@@ -195,26 +198,55 @@ describe("buildPymobiledevice3Args", () => {
       rawExtraArgs: ["--process-name", null],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
-    expect(result.args).toEqual(["syslog", "live", "--label", "--match", "dev.tuist.pulse-2050"]);
+    expect(result.args).toEqual(["syslog", "live", "--label"]);
+  });
+
+  it("escapes regex metacharacters in the default regex", () => {
+    const result = buildPymobiledevice3Args({
+      processName: "pulse_2050+beta",
+      rawExtraArgs: [],
+    });
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.args).toEqual([
+      "syslog",
+      "live",
+      "--label",
+      "--process-name",
+      "pulse_2050+beta",
+      "--regex",
+      "pulse_2050\\+beta\\{pulse_2050\\+beta(\\.debug\\.dylib)?\\}\\[",
+    ]);
   });
 
   it("drops trailing flag with no value", () => {
     const result = buildPymobiledevice3Args({
       ...base,
-      rawExtraArgs: ["--match"],
+      rawExtraArgs: ["--regex"],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
-    expect(result.hasMatchOverride).toBe(true);
+    expect(result.hasRegexOverride).toBe(true);
     expect(result.args).toEqual(["syslog", "live", "--label", "--process-name", "pulse_2050"]);
   });
 
   it("preserves extras declared after a null-suppressed flag", () => {
     const result = buildPymobiledevice3Args({
       ...base,
-      rawExtraArgs: ["--match", null, "--verbose"],
+      rawExtraArgs: ["--regex", null, "--verbose"],
     });
     if (result.kind !== "ok") throw new Error("expected ok");
     expect(result.args).toEqual(["syslog", "live", "--label", "--process-name", "pulse_2050", "--verbose"]);
+  });
+});
+
+describe("buildDefaultPymobiledevice3Regex", () => {
+  it("matches the main executable and optional debug dylib image name", () => {
+    expect(buildDefaultPymobiledevice3Regex("pulse_2050")).toBe("pulse_2050\\{pulse_2050(\\.debug\\.dylib)?\\}\\[");
+  });
+});
+
+describe("escapeRegex", () => {
+  it("escapes regex metacharacters", () => {
+    expect(escapeRegex("pulse_2050+beta")).toBe("pulse_2050\\+beta");
   });
 });
 
@@ -250,5 +282,11 @@ describe("formatCommandLine", () => {
 
   it("quotes args that need it", () => {
     expect(formatCommandLine("pymobiledevice3", ["--match", "a b"])).toBe("pymobiledevice3 --match 'a b'");
+  });
+
+  it("quotes regex args with shell metacharacters", () => {
+    expect(formatCommandLine("pymobiledevice3", ["--regex", "pulse_2050\\{pulse_2050(\\.debug\\.dylib)?\\}\\["])).toBe(
+      "pymobiledevice3 --regex 'pulse_2050\\{pulse_2050(\\.debug\\.dylib)?\\}\\['",
+    );
   });
 });

--- a/src/debugger/device-log-backend.ts
+++ b/src/debugger/device-log-backend.ts
@@ -15,7 +15,6 @@ export function getDeviceLaunchEnvExtras(backend: DeviceLogBackend): Record<stri
 export type Pymobiledevice3ArgsInput = {
   rawExtraArgs: (string | null)[];
   processName: string | undefined;
-  bundleIdentifier: string;
 };
 
 export type Pymobiledevice3ArgsResult =
@@ -23,35 +22,48 @@ export type Pymobiledevice3ArgsResult =
       kind: "ok";
       args: string[];
       hasProcessNameOverride: boolean;
-      hasMatchOverride: boolean;
+      hasRegexOverride: boolean;
     }
   | { kind: "missingProcessName" };
+
+export function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function buildDefaultPymobiledevice3Regex(processName: string): string {
+  const escaped = escapeRegex(processName);
+  return `${escaped}\\{${escaped}(\\.debug\\.dylib)?\\}\\[`;
+}
 
 /**
  * Merge SweetPad's default `pymobiledevice3 syslog live` arguments with user-supplied extras.
  *
  * Rules:
- * - `--process-name`/`-p` and `--match`/`-m` in extras fully replace SweetPad's defaults.
+ * - `--process-name`/`-p` and `--regex`/`-e` in extras fully replace SweetPad's defaults.
  * - A null value after either flag suppresses SweetPad's default without adding a replacement.
  * - Any other args are passed through in order.
  * - If the process name is missing AND no override was provided, returns `missingProcessName`.
  */
 export function buildPymobiledevice3Args(input: Pymobiledevice3ArgsInput): Pymobiledevice3ArgsResult {
-  const { rawExtraArgs, processName, bundleIdentifier } = input;
+  const { rawExtraArgs, processName } = input;
 
   let hasProcessNameOverride = false;
-  let hasMatchOverride = false;
+  let hasRegexOverride = false;
+  let overriddenProcessName: string | undefined;
   const cleanedExtra: string[] = [];
 
   for (let i = 0; i < rawExtraArgs.length; i++) {
     const arg = rawExtraArgs[i];
     const isProcessName = arg === "--process-name" || arg === "-p";
-    const isMatch = arg === "--match" || arg === "-m";
-    if (isProcessName || isMatch) {
+    const isRegex = arg === "--regex" || arg === "-e";
+    if (isProcessName || isRegex) {
       if (isProcessName) hasProcessNameOverride = true;
-      else hasMatchOverride = true;
+      else hasRegexOverride = true;
       const value = rawExtraArgs[i + 1];
       if (typeof value === "string") {
+        if (isProcessName) {
+          overriddenProcessName = value;
+        }
         cleanedExtra.push(arg as string, value);
       }
       i++;
@@ -70,15 +82,16 @@ export function buildPymobiledevice3Args(input: Pymobiledevice3ArgsInput): Pymob
   if (!hasProcessNameOverride) {
     baseArgs.push("--process-name", processName as string);
   }
-  if (!hasMatchOverride) {
-    baseArgs.push("--match", bundleIdentifier);
+  const regexProcessName = overriddenProcessName ?? processName;
+  if (!hasRegexOverride && regexProcessName) {
+    baseArgs.push("--regex", buildDefaultPymobiledevice3Regex(regexProcessName));
   }
 
   return {
     kind: "ok",
     args: [...baseArgs, ...cleanedExtra],
     hasProcessNameOverride,
-    hasMatchOverride,
+    hasRegexOverride,
   };
 }
 

--- a/src/debugger/device-log-backend.ts
+++ b/src/debugger/device-log-backend.ts
@@ -22,48 +22,51 @@ export type Pymobiledevice3ArgsResult =
       kind: "ok";
       args: string[];
       hasProcessNameOverride: boolean;
-      hasRegexOverride: boolean;
     }
   | { kind: "missingProcessName" };
 
-export function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-export function buildDefaultPymobiledevice3Regex(processName: string): string {
-  const escaped = escapeRegex(processName);
-  return `${escaped}\\{${escaped}(\\.debug\\.dylib)?\\}\\[`;
-}
-
 /**
- * Merge SweetPad's default `pymobiledevice3 syslog live` arguments with user-supplied extras.
+ * Build the argv for `pymobiledevice3 syslog live`, merging SweetPad's defaults
+ * with user-supplied extras.
+ *
+ * SweetPad intentionally does NOT add "--match" / "--regex" any more — those
+ * flags filter on the rendered line and are prone to both false positives
+ * (framework chatter whose subsystem contains the bundle id) and false
+ * negatives (logs from a custom `Logger(subsystem:)` that doesn't mention the
+ * bundle id). Fine-grained filtering happens locally against the parsed
+ * {@link SyslogEntry}; see `log-pipe.ts`.
+ *
+ * "--process-name" is still applied server-side as a cheap volume filter
+ * (the relay only sends entries from processes matching the name). It does
+ * NOT by itself exclude framework-emitted lines from *within* the app's
+ * process — that's what the local image-name filter is for.
+ *
+ * "--no-color" is prepended as a top-level option so that piped output never
+ * carries ANSI escape sequences; the parser tolerates them too, but stripping
+ * at the source keeps the output channel clean if a user ever disables the
+ * parser.
  *
  * Rules:
- * - `--process-name`/`-p` and `--regex`/`-e` in extras fully replace SweetPad's defaults.
- * - A null value after either flag suppresses SweetPad's default without adding a replacement.
- * - Any other args are passed through in order.
- * - If the process name is missing AND no override was provided, returns `missingProcessName`.
+ * - "--process-name" / "-p" in extras fully replaces SweetPad's default.
+ * - A "null" value after the flag suppresses SweetPad's default without
+ *   adding a replacement.
+ * - Any other args pass through in order.
+ * - If the process name is missing AND no override was provided, returns
+ *   `missingProcessName`.
  */
 export function buildPymobiledevice3Args(input: Pymobiledevice3ArgsInput): Pymobiledevice3ArgsResult {
   const { rawExtraArgs, processName } = input;
 
   let hasProcessNameOverride = false;
-  let hasRegexOverride = false;
-  let overriddenProcessName: string | undefined;
   const cleanedExtra: string[] = [];
 
   for (let i = 0; i < rawExtraArgs.length; i++) {
     const arg = rawExtraArgs[i];
     const isProcessName = arg === "--process-name" || arg === "-p";
-    const isRegex = arg === "--regex" || arg === "-e";
-    if (isProcessName || isRegex) {
-      if (isProcessName) hasProcessNameOverride = true;
-      else hasRegexOverride = true;
+    if (isProcessName) {
+      hasProcessNameOverride = true;
       const value = rawExtraArgs[i + 1];
       if (typeof value === "string") {
-        if (isProcessName) {
-          overriddenProcessName = value;
-        }
         cleanedExtra.push(arg as string, value);
       }
       i++;
@@ -78,20 +81,17 @@ export function buildPymobiledevice3Args(input: Pymobiledevice3ArgsInput): Pymob
     return { kind: "missingProcessName" };
   }
 
-  const baseArgs: string[] = ["syslog", "live", "--label"];
+  // "--no-color" is a top-level option; it must precede the `syslog` subcommand.
+  // "--label" makes the CLI emit `[subsystem][category]` suffixes the parser reads.
+  const baseArgs: string[] = ["--no-color", "syslog", "live", "--label"];
   if (!hasProcessNameOverride) {
     baseArgs.push("--process-name", processName as string);
-  }
-  const regexProcessName = overriddenProcessName ?? processName;
-  if (!hasRegexOverride && regexProcessName) {
-    baseArgs.push("--regex", buildDefaultPymobiledevice3Regex(regexProcessName));
   }
 
   return {
     kind: "ok",
     args: [...baseArgs, ...cleanedExtra],
     hasProcessNameOverride,
-    hasRegexOverride,
   };
 }
 

--- a/src/debugger/log-pipe.spec.ts
+++ b/src/debugger/log-pipe.spec.ts
@@ -1,0 +1,410 @@
+import {
+  PassthroughLogPipe,
+  Pymobiledevice3JsonLogPipe,
+  Pymobiledevice3LogPipe,
+  buildAppImageFilter,
+  parseSyslogLine,
+} from "./log-pipe";
+
+describe("parseSyslogLine", () => {
+  it("parses a line with subsystem and category (the --label suffix)", () => {
+    const line =
+      "2026-04-16 12:52:32.707333 Laboratory{Laboratory.debug.dylib}[67135] <NOTICE>: ContentView initialized [Laboratory Test][App]";
+    expect(parseSyslogLine(line)).toEqual({
+      timestamp: "2026-04-16 12:52:32.707333",
+      processName: "Laboratory",
+      imageName: "Laboratory.debug.dylib",
+      pid: 67135,
+      level: "NOTICE",
+      message: "ContentView initialized",
+      label: { subsystem: "Laboratory Test", category: "App" },
+    });
+  });
+
+  it("parses a framework-emitted line (image_name != process_name)", () => {
+    const line =
+      "2026-04-16 12:52:32.707333 Laboratory{CoreFoundation}[67116] <NOTICE>: looked up value for key AppleLanguages [com.apple.defaults][User Defaults]";
+    expect(parseSyslogLine(line)).toMatchObject({
+      processName: "Laboratory",
+      imageName: "CoreFoundation",
+      pid: 67116,
+      level: "NOTICE",
+      label: { subsystem: "com.apple.defaults", category: "User Defaults" },
+    });
+  });
+
+  it("parses a line without a trailing label (no --label passed)", () => {
+    const line = "2026-04-16 12:52:32.707333 Laboratory{Laboratory}[67135] <DEBUG>: hello world";
+    const entry = parseSyslogLine(line);
+    expect(entry).toMatchObject({
+      imageName: "Laboratory",
+      level: "DEBUG",
+      message: "hello world",
+    });
+    expect(entry?.label).toBeUndefined();
+  });
+
+  it("extracts image_offset when --image-offset is enabled", () => {
+    const line = "2026-04-16 12:52:32.707333 Laboratory{Laboratory+0x1a2b3c}[67135] <NOTICE>: tick [sub][cat]";
+    expect(parseSyslogLine(line)).toMatchObject({
+      imageName: "Laboratory",
+      imageOffset: 0x1a2b3c,
+    });
+  });
+
+  it("preserves brackets inside the message body and only strips the trailing label", () => {
+    const line =
+      "2026-04-16 12:52:32.707333 Laboratory{Laboratory.debug.dylib}[1] <NOTICE>: got [inner][pair] and [another] [Laboratory Test][App]";
+    expect(parseSyslogLine(line)).toMatchObject({
+      message: "got [inner][pair] and [another]",
+      label: { subsystem: "Laboratory Test", category: "App" },
+    });
+  });
+
+  it("strips ANSI color escape sequences before parsing", () => {
+    const line = "\x1b[32m2026-04-16 12:52:32.707333\x1b[0m Laboratory{Laboratory}[1] <\x1b[33mNOTICE\x1b[0m>: colored";
+    expect(parseSyslogLine(line)).toMatchObject({
+      processName: "Laboratory",
+      level: "NOTICE",
+      message: "colored",
+    });
+  });
+
+  it("returns null for non-log lines (banners, blank, tunnel notices)", () => {
+    expect(parseSyslogLine("")).toBeNull();
+    expect(parseSyslogLine("[SweetPad] banner")).toBeNull();
+    expect(parseSyslogLine("Connected to remote tunnel")).toBeNull();
+  });
+});
+
+describe("buildAppImageFilter", () => {
+  const make = (imageName: string) => ({
+    timestamp: "t",
+    processName: "Laboratory",
+    imageName,
+    pid: 1,
+    level: "NOTICE",
+    message: "m",
+  });
+
+  it("keeps both main image and debug dylib by default", () => {
+    const keep = buildAppImageFilter("Laboratory");
+    expect(keep(make("Laboratory"))).toBe(true);
+    expect(keep(make("Laboratory.debug.dylib"))).toBe(true);
+  });
+
+  it("debugDylibOnly=true keeps only the debug dylib", () => {
+    const keep = buildAppImageFilter("Laboratory", true);
+    expect(keep(make("Laboratory.debug.dylib"))).toBe(true);
+    expect(keep(make("Laboratory"))).toBe(false);
+  });
+
+  it("drops framework-emitted noise (CoreFoundation, Foundation, etc.)", () => {
+    const keep = buildAppImageFilter("Laboratory");
+    expect(keep(make("CoreFoundation"))).toBe(false);
+    expect(keep(make("Foundation"))).toBe(false);
+    expect(keep(make("libdispatch.dylib"))).toBe(false);
+  });
+
+  it("does not match by prefix — 'LaboratoryExt' is a different image", () => {
+    const keep = buildAppImageFilter("Laboratory");
+    expect(keep(make("LaboratoryExt"))).toBe(false);
+  });
+});
+
+describe("Pymobiledevice3LogPipe", () => {
+  function createPipe(
+    options: {
+      executableName: string;
+      debugDylibOnly?: boolean;
+      subsystemDenyList?: string[];
+      subsystemAllowList?: string[];
+      minLevel?: string;
+    } = { executableName: "Laboratory" },
+  ) {
+    const lines: string[] = [];
+    const pipe = new Pymobiledevice3LogPipe((line) => lines.push(line), options);
+    return { pipe, lines };
+  }
+
+  it("drops framework noise", () => {
+    const { pipe, lines } = createPipe();
+    const noise =
+      "2026-04-16 12:52:32.707333 Laboratory{CoreFoundation}[67116] <NOTICE>: noise [com.apple.defaults][User Defaults]";
+    pipe.push(`${noise}\n`);
+    expect(lines).toEqual([]);
+  });
+
+  it("keeps app logs from debug dylib", () => {
+    const { pipe, lines } = createPipe();
+    const appLog =
+      "2026-04-16 12:53:59.832625 Laboratory{Laboratory.debug.dylib}[67135] <NOTICE>: hello [Lab Test][App]";
+    pipe.push(`${appLog}\n`);
+    expect(lines).toEqual([appLog]);
+  });
+
+  it("keeps the main image by default (debugDylibOnly=false)", () => {
+    const { pipe, lines } = createPipe();
+    const line = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <NOTICE>: hi [sub][cat]";
+    pipe.push(`${line}\n`);
+    expect(lines).toEqual([line]);
+  });
+
+  it("debugDylibOnly=true drops the main image", () => {
+    const { pipe, lines } = createPipe({ executableName: "Laboratory", debugDylibOnly: true });
+    const mainImage = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <DEBUG>: noise [com.apple.Previews][X]";
+    const debugDylib = "2026-04-16 12:53:59.832625 Laboratory{Laboratory.debug.dylib}[1] <NOTICE>: app log [sub][cat]";
+    pipe.push(`${mainImage}\n`);
+    pipe.push(`${debugDylib}\n`);
+    expect(lines).toEqual([debugDylib]);
+  });
+
+  it("subsystem deny-list drops matching subsystems", () => {
+    const { pipe, lines } = createPipe({
+      executableName: "Laboratory",
+      subsystemDenyList: ["com.apple.*"],
+    });
+    const apple = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <DEBUG>: noise [com.apple.CFBundle][resources]";
+    const app = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <NOTICE>: hi [com.example.app][ui]";
+    pipe.push(`${apple}\n`);
+    pipe.push(`${app}\n`);
+    expect(lines).toEqual([app]);
+  });
+
+  it("subsystem deny-list does not affect entries without a label", () => {
+    const { pipe, lines } = createPipe({
+      executableName: "Laboratory",
+      subsystemDenyList: ["com.apple.*"],
+    });
+    const noLabel = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <NOTICE>: no label here";
+    pipe.push(`${noLabel}\n`);
+    expect(lines).toEqual([noLabel]);
+  });
+
+  it("subsystem allow-list keeps only matching subsystems", () => {
+    const { pipe, lines } = createPipe({
+      executableName: "Laboratory",
+      subsystemAllowList: ["com.example.*"],
+    });
+    const match = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <NOTICE>: a [com.example.app][ui]";
+    const other = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <NOTICE>: b [com.apple.CFBundle][resources]";
+    pipe.push(`${match}\n`);
+    pipe.push(`${other}\n`);
+    expect(lines).toEqual([match]);
+  });
+
+  it("subsystem allow-list drops entries without a label", () => {
+    const { pipe, lines } = createPipe({
+      executableName: "Laboratory",
+      subsystemAllowList: ["com.example.*"],
+    });
+    const noLabel = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <NOTICE>: no label";
+    pipe.push(`${noLabel}\n`);
+    expect(lines).toEqual([]);
+  });
+
+  it("deny-list and allow-list work together", () => {
+    const { pipe, lines } = createPipe({
+      executableName: "Laboratory",
+      subsystemDenyList: ["com.apple.*"],
+      subsystemAllowList: ["com.example.myapp"],
+    });
+    const apple = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <NOTICE>: a [com.apple.X][Y]";
+    const myApp = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <NOTICE>: b [com.example.myapp][ui]";
+    const otherApp = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <NOTICE>: c [com.example.other][ui]";
+    pipe.push(`${apple}\n`);
+    pipe.push(`${myApp}\n`);
+    pipe.push(`${otherApp}\n`);
+    expect(lines).toEqual([myApp]);
+  });
+
+  it("honors an optional minimum level", () => {
+    const { pipe, lines } = createPipe({ executableName: "Laboratory", minLevel: "ERROR" });
+    const info = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <INFO>: quiet [s][c]";
+    const error = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <ERROR>: loud [s][c]";
+    pipe.push(`${info}\n`);
+    pipe.push(`${error}\n`);
+    expect(lines).toEqual([error]);
+  });
+
+  it("passes through tunnel notices before the first parsed entry", () => {
+    const { pipe, lines } = createPipe();
+    pipe.push("Connected to tunnel\n");
+    expect(lines).toEqual(["Connected to tunnel"]);
+  });
+
+  it("drops empty lines", () => {
+    const { pipe, lines } = createPipe();
+    pipe.push("\n");
+    expect(lines).toEqual([]);
+  });
+
+  it("drops continuation lines after a dropped entry", () => {
+    const { pipe, lines } = createPipe();
+    const dropped =
+      "2026-04-16 12:53:59.832625 Laboratory{CoreFoundation}[1] <DEBUG>: first [com.apple.CFBundle][resources]";
+    pipe.push(`${dropped}\n`);
+    pipe.push("    Localizations : [en]\n");
+    pipe.push("    Dev language  : en\n");
+    expect(lines).toEqual([]);
+  });
+
+  it("keeps continuation lines after a kept entry", () => {
+    const { pipe, lines } = createPipe();
+    const kept = "2026-04-16 12:53:59.832625 Laboratory{Laboratory.debug.dylib}[1] <NOTICE>: multi-line [sub][cat]";
+    pipe.push(`${kept}\n`);
+    pipe.push("    second line\n");
+    pipe.push("    third line\n");
+    expect(lines).toEqual([kept, "    second line", "    third line"]);
+  });
+
+  it("passes through unparseable lines before the first parsed entry (tunnel notices)", () => {
+    const { pipe, lines } = createPipe();
+    pipe.push("Connected to tunnel\n");
+    pipe.push("Enabling developer disk image\n");
+    const dropped = "2026-04-16 12:53:59.832625 Laboratory{CoreFoundation}[1] <DEBUG>: noise [com.apple.X][Y]";
+    pipe.push(`${dropped}\n`);
+    pipe.push("    continuation of noise\n");
+    expect(lines).toEqual(["Connected to tunnel", "Enabling developer disk image"]);
+  });
+
+  it("buffers partial fragments across chunks", () => {
+    const { pipe, lines } = createPipe();
+    const line = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <NOTICE>: hi [s][c]";
+    pipe.push(line.slice(0, 10));
+    expect(lines).toEqual([]);
+    pipe.push(`${line.slice(10)}\n`);
+    expect(lines).toEqual([line]);
+  });
+
+  it("flush() emits a trailing fragment without newline", () => {
+    const { pipe, lines } = createPipe();
+    const line = "2026-04-16 12:53:59.832625 Laboratory{Laboratory}[1] <NOTICE>: hi [s][c]";
+    pipe.push(line);
+    expect(lines).toEqual([]);
+    pipe.flush();
+    expect(lines).toEqual([line]);
+  });
+});
+
+describe("PassthroughLogPipe", () => {
+  it("forwards chunks as-is", () => {
+    const lines: string[] = [];
+    const processor = new PassthroughLogPipe((text) => lines.push(text));
+    processor.push("hello");
+    processor.push("world\nfoo");
+    expect(lines).toEqual(["hello", "world\nfoo"]);
+  });
+
+  it("flush() does nothing", () => {
+    const lines: string[] = [];
+    const processor = new PassthroughLogPipe((text) => lines.push(text));
+    processor.flush();
+    expect(lines).toEqual([]);
+  });
+});
+
+describe("Pymobiledevice3JsonLogPipe", () => {
+  function jsonLine(overrides: Record<string, unknown> = {}): string {
+    return JSON.stringify({
+      pid: 67135,
+      timestamp: "2026-04-16T12:53:59.832625",
+      level: "NOTICE",
+      image_name: "/usr/lib/Laboratory.debug.dylib",
+      image_offset: 0,
+      filename: "/private/var/containers/Bundle/Application/ABC/Laboratory.app/Laboratory",
+      message: "ContentView initialized",
+      label: { subsystem: "Laboratory Test", category: "App" },
+      ...overrides,
+    });
+  }
+
+  function createPipe(
+    options: {
+      executableName: string;
+      debugDylibOnly?: boolean;
+      subsystemDenyList?: string[];
+      subsystemAllowList?: string[];
+      minLevel?: string;
+    } = { executableName: "Laboratory" },
+  ) {
+    const lines: string[] = [];
+    const pipe = new Pymobiledevice3JsonLogPipe((line) => lines.push(line), options);
+    return { pipe, lines };
+  }
+
+  it("keeps app logs and formats them for display", () => {
+    const { pipe, lines } = createPipe();
+    pipe.push(`${jsonLine()}\n`);
+    expect(lines).toEqual([
+      "2026-04-16T12:53:59.832625 Laboratory{Laboratory.debug.dylib}[67135] <NOTICE>: ContentView initialized [Laboratory Test][App]",
+    ]);
+  });
+
+  it("drops framework noise by image_name basename", () => {
+    const { pipe, lines } = createPipe();
+    pipe.push(`${jsonLine({ image_name: "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation" })}\n`);
+    expect(lines).toEqual([]);
+  });
+
+  it("passes through non-JSON lines (tunnel notices)", () => {
+    const { pipe, lines } = createPipe();
+    pipe.push("Connected to remote tunnel\n");
+    expect(lines).toEqual(["Connected to remote tunnel"]);
+  });
+
+  it("formats entries without a label", () => {
+    const { pipe, lines } = createPipe();
+    pipe.push(`${jsonLine({ label: null })}\n`);
+    expect(lines).toEqual([
+      "2026-04-16T12:53:59.832625 Laboratory{Laboratory.debug.dylib}[67135] <NOTICE>: ContentView initialized",
+    ]);
+  });
+
+  it("subsystem deny-list drops matching subsystems", () => {
+    const { pipe, lines } = createPipe({
+      executableName: "Laboratory",
+      subsystemDenyList: ["com.apple.*"],
+    });
+    pipe.push(`${jsonLine({ label: { subsystem: "com.apple.CFBundle", category: "resources" } })}\n`);
+    pipe.push(`${jsonLine()}\n`);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain("ContentView initialized");
+  });
+
+  it("subsystem allow-list keeps only matching subsystems", () => {
+    const { pipe, lines } = createPipe({
+      executableName: "Laboratory",
+      subsystemAllowList: ["Laboratory Test"],
+    });
+    pipe.push(`${jsonLine({ label: { subsystem: "Other", category: "Cat" } })}\n`);
+    pipe.push(`${jsonLine()}\n`);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain("ContentView initialized");
+  });
+
+  it("honors minimum level", () => {
+    const { pipe, lines } = createPipe({ executableName: "Laboratory", minLevel: "ERROR" });
+    pipe.push(`${jsonLine({ level: "INFO" })}\n`);
+    pipe.push(`${jsonLine({ level: "ERROR" })}\n`);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain("<ERROR>");
+  });
+
+  it("buffers partial chunks", () => {
+    const { pipe, lines } = createPipe();
+    const full = `${jsonLine()}\n`;
+    pipe.push(full.slice(0, 20));
+    expect(lines).toEqual([]);
+    pipe.push(full.slice(20));
+    expect(lines.length).toBe(1);
+  });
+
+  it("flush() emits trailing fragment", () => {
+    const { pipe, lines } = createPipe();
+    pipe.push(jsonLine());
+    expect(lines).toEqual([]);
+    pipe.flush();
+    expect(lines.length).toBe(1);
+  });
+});

--- a/src/debugger/log-pipe.ts
+++ b/src/debugger/log-pipe.ts
@@ -1,0 +1,347 @@
+/**
+ * Parse pymobiledevice3 `syslog live --label` output into structured entries and
+ * apply local filters on those structured fields.
+ *
+ * Why structured?
+ *   The CLI's "--match"/"--regex" flags filter on the rendered line, which is
+ *   brittle in two ways (see PR #231):
+ *     1. A "--match <bundleId>" still admits framework-originated log lines
+ *        whose subsystem contains the bundle id (e.g. image_name=CoreFoundation
+ *        but subsystem=com.example.app → the app's UserDefaults chatter).
+ *     2. Apps that use a custom `Logger(subsystem: "My Name")` won't have the
+ *        bundle id anywhere on the line, so "--match <bundleId>" drops them.
+ *
+ *   Both disappear when we filter by `image_name`, which identifies the Mach-O
+ *   image that emitted the log. We can't do that at the CLI (no "--image-name"
+ *   flag), but we can do it locally on the parsed entry.
+ *
+ * Why text-parse when a JSON flag could ship upstream?
+ *   The CLI format today is hard-coded:
+ *     `{timestamp} {process}{{image}{+0xoffset?}}}[{pid}] <{LEVEL}>: {msg}[subsystem][category]?`
+ *     (pymobiledevice3/cli/syslog.py::format_line)
+ *   If/when upstream adds "--format json", the Python `SyslogEntry` dataclass
+ *   (pymobiledevice3/services/os_trace.py) already maps 1:1 onto `SyslogEntry`
+ *   below. Only the parser swaps — the filter and renderer keep working.
+ */
+
+const LEVEL_RANK: Record<string, number> = {
+  DEBUG: 0,
+  INFO: 1,
+  NOTICE: 2,
+  USER_ACTION: 3,
+  ERROR: 4,
+  FAULT: 5,
+};
+
+// Defensive ANSI stripping — shouldn't appear (upstream checks isatty, we pass --no-color).
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — matching ANSI escape sequences
+const ANSI_ESCAPE_RE = /\x1b\[[0-9;]*m/g;
+
+// Example: "2026-04-16 12:52:32.707333 Laboratory{Laboratory.debug.dylib+0x1a2b}[67135] <NOTICE>: hello"
+//           |---- timestamp ---------| |process| |--- image + offset? ---| |pid|  |level|  |msg|
+const LINE_RE =
+  /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+) (.+?)\{([^}]+?)(?:\+0x([0-9a-fA-F]+))?\}\[(\d+)\] <([^>]*)>: (.*)$/;
+
+// Example: "... some message [com.example.app][Network]"
+//                             |-- subsystem --||category|
+const LABEL_SUFFIX_RE = / \[([^\]]*)\]\[([^\]]*)\]$/;
+
+export type SyslogLevel = "NOTICE" | "INFO" | "DEBUG" | "USER_ACTION" | "ERROR" | "FAULT" | string;
+
+export type SyslogLabel = {
+  subsystem: string;
+  category: string;
+};
+
+/** Mirrors upstream `pymobiledevice3.services.os_trace.SyslogEntry`. */
+export type SyslogEntry = {
+  timestamp: string;
+  processName: string;
+  // "Image" is macOS/Mach-O terminology for any executable binary loaded into a
+  // process: the main app binary, dynamic libraries (.dylib), or frameworks.
+  // Apple's unified logging stores the image_name of the Mach-O binary that
+  // called the log function. For example, "CoreFoundation" means the log was
+  // emitted by the CoreFoundation framework, while "Laboratory.debug.dylib"
+  // means it came from the app's own code.
+  imageName: string;
+  imageOffset?: number;
+  pid: number;
+  level: SyslogLevel;
+  message: string;
+  label?: SyslogLabel;
+};
+
+export type SyslogFilter = (entry: SyslogEntry) => boolean;
+
+export type LineOutput = (text: string) => void;
+
+/** Processes raw stdout chunks and writes to the output. */
+export interface LogPipe {
+  push(chunk: string): void;
+  flush(): void;
+}
+
+export type Pymobiledevice3LogPipeOptions = {
+  executableName: string;
+  debugDylibOnly?: boolean;
+  subsystemDenyList?: readonly string[];
+  subsystemAllowList?: readonly string[];
+  minLevel?: SyslogLevel;
+};
+
+type Pymobiledevice3JsonEntry = {
+  pid: number;
+  timestamp: string;
+  level: string;
+  image_name: string;
+  image_offset: number;
+  filename: string;
+  message: string;
+  label: { subsystem: string; category: string } | null;
+};
+
+// Convert a simple glob pattern (e.g. "com.apple.*") into a RegExp.
+// Only "*" is a wildcard (matches zero or more characters).
+function patternToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped.replace(/\*/g, ".*")}$`);
+}
+
+// Compile an array of glob patterns into a single predicate, or undefined if empty.
+function compilePatterns(patterns: readonly string[]): ((value: string) => boolean) | undefined {
+  if (patterns.length === 0) return undefined;
+  const regexes = patterns.map(patternToRegex);
+  return (value) => regexes.some((re) => re.test(value));
+}
+
+export function parseSyslogLine(rawLine: string): SyslogEntry | null {
+  const line = rawLine.replace(ANSI_ESCAPE_RE, "").replace(/\r$/, "");
+  const match = LINE_RE.exec(line);
+  if (!match) {
+    return null;
+  }
+  // imageName: Mach-O binary that emitted the log (e.g. "Laboratory.debug.dylib", "CoreFoundation")
+  // imageOffsetHex: instruction offset within that image (only present with --image-offset)
+  const [, timestamp, processName, imageName, imageOffsetHex, pidStr, level, rest] = match;
+
+  let message = rest;
+  let label: SyslogLabel | undefined;
+  const labelMatch = LABEL_SUFFIX_RE.exec(rest);
+  if (labelMatch) {
+    message = rest.slice(0, labelMatch.index);
+    label = { subsystem: labelMatch[1], category: labelMatch[2] };
+  }
+
+  const entry: SyslogEntry = {
+    timestamp,
+    processName,
+    imageName,
+    pid: Number.parseInt(pidStr, 10),
+    level,
+    message,
+  };
+  if (imageOffsetHex !== undefined) {
+    entry.imageOffset = Number.parseInt(imageOffsetHex, 16);
+  }
+  if (label) {
+    entry.label = label;
+  }
+  return entry;
+}
+
+export function buildAppImageFilter(executableName: string, debugDylibOnly = false): SyslogFilter {
+  const debugDylib = `${executableName}.debug.dylib`;
+  if (debugDylibOnly) {
+    return (entry) => entry.imageName === debugDylib;
+  }
+  return (entry) => entry.imageName === executableName || entry.imageName === debugDylib;
+}
+
+function basename(path: string): string {
+  const idx = path.lastIndexOf("/");
+  return idx === -1 ? path : path.slice(idx + 1);
+}
+
+/** Forwards raw chunks as-is. */
+export class PassthroughLogPipe implements LogPipe {
+  constructor(private readonly output: LineOutput) {}
+
+  push(chunk: string): void {
+    this.output(chunk);
+  }
+  flush(): void {}
+}
+
+/** Text-mode pipe for `syslog live --label`. Parses lines via regex and filters. */
+export class Pymobiledevice3LogPipe implements LogPipe {
+  private readonly output: LineOutput;
+  private readonly appFilter: SyslogFilter;
+  private readonly denyMatch: ((subsystem: string) => boolean) | undefined;
+  private readonly allowMatch: ((subsystem: string) => boolean) | undefined;
+  private readonly minRank: number | undefined;
+  private pending = "";
+  // Tracks whether the last parsed entry was kept or dropped.
+  // Unparseable lines (continuations of multi-line messages) inherit this decision.
+  // Starts as "keep" so lines before the first parsed entry (tunnel notices) pass through.
+  private keepPrevious = true;
+
+  constructor(output: LineOutput, options: Pymobiledevice3LogPipeOptions) {
+    this.output = output;
+    this.appFilter = buildAppImageFilter(options.executableName, options.debugDylibOnly ?? false);
+    this.denyMatch = compilePatterns(options.subsystemDenyList ?? []);
+    this.allowMatch = compilePatterns(options.subsystemAllowList ?? []);
+    this.minRank = options.minLevel !== undefined ? LEVEL_RANK[options.minLevel] : undefined;
+  }
+
+  push(chunk: string): void {
+    this.pending += chunk;
+    let idx = this.pending.indexOf("\n");
+    while (idx !== -1) {
+      const line = this.pending.slice(0, idx);
+      this.pending = this.pending.slice(idx + 1);
+      const result = this.processLine(line);
+      if (result !== null) {
+        this.output(result);
+      }
+      idx = this.pending.indexOf("\n");
+    }
+  }
+
+  flush(): void {
+    if (this.pending.length > 0) {
+      const line = this.pending;
+      this.pending = "";
+      const result = this.processLine(line);
+      if (result !== null) {
+        this.output(result);
+      }
+    }
+  }
+
+  private processLine(line: string): string | null {
+    if (line.length === 0) {
+      return null;
+    }
+    const entry = parseSyslogLine(line);
+    if (!entry) {
+      return this.keepPrevious ? line : null;
+    }
+    if (!this.appFilter(entry)) {
+      this.keepPrevious = false;
+      return null;
+    }
+    const subsystem = entry.label?.subsystem;
+    if (this.denyMatch && subsystem && this.denyMatch(subsystem)) {
+      this.keepPrevious = false;
+      return null;
+    }
+    if (this.allowMatch && (!subsystem || !this.allowMatch(subsystem))) {
+      this.keepPrevious = false;
+      return null;
+    }
+    if (this.minRank !== undefined) {
+      const rank = LEVEL_RANK[entry.level];
+      if (rank !== undefined && rank < this.minRank) {
+        this.keepPrevious = false;
+        return null;
+      }
+    }
+    this.keepPrevious = true;
+    return line;
+  }
+}
+
+/**
+ * JSON-mode pipe for `syslog live --format json` (see doronz88/pymobiledevice3#1659).
+ * Not wired up yet.
+ */
+export class Pymobiledevice3JsonLogPipe implements LogPipe {
+  private readonly output: LineOutput;
+  private readonly appFilter: SyslogFilter;
+  private readonly denyMatch: ((subsystem: string) => boolean) | undefined;
+  private readonly allowMatch: ((subsystem: string) => boolean) | undefined;
+  private readonly minRank: number | undefined;
+  private pending = "";
+
+  constructor(output: LineOutput, options: Pymobiledevice3LogPipeOptions) {
+    this.output = output;
+    this.appFilter = buildAppImageFilter(options.executableName, options.debugDylibOnly ?? false);
+    this.denyMatch = compilePatterns(options.subsystemDenyList ?? []);
+    this.allowMatch = compilePatterns(options.subsystemAllowList ?? []);
+    this.minRank = options.minLevel !== undefined ? LEVEL_RANK[options.minLevel] : undefined;
+  }
+
+  push(chunk: string): void {
+    this.pending += chunk;
+    let idx = this.pending.indexOf("\n");
+    while (idx !== -1) {
+      const line = this.pending.slice(0, idx);
+      this.pending = this.pending.slice(idx + 1);
+      this.processLine(line);
+      idx = this.pending.indexOf("\n");
+    }
+  }
+
+  flush(): void {
+    if (this.pending.length > 0) {
+      const line = this.pending;
+      this.pending = "";
+      this.processLine(line);
+    }
+  }
+
+  private processLine(line: string): void {
+    if (line.length === 0) {
+      return;
+    }
+    let json: Pymobiledevice3JsonEntry;
+    try {
+      json = JSON.parse(line);
+    } catch {
+      this.output(line);
+      return;
+    }
+    const entry = this.toSyslogEntry(json);
+    if (!this.appFilter(entry)) {
+      return;
+    }
+    const subsystem = entry.label?.subsystem;
+    if (this.denyMatch && subsystem && this.denyMatch(subsystem)) {
+      return;
+    }
+    if (this.allowMatch && (!subsystem || !this.allowMatch(subsystem))) {
+      return;
+    }
+    if (this.minRank !== undefined) {
+      const rank = LEVEL_RANK[entry.level];
+      if (rank !== undefined && rank < this.minRank) {
+        return;
+      }
+    }
+    this.output(this.formatEntry(entry));
+  }
+
+  private toSyslogEntry(json: Pymobiledevice3JsonEntry): SyslogEntry {
+    const imageName = basename(json.image_name);
+    const entry: SyslogEntry = {
+      timestamp: json.timestamp,
+      processName: basename(json.filename),
+      imageName,
+      pid: json.pid,
+      level: json.level,
+      message: json.message,
+    };
+    if (json.image_offset !== 0) {
+      entry.imageOffset = json.image_offset;
+    }
+    if (json.label !== null) {
+      entry.label = json.label;
+    }
+    return entry;
+  }
+
+  private formatEntry(entry: SyslogEntry): string {
+    const label = entry.label ? ` [${entry.label.subsystem}][${entry.label.category}]` : "";
+    return `${entry.timestamp} ${entry.processName}{${entry.imageName}}[${entry.pid}] <${entry.level}>: ${entry.message}${label}`;
+  }
+}

--- a/src/debugger/log-stream.ts
+++ b/src/debugger/log-stream.ts
@@ -262,7 +262,6 @@ export class LogStreamManager {
     const result = buildPymobiledevice3Args({
       rawExtraArgs,
       processName: launchContext.executableName,
-      bundleIdentifier: launchContext.bundleIdentifier,
     });
     if (result.kind === "missingProcessName") {
       channel.appendLine(

--- a/src/debugger/log-stream.ts
+++ b/src/debugger/log-stream.ts
@@ -5,11 +5,13 @@ import { getWorkspaceConfig } from "../common/config";
 import { exec } from "../common/exec";
 import { commonLogger } from "../common/logger";
 import { buildPymobiledevice3Args, formatCommandLine } from "./device-log-backend";
+import { type LogPipe, PassthroughLogPipe, Pymobiledevice3LogPipe } from "./log-pipe";
 
 type LogStreamSpec = {
   command: string;
   args: string[];
   stderrPrefix: string;
+  lineProcessor: LogPipe;
 };
 
 /**
@@ -177,7 +179,7 @@ export class LogStreamManager {
     commonLogger.debug("Starting log stream", { command: spec.command, args: spec.args });
     const subprocess = spawn(spec.command, spec.args, { stdio: ["ignore", "pipe", "pipe"] });
     this.logStreamProcess = subprocess;
-    this.attachSubprocessHandlers(subprocess, channel, spec.stderrPrefix);
+    this.attachSubprocessHandlers(subprocess, channel, spec.stderrPrefix, spec.lineProcessor);
   }
 
   private async resolveLogStreamSpec(
@@ -187,15 +189,15 @@ export class LogStreamManager {
   ): Promise<LogStreamSpec | null> {
     switch (launchContext.type) {
       case "simulator":
-        return this.buildSimulatorSpec(launchContext.simulatorUdid, predicate);
+        return this.buildSimulatorSpec(launchContext.simulatorUdid, predicate, channel);
       case "macos":
-        return this.buildMacOSSpec(predicate);
+        return this.buildMacOSSpec(predicate, channel);
       case "device":
         return this.resolveDeviceSpec(launchContext, channel);
     }
   }
 
-  private buildSimulatorSpec(simulatorUdid: string, predicate: string): LogStreamSpec {
+  private buildSimulatorSpec(simulatorUdid: string, predicate: string, channel: vscode.OutputChannel): LogStreamSpec {
     return {
       command: "xcrun",
       args: [
@@ -212,14 +214,16 @@ export class LogStreamManager {
         "compact",
       ],
       stderrPrefix: "[log stream stderr]",
+      lineProcessor: new PassthroughLogPipe((text) => channel.append(text)),
     };
   }
 
-  private buildMacOSSpec(predicate: string): LogStreamSpec {
+  private buildMacOSSpec(predicate: string, channel: vscode.OutputChannel): LogStreamSpec {
     return {
       command: "log",
       args: ["stream", "--predicate", predicate, "--level", "debug", "--style", "compact"],
       stderrPrefix: "[log stream stderr]",
+      lineProcessor: new PassthroughLogPipe((text) => channel.append(text)),
     };
   }
 
@@ -275,10 +279,50 @@ export class LogStreamManager {
     channel.appendLine(`[SweetPad] Extra args: ${JSON.stringify(rawExtraArgs)}`);
     channel.appendLine(`[SweetPad] Command: ${formatCommandLine(binaryPath, result.args)}`);
     channel.appendLine("[SweetPad] On iOS 17+, requires a running tunnel: sudo pymobiledevice3 remote tunneld");
+
+    // We drop "--match" / "--regex" at the CLI and instead parse each line into
+    // a structured entry locally, then filter by image name. This fixes the two
+    // gaps with server-side matching (see PR #231): framework-emitted lines
+    // whose subsystem happens to contain the bundle id, and app-emitted lines
+    // whose custom `Logger(subsystem:)` doesn't.
+    //
+    // When the override replaces "--process-name", prefer that for the filter
+    // — the user knows better than us what image names the app produces.
+    const filterExecutable = extractProcessNameOverride(rawExtraArgs) ?? launchContext.executableName;
+    const debugDylibOnly = getWorkspaceConfig("build.pymobiledevice3DebugDylibOnly") ?? true;
+    const subsystemDenyList = getWorkspaceConfig("build.pymobiledevice3SubsystemDenyList") ?? ["com.apple.*"];
+    const subsystemAllowList = getWorkspaceConfig("build.pymobiledevice3SubsystemAllowList") ?? [];
+
+    const output = (text: string) => channel.appendLine(text);
+    let lineProcessor: LogPipe;
+    if (filterExecutable) {
+      lineProcessor = new Pymobiledevice3LogPipe(output, {
+        executableName: filterExecutable,
+        debugDylibOnly,
+        subsystemDenyList,
+        subsystemAllowList,
+      });
+      if (debugDylibOnly) {
+        channel.appendLine(`[SweetPad] Image filter: only '${filterExecutable}.debug.dylib'.`);
+      } else {
+        channel.appendLine(`[SweetPad] Image filter: '${filterExecutable}' + '${filterExecutable}.debug.dylib'.`);
+      }
+      if (subsystemDenyList.length > 0) {
+        channel.appendLine(`[SweetPad] Subsystem deny-list: ${JSON.stringify(subsystemDenyList)}`);
+      }
+      if (subsystemAllowList.length > 0) {
+        channel.appendLine(`[SweetPad] Subsystem allow-list: ${JSON.stringify(subsystemAllowList)}`);
+      }
+    } else {
+      lineProcessor = new PassthroughLogPipe(output);
+      channel.appendLine("[SweetPad] Local filter disabled (no executable name available).");
+    }
+
     return {
       command: binaryPath,
       args: result.args,
       stderrPrefix: "[pymobiledevice3]",
+      lineProcessor,
     };
   }
 
@@ -286,10 +330,10 @@ export class LogStreamManager {
     subprocess: ChildProcess,
     channel: vscode.OutputChannel,
     stderrPrefix: string,
+    lineProcessor: LogPipe,
   ): void {
-    subprocess.stdout?.on("data", (data: Buffer) => {
-      channel.append(data.toString());
-    });
+    subprocess.stdout?.on("data", (data: Buffer) => lineProcessor.push(data.toString()));
+    subprocess.stdout?.on("end", () => lineProcessor.flush());
     subprocess.stderr?.on("data", (data: Buffer) => {
       channel.append(`${stderrPrefix} ${data.toString()}`);
     });
@@ -334,6 +378,25 @@ export class LogStreamManager {
       this.outputChannel = undefined;
     }
   }
+}
+
+/**
+ * When the user puts "--process-name NAME" / "-p NAME" into the extra args, we
+ * honor it for the local image-name filter too. A null value (used to suppress
+ * the default) yields undefined so we fall back to `launchContext.executableName`.
+ */
+function extractProcessNameOverride(rawExtraArgs: (string | null)[]): string | undefined {
+  for (let i = 0; i < rawExtraArgs.length; i++) {
+    const arg = rawExtraArgs[i];
+    if (arg === "--process-name" || arg === "-p") {
+      const value = rawExtraArgs[i + 1];
+      if (typeof value === "string") {
+        return value;
+      }
+      return undefined;
+    }
+  }
+  return undefined;
 }
 
 async function isPymobiledevice3Available(binaryPath: string): Promise<boolean> {


### PR DESCRIPTION
Replace server-side --match/--regex filtering with local structured parsing.
The CLI's line-matching flags cause false positives (framework noise whose
subsystem contains the bundle id) and false negatives (app logs from a custom
Logger subsystem). Parsing each line into a structured entry and filtering by
Mach-O image name fixes both.