### PR TITLE
Derive pymobiledevice3 debug dylib filtering from Xcode build settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1024,11 +1024,6 @@
           "default": [],
           "description": "Extra CLI arguments appended to 'pymobiledevice3 syslog live'."
         },
-        "sweetpad.build.pymobiledevice3DebugDylibOnly": {
-          "type": "boolean",
-          "default": true,
-          "description": "Only keep syslog entries from the .debug.dylib image, dropping noise from the main binary. Disable if not using ENABLE_DEBUG_DYLIB."
-        },
         "sweetpad.build.pymobiledevice3SubsystemDenyList": {
           "type": "array",
           "items": {

--- a/src/build/manager.ts
+++ b/src/build/manager.ts
@@ -757,7 +757,10 @@ export class BuildManager {
         // a [sweetpad] warning when streaming is disabled, the binary is missing, or the
         // executable name is unknown; pymd3's own stderr (e.g. tunneld not running)
         // surfaces via [pymobiledevice3]. The launch proceeds either way.
-        const logSidecar = new Pymd3Sidecar(group, { executableName: buildSettings.executableName });
+        const logSidecar = new Pymd3Sidecar(group, {
+          executableName: buildSettings.executableName,
+          enableDebugDylib: buildSettings.enableDebugDylib,
+        });
         await logSidecar.spawn();
 
         const main = new MainExecutable(group, {

--- a/src/common/cli/scripts.ts
+++ b/src/common/cli/scripts.ts
@@ -189,6 +189,12 @@ export class XcodeBuildSettings {
     return this.settings.PRODUCT_BUNDLE_IDENTIFIER;
   }
 
+  get enableDebugDylib(): boolean {
+    // Xcode 15+ Debug Dylib Support: when YES, app code is loaded from
+    // <EXECUTABLE>.debug.dylib instead of the main binary.
+    return this.settings.ENABLE_DEBUG_DYLIB === "YES";
+  }
+
   get supportedPlatforms(): DestinationPlatform[] | undefined {
     // ex: ["iphonesimulator", "iphoneos"]
     const platformsRaw = this.settings.SUPPORTED_PLATFORMS; // ex: "iphonesimulator iphoneos"

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -27,7 +27,6 @@ type Config = {
   "build.deviceTunnelAutoStart": boolean;
   "build.pymobiledevice3Path": string;
   "build.pymobiledevice3ExtraArgs": (string | null)[];
-  "build.pymobiledevice3DebugDylibOnly": boolean;
   "build.pymobiledevice3SubsystemDenyList": string[];
   "build.pymobiledevice3SubsystemAllowList": string[];
   "system.taskExecutor": "v2" | "v3";

--- a/src/run/sidecars.ts
+++ b/src/run/sidecars.ts
@@ -225,6 +225,11 @@ export class SimulatorLogSidecar extends LogSidecar {
 
 export type Pymd3SidecarOptions = {
   executableName: string | undefined;
+  // ENABLE_DEBUG_DYLIB build setting. When true, app code lives in
+  // <EXECUTABLE>.debug.dylib and the main binary is a thin stub; the filter
+  // restricts to that image. When false, no .debug.dylib exists and the filter
+  // accepts the main image instead.
+  enableDebugDylib: boolean;
 };
 
 export class Pymd3Sidecar extends LogSidecar {
@@ -243,7 +248,7 @@ export class Pymd3Sidecar extends LogSidecar {
     this.filter = filterExecutable
       ? this.buildPymd3Filter({
           executableName: filterExecutable,
-          debugDylibOnly: getWorkspaceConfig("build.pymobiledevice3DebugDylibOnly") ?? true,
+          debugDylibOnly: options.enableDebugDylib,
           subsystemDenyList: getWorkspaceConfig("build.pymobiledevice3SubsystemDenyList") ?? ["com.apple.*"],
           subsystemAllowList: getWorkspaceConfig("build.pymobiledevice3SubsystemAllowList") ?? [],
         })


### PR DESCRIPTION
This PR updates the pymobiledevice3 log filtering behavior to derive debugDylibOnly from Xcode build settings.

SweetPad already reads build settings through xcodebuild -showBuildSettings before launching the app. This change reuses ENABLE_DEBUG_DYLIB from that result and stores it in the launch context, so the log filter can follow the actual project configuration automatically.

With this change:

- when ENABLE_DEBUG_DYLIB=YES, keeps filtering for the .debug.dylib image
- when ENABLE_DEBUG_DYLIB=NO, back to the main executable image as well

As a result, sweetpad.build.pymobiledevice3DebugDylibOnly is no longer needed and has been removed.