### PR TITLE
Sort devices by connection status and last-connection date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ New features, improvements and bug fixes for SweetPad are documented in this fil
 
 ## [0.1.82] - 2026-04-26
 
+- Sort physical devices so the connected one appears above stale paired entries ([#234](https://github.com/sweetpad-dev/sweetpad/issues/234))
 - Move os_log streaming from the output channel to the task terminal ([#233](https://github.com/sweetpad-dev/sweetpad/pull/233))
 - New `v3` task executor (now default), backed by `node-pty` for real PTYs, ANSI/TUI output, and a shared login-shell environment; revert to the legacy executor via `sweetpad.system.taskExecutor: v2`
 - Resolve the login shell environment on activation so tasks see PATH/toolchains from `~/.zshrc`, `~/.zprofile`, mise, asdf, and direnv; tune via `sweetpad.shellEnv.shell` and `sweetpad.shellEnv.timeout`

--- a/src/destination/constants.ts
+++ b/src/destination/constants.ts
@@ -49,3 +49,5 @@ export const SIMULATOR_TYPE_PRIORITY: SimulatorType[] = [
   "AppleVision",
   "iPod",
 ];
+
+export const DEVICE_STATE_PRIORITY = ["connected", "disconnected", "unavailable"] as const;

--- a/src/destination/manager.spec.ts
+++ b/src/destination/manager.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for DestinationsManager.sortCompareFn — the device-tier ordering
+ * (status priority + lastConnectionDate) added for sweetpad-dev/sweetpad#234.
+ */
+
+import { createMockDevice } from "../__mocks__/devices";
+import type { DeviceCtlDevice } from "../common/xcode/devicectl";
+import { DevicesManager } from "../devices/manager";
+import { iOSDeviceDestination } from "../devices/types";
+import type { SimulatorsManager } from "../simulators/manager";
+import { DestinationsManager } from "./manager";
+
+function buildManager(): DestinationsManager {
+  const simulatorsManager = { on: jest.fn() } as unknown as SimulatorsManager;
+  const devicesManager = new DevicesManager();
+  return new DestinationsManager({ simulatorsManager, devicesManager });
+}
+
+function makeDevice(overrides: {
+  name: string;
+  udid: string;
+  state?: "connected" | "disconnected" | "unavailable";
+  lastConnectionDate?: string | null;
+}): iOSDeviceDestination {
+  const dc: DeviceCtlDevice = createMockDevice({
+    deviceProperties: { name: overrides.name, osVersionNumber: "17.0" },
+    hardwareProperties: {
+      deviceType: "iPhone",
+      marketingName: "iPhone 15 Pro",
+      productType: "iPhone16,1",
+      udid: overrides.udid,
+      platform: "iOS",
+    },
+    connectionProperties: {
+      tunnelState: overrides.state ?? "connected",
+      pairingState: "paired",
+      ...(overrides.lastConnectionDate === null
+        ? {}
+        : overrides.lastConnectionDate !== undefined
+          ? { lastConnectionDate: overrides.lastConnectionDate }
+          : {}),
+    },
+  });
+  return new iOSDeviceDestination({ devicectl: dc });
+}
+
+describe("DestinationsManager.sortCompareFn", () => {
+  let manager: DestinationsManager;
+
+  beforeEach(() => {
+    manager = buildManager();
+  });
+
+  describe("device status priority", () => {
+    it("orders connected before disconnected before unavailable", () => {
+      const connected = makeDevice({ name: "Z phone", udid: "udid-c", state: "connected" });
+      const disconnected = makeDevice({ name: "A phone", udid: "udid-d", state: "disconnected" });
+      const unavailable = makeDevice({ name: "M phone", udid: "udid-u", state: "unavailable" });
+
+      const sorted = [unavailable, connected, disconnected].sort((a, b) => manager.sortCompareFn(a, b));
+
+      expect(sorted.map((d) => d.state)).toEqual(["connected", "disconnected", "unavailable"]);
+    });
+
+    it("keeps name from leaking across status buckets (connected wins over earlier-named unavailable)", () => {
+      const connected = makeDevice({ name: "Z phone", udid: "udid-c", state: "connected" });
+      const unavailable = makeDevice({ name: "A phone", udid: "udid-u", state: "unavailable" });
+
+      const sorted = [unavailable, connected].sort((a, b) => manager.sortCompareFn(a, b));
+
+      expect(sorted[0].name).toBe("Z phone");
+    });
+  });
+
+  describe("lastConnectionDate ordering within a status bucket", () => {
+    it("places more-recently-connected device first", () => {
+      const newer = makeDevice({
+        name: "B phone",
+        udid: "udid-new",
+        state: "unavailable",
+        lastConnectionDate: "2026-04-25T10:00:00Z",
+      });
+      const older = makeDevice({
+        name: "A phone",
+        udid: "udid-old",
+        state: "unavailable",
+        lastConnectionDate: "2024-01-01T10:00:00Z",
+      });
+
+      const sorted = [older, newer].sort((a, b) => manager.sortCompareFn(a, b));
+
+      expect(sorted.map((d) => d.udid)).toEqual(["udid-new", "udid-old"]);
+    });
+
+    it("treats missing lastConnectionDate as oldest within the same status bucket", () => {
+      const dated = makeDevice({
+        name: "Z phone",
+        udid: "udid-dated",
+        state: "unavailable",
+        lastConnectionDate: "2024-01-01T10:00:00Z",
+      });
+      const undated = makeDevice({
+        name: "A phone",
+        udid: "udid-undated",
+        state: "unavailable",
+        lastConnectionDate: null,
+      });
+
+      const sorted = [undated, dated].sort((a, b) => manager.sortCompareFn(a, b));
+
+      expect(sorted.map((d) => d.udid)).toEqual(["udid-dated", "udid-undated"]);
+    });
+  });
+
+  describe("name fallback", () => {
+    it("falls back to alphabetical name when status and date are tied", () => {
+      const sameDate = "2026-04-25T10:00:00Z";
+      const z = makeDevice({ name: "Z phone", udid: "udid-z", state: "connected", lastConnectionDate: sameDate });
+      const a = makeDevice({ name: "A phone", udid: "udid-a", state: "connected", lastConnectionDate: sameDate });
+
+      const sorted = [z, a].sort((a, b) => manager.sortCompareFn(a, b));
+
+      expect(sorted.map((d) => d.name)).toEqual(["A phone", "Z phone"]);
+    });
+
+    it("falls back to alphabetical name when both devices have no lastConnectionDate", () => {
+      const z = makeDevice({ name: "Z phone", udid: "udid-z", state: "connected", lastConnectionDate: null });
+      const a = makeDevice({ name: "A phone", udid: "udid-a", state: "connected", lastConnectionDate: null });
+
+      const sorted = [z, a].sort((a, b) => manager.sortCompareFn(a, b));
+
+      expect(sorted.map((d) => d.name)).toEqual(["A phone", "Z phone"]);
+    });
+  });
+
+  describe("doronz88 scenario", () => {
+    it("surfaces the one connected iPhone above a wall of unavailable paired entries", () => {
+      const stale = Array.from({ length: 10 }, (_, i) =>
+        makeDevice({
+          name: `Stale iPhone ${String.fromCharCode(65 + i)}`,
+          udid: `udid-stale-${i}`,
+          state: "unavailable",
+          lastConnectionDate: `2023-0${(i % 9) + 1}-01T10:00:00Z`,
+        }),
+      );
+      const connected = makeDevice({
+        name: "iPhone 11", // alphabetically-late name to prove status wins, not name
+        udid: "udid-connected",
+        state: "connected",
+      });
+
+      const sorted = [...stale, connected].sort((a, b) => manager.sortCompareFn(a, b));
+
+      expect(sorted[0].udid).toBe("udid-connected");
+    });
+  });
+});
+
+describe("DeviceDestinationBase.lastConnectionDate", () => {
+  it("parses ISO 8601 lastConnectionDate from devicectl", () => {
+    const dc = createMockDevice({
+      connectionProperties: {
+        tunnelState: "connected",
+        pairingState: "paired",
+        lastConnectionDate: "2026-04-25T10:00:00Z",
+      },
+    });
+    const dest = new iOSDeviceDestination({ devicectl: dc });
+
+    expect(dest.lastConnectionDate?.toISOString()).toBe("2026-04-25T10:00:00.000Z");
+  });
+
+  it("returns null when devicectl omits lastConnectionDate", () => {
+    const dc = createMockDevice();
+    const dest = new iOSDeviceDestination({ devicectl: dc });
+
+    expect(dest.lastConnectionDate).toBeNull();
+  });
+
+  it("returns null for xcdevice-only devices (no devicectl source)", () => {
+    const dest = new iOSDeviceDestination({
+      xcdevice: {
+        identifier: "00008110-001234567890001E",
+        modelCode: "iPhone16,1",
+        name: "Old iPhone",
+        operatingSystemVersion: "16.4",
+        platform: "com.apple.platform.iphoneos",
+      } as any,
+    });
+
+    expect(dest.lastConnectionDate).toBeNull();
+  });
+
+  it("returns null when devicectl lastConnectionDate is unparseable", () => {
+    const dc = createMockDevice({
+      connectionProperties: {
+        tunnelState: "connected",
+        pairingState: "paired",
+        lastConnectionDate: "not-a-date",
+      },
+    });
+    const dest = new iOSDeviceDestination({ devicectl: dc });
+
+    expect(dest.lastConnectionDate).toBeNull();
+  });
+});

--- a/src/destination/manager.ts
+++ b/src/destination/manager.ts
@@ -2,11 +2,12 @@ import events from "node:events";
 import type { ExtensionContext } from "../common/commands";
 import { checkUnreachable } from "../common/types";
 import type { DevicesManager } from "../devices/manager";
-import type {
-  iOSDeviceDestination,
-  tvOSDeviceDestination,
-  visionOSDeviceDestination,
-  watchOSDeviceDestination,
+import {
+  DeviceDestinationBase,
+  type iOSDeviceDestination,
+  type tvOSDeviceDestination,
+  type visionOSDeviceDestination,
+  type watchOSDeviceDestination,
 } from "../devices/types";
 import type { SimulatorsManager } from "../simulators/manager";
 import type {
@@ -16,7 +17,12 @@ import type {
   visionOSSimulatorDestination,
   watchOSSimulatorDestination,
 } from "../simulators/types";
-import { DESTINATION_TYPE_PRIORITY, SIMULATOR_TYPE_PRIORITY, SUPPORTED_DESTINATION_PLATFORMS } from "./constants";
+import {
+  DESTINATION_TYPE_PRIORITY,
+  DEVICE_STATE_PRIORITY,
+  SIMULATOR_TYPE_PRIORITY,
+  SUPPORTED_DESTINATION_PLATFORMS,
+} from "./constants";
 import {
   ALL_DESTINATION_TYPES,
   type Destination,
@@ -144,24 +150,48 @@ export class DestinationsManager {
     return simulators.filter((simulator) => simulator.type === "visionOSSimulator");
   }
 
-  async getiOSDevices(): Promise<iOSDeviceDestination[]> {
+  async getiOSDevices(options?: { sort?: boolean }): Promise<iOSDeviceDestination[]> {
     const devices = await this.devicesManager.getDevices();
-    return devices.filter((device) => device.type === "iOSDevice");
+    const items = [...devices];
+
+    if (options?.sort) {
+      items.sort((a, b) => this.sortCompareFn(a, b));
+    }
+
+    return items.filter((device) => device.type === "iOSDevice");
   }
 
-  async getWatchOSDevices(): Promise<watchOSDeviceDestination[]> {
+  async getWatchOSDevices(options?: { sort?: boolean }): Promise<watchOSDeviceDestination[]> {
     const devices = await this.devicesManager.getDevices();
-    return devices.filter((device) => device.type === "watchOSDevice");
+    const items = [...devices];
+
+    if (options?.sort) {
+      items.sort((a, b) => this.sortCompareFn(a, b));
+    }
+
+    return items.filter((device) => device.type === "watchOSDevice");
   }
 
-  async gettvOSDevices(): Promise<tvOSDeviceDestination[]> {
+  async gettvOSDevices(options?: { sort?: boolean }): Promise<tvOSDeviceDestination[]> {
     const devices = await this.devicesManager.getDevices();
-    return devices.filter((device) => device.type === "tvOSDevice");
+    const items = [...devices];
+
+    if (options?.sort) {
+      items.sort((a, b) => this.sortCompareFn(a, b));
+    }
+
+    return items.filter((device) => device.type === "tvOSDevice");
   }
 
-  async getVisionOSDevices(): Promise<visionOSDeviceDestination[]> {
+  async getVisionOSDevices(options?: { sort?: boolean }): Promise<visionOSDeviceDestination[]> {
     const devices = await this.devicesManager.getDevices();
-    return devices.filter((device) => device.type === "visionOSDevice");
+    const items = [...devices];
+
+    if (options?.sort) {
+      items.sort((a, b) => this.sortCompareFn(a, b));
+    }
+
+    return items.filter((device) => device.type === "visionOSDevice");
   }
 
   async getmacOSDevices(): Promise<macOSDestination[]> {
@@ -194,13 +224,19 @@ export class DestinationsManager {
       }
     }
 
-    // if (a.type === "iOSDevice" && b.type === "iOSDevice") {
-    //   const aPriority = DESTINATION_IOS_DEVICE_TYPE_PRIORITY.findIndex((type) => type === a.deviceType);
-    //   const bPriority = DESTINATION_IOS_DEVICE_TYPE_PRIORITY.findIndex((type) => type === b.deviceType);
-    //   if (aPriority !== bPriority) {
-    //     return aPriority - bPriority;
-    //   }
-    // }
+    // Show connected devices first so the one plugged in right now isn't buried under
+    // every iPhone this Mac has ever been paired with.
+    if (a instanceof DeviceDestinationBase && b instanceof DeviceDestinationBase) {
+      const stateDelta = DEVICE_STATE_PRIORITY.indexOf(a.state) - DEVICE_STATE_PRIORITY.indexOf(b.state);
+      if (stateDelta !== 0) {
+        return stateDelta;
+      }
+      const aDate = a.lastConnectionDate?.getTime() ?? 0;
+      const bDate = b.lastConnectionDate?.getTime() ?? 0;
+      if (aDate !== bDate) {
+        return bDate - aDate;
+      }
+    }
 
     // In any other cases, fallback to sorting by name
     return a.name.localeCompare(b.name);

--- a/src/destination/tree.ts
+++ b/src/destination/tree.ts
@@ -790,7 +790,7 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
   }
 
   async getiOSDevices(): Promise<DestinationTreeItem[]> {
-    const device = await this.manager.getiOSDevices();
+    const device = await this.manager.getiOSDevices({ sort: true });
 
     return device.map((device) => {
       return new iOSDeviceDestinationTreeItem({
@@ -801,7 +801,7 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
   }
 
   async getWatchOSDevices(): Promise<DestinationTreeItem[]> {
-    const devices = await this.manager.getWatchOSDevices();
+    const devices = await this.manager.getWatchOSDevices({ sort: true });
 
     return devices.map((device) => {
       return new watchOSDeviceDestinationTreeItem({
@@ -812,7 +812,7 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
   }
 
   async getVisionOSDevices(): Promise<DestinationTreeItem[]> {
-    const devices = await this.manager.getVisionOSDevices();
+    const devices = await this.manager.getVisionOSDevices({ sort: true });
 
     return devices.map((device) => {
       return new visionOSDeviceDestinationTreeItem({
@@ -823,7 +823,7 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
   }
 
   async gettvOSDevices(): Promise<DestinationTreeItem[]> {
-    const devices = await this.manager.gettvOSDevices();
+    const devices = await this.manager.gettvOSDevices({ sort: true });
 
     return devices.map((device) => {
       return new tvOSDeviceDestinationTreeItem({

--- a/src/devices/types.ts
+++ b/src/devices/types.ts
@@ -228,6 +228,21 @@ export abstract class DeviceDestinationBase {
     const v = this.osVersion === "Unknown" ? undefined : this.osVersion;
     return supportsDevicectl(v, this.minDevicectlMajor);
   }
+
+  /**
+   * Timestamp of the device's most recent connection, from devicectl. Used by the
+   * destination sort to surface recently-used devices ahead of long-stale paired
+   * entries. Null for xcdevice-only devices (iOS <= 16) and when devicectl omits the
+   * field. Invalid date strings also yield null so callers can treat "unknown" as oldest.
+   */
+  get lastConnectionDate(): Date | null {
+    const raw = this.raw.devicectl?.connectionProperties?.lastConnectionDate;
+    if (!raw) {
+      return null;
+    }
+    const date = new Date(raw);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
 }
 
 export class iOSDeviceDestination extends DeviceDestinationBase implements IDestination {


### PR DESCRIPTION
Closes #234. Devices are now ordered connected → disconnected → unavailable, then by most-recent `lastConnectionDate`, so a freshly plugged-in iPhone surfaces above the stale paired entries devicectl carries forward.