### PR TITLE
Refine macOS and simulator log stream defaults and enable unbuffered stdout on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -996,9 +996,9 @@
         "sweetpad.build.logStreamPredicate": {
           "type": "string",
           "default": null,
-          "description": "Custom predicate for log stream filtering. Use ${bundleId} for the bundle identifier and ${processName} for the process name. Default: captures os_log/Logger by subsystem.",
+          "description": "Custom predicate for log stream filtering. Use ${bundleId} and ${processName} as placeholders.",
           "examples": [
-            "subsystem BEGINSWITH \"${bundleId}\" OR (process == \"${processName}\" AND sender == \"Foundation\")",
+            "process == \"${processName}\" AND (sender == \"${processName}\" OR sender == \"${processName}.debug.dylib\")",
             "subsystem BEGINSWITH \"${bundleId}\"",
             "process == \"${processName}\""
           ]

--- a/src/build/manager.ts
+++ b/src/build/manager.ts
@@ -530,12 +530,18 @@ export class BuildManager {
 
     context.updateProgressStatus(`Running "${options.scheme}" on Mac`);
     await terminal.runGroup(async (group) => {
-      await new MacOSLogSidecar(group, buildSettings.bundleIdentifier).spawn();
+      const logSidecar = new MacOSLogSidecar(group, {
+        bundleId: buildSettings.bundleIdentifier,
+        executableName: buildSettings.executableName,
+      });
+      await logSidecar.spawn();
 
       const main = new MainExecutable(group, {
         command: executablePath,
         args: options.launchArgs,
-        env: options.launchEnv,
+        // NSUnbufferedIO is a no-op when stdout is a tty (the v3/node-pty path), but acts as a
+        // safety net for the v2 fallback where stdout is a plain pipe and Foundation block-buffers print().
+        env: { NSUnbufferedIO: "YES", ...options.launchEnv },
         pty: true,
       });
       await main.wait();
@@ -629,7 +635,12 @@ export class BuildManager {
     // Run app
     context.updateProgressStatus(`Running "${options.scheme}" on "${simulator.name}"`);
     await terminal.runGroup(async (group) => {
-      await new SimulatorLogSidecar(group, simulator.udid, bundlerId).spawn();
+      const logSidecar = new SimulatorLogSidecar(group, {
+        simulatorUdid: simulator.udid,
+        bundleId: bundlerId,
+        executableName: buildSettings.executableName,
+      });
+      await logSidecar.spawn();
 
       const main = new MainExecutable(group, {
         command: "xcrun",
@@ -746,7 +757,8 @@ export class BuildManager {
         // a [sweetpad] warning when streaming is disabled, the binary is missing, or the
         // executable name is unknown; pymd3's own stderr (e.g. tunneld not running)
         // surfaces via [pymobiledevice3]. The launch proceeds either way.
-        await new Pymd3Sidecar(group, buildSettings.executableName).spawn();
+        const logSidecar = new Pymd3Sidecar(group, { executableName: buildSettings.executableName });
+        await logSidecar.spawn();
 
         const main = new MainExecutable(group, {
           command: "xcrun",

--- a/src/run/sidecars.ts
+++ b/src/run/sidecars.ts
@@ -97,12 +97,26 @@ abstract class LogSidecar {
     return getWorkspaceConfig("build.logStreamEnabled") ?? true;
   }
 
-  buildPredicate(bundleId: string): string {
-    const processName = bundleId.split(".").pop() ?? bundleId;
+  /**
+   * Builds the `log stream` predicate that selects which os_log/Logger entries reach the terminal.
+   *
+   * `bundleId` is the app's bundle identifier (e.g. "com.example.MyApp") and `executableName`
+   * is CFBundleExecutable — the process name as it appears in os_log (e.g. "MyApp").
+   *
+   * The default matches by image (process + sender) rather than by subsystem, so apps that don't
+   * set `Logger(subsystem:)` still show up while Apple framework chatter is filtered out. Both
+   * the bare executable and its `.debug.dylib` sidecar are accepted to cover Xcode 15+ Debug
+   * Dylib Support, which loads app code from a separate dylib in Debug builds.
+   *
+   * Users can override the whole predicate via `build.logStreamPredicate`, with `${bundleId}` and
+   * `${processName}` placeholders.
+   */
+  buildPredicate(bundleId: string, executableName: string): string {
     const custom = getWorkspaceConfig("build.logStreamPredicate");
-    return custom
-      ? custom.replace(/\$\{bundleId\}/g, bundleId).replace(/\$\{processName\}/g, processName)
-      : `subsystem BEGINSWITH "${bundleId}"`;
+    if (custom) {
+      return custom.replace(/\$\{bundleId\}/g, bundleId).replace(/\$\{processName\}/g, executableName);
+    }
+    return `process == "${executableName}" AND (sender == "${executableName}" OR sender == "${executableName}.debug.dylib")`;
   }
 
   async spawn(): Promise<void> {
@@ -136,10 +150,15 @@ abstract class LogSidecar {
   }
 }
 
+export type MacOSLogSidecarOptions = {
+  bundleId: string;
+  executableName: string;
+};
+
 export class MacOSLogSidecar extends LogSidecar {
   constructor(
     group: ProcessGroup,
-    readonly bundleId: string,
+    readonly options: MacOSLogSidecarOptions,
   ) {
     super(group);
   }
@@ -148,36 +167,10 @@ export class MacOSLogSidecar extends LogSidecar {
     if (!this.isLogStreamEnabled()) return null;
     return {
       command: "log",
-      args: ["stream", "--predicate", this.buildPredicate(this.bundleId), "--level", "debug", "--style", "ndjson"],
-    };
-  }
-
-  processStdoutLine(line: string): void {
-    renderNdjsonLine(line, this.terminal);
-  }
-}
-
-export class SimulatorLogSidecar extends LogSidecar {
-  constructor(
-    group: ProcessGroup,
-    readonly simulatorUdid: string,
-    readonly bundleId: string,
-  ) {
-    super(group);
-  }
-
-  async spec(): Promise<ProcessSpec | null> {
-    if (!this.isLogStreamEnabled()) return null;
-    return {
-      command: "xcrun",
       args: [
-        "simctl",
-        "spawn",
-        this.simulatorUdid,
-        "log",
         "stream",
         "--predicate",
-        this.buildPredicate(this.bundleId),
+        this.buildPredicate(this.options.bundleId, this.options.executableName),
         "--level",
         "debug",
         "--style",
@@ -191,6 +184,49 @@ export class SimulatorLogSidecar extends LogSidecar {
   }
 }
 
+export type SimulatorLogSidecarOptions = {
+  simulatorUdid: string;
+  bundleId: string;
+  executableName: string;
+};
+
+export class SimulatorLogSidecar extends LogSidecar {
+  constructor(
+    group: ProcessGroup,
+    readonly options: SimulatorLogSidecarOptions,
+  ) {
+    super(group);
+  }
+
+  async spec(): Promise<ProcessSpec | null> {
+    if (!this.isLogStreamEnabled()) return null;
+    return {
+      command: "xcrun",
+      args: [
+        "simctl",
+        "spawn",
+        this.options.simulatorUdid,
+        "log",
+        "stream",
+        "--predicate",
+        this.buildPredicate(this.options.bundleId, this.options.executableName),
+        "--level",
+        "debug",
+        "--style",
+        "ndjson",
+      ],
+    };
+  }
+
+  processStdoutLine(line: string): void {
+    renderNdjsonLine(line, this.terminal);
+  }
+}
+
+export type Pymd3SidecarOptions = {
+  executableName: string | undefined;
+};
+
 export class Pymd3Sidecar extends LogSidecar {
   readonly rawExtraArgs: (string | null)[];
   readonly filter: ((entry: SyslogEntry) => boolean) | null;
@@ -199,11 +235,11 @@ export class Pymd3Sidecar extends LogSidecar {
 
   constructor(
     group: ProcessGroup,
-    readonly executableName: string | undefined,
+    readonly options: Pymd3SidecarOptions,
   ) {
     super(group);
     this.rawExtraArgs = getWorkspaceConfig("build.pymobiledevice3ExtraArgs") ?? [];
-    const filterExecutable = this.extractProcessNameOverride(this.rawExtraArgs) ?? executableName;
+    const filterExecutable = this.extractProcessNameOverride(this.rawExtraArgs) ?? options.executableName;
     this.filter = filterExecutable
       ? this.buildPymd3Filter({
           executableName: filterExecutable,
@@ -237,7 +273,7 @@ export class Pymd3Sidecar extends LogSidecar {
 
     const args = this.buildPymobiledevice3Args({
       rawExtraArgs: this.rawExtraArgs,
-      processName: this.executableName,
+      processName: this.options.executableName,
     });
     if (args.kind === "missingProcessName") {
       writeErrorLine(


### PR DESCRIPTION
This PR updates the default log subscription behavior for app launches on macOS and simulators.

The current `log stream` predicate matches logs by `subsystem` and bundle identifier. This change switches the default predicate to an image-name-based match, similar to the approach used by `pymobiledevice3`, so it can more reliably capture logs emitted by the app itself.

`Foundation` logs are no longer matched explicitly. `NSLog` output already appears in both `log stream` and `stdout`/`stderr`, so matching it again in `log stream` is unnecessary.

This PR also adds `NSUnbufferedIO=YES` as a default launch environment variable on macOS. Without it, `print` output from macOS apps may stay buffered and only appear after the app exits. Enabling this environment variable makes those logs flush in real time.

Please let me know if anything in this PR looks off. Thanks!