### PR TITLE
Use resolved shell env in exec() (#241)

### DIFF
--- a/src/common/declrations.d.ts
+++ b/src/common/declrations.d.ts
@@ -21,6 +21,7 @@ declare module "execa" {
       cwd: string;
       buffer?: boolean;
       env?: { [key: string]: string | undefined };
+      extendEnv?: boolean;
     },
   ): Promise<ExecaReturnValue>;
 }

--- a/src/common/exec.ts
+++ b/src/common/exec.ts
@@ -2,6 +2,7 @@ import { getWorkspacePath } from "../build/utils";
 import { ExecBaseError, ExecError } from "./errors";
 import { prepareEnvVars } from "./helpers";
 import { commonLogger } from "./logger";
+import { getShellEnv } from "./tasks/shell-env";
 
 import { execa } from "execa";
 
@@ -37,13 +38,19 @@ export async function exec(options: {
     env: options.env,
   });
 
-  const env = prepareEnvVars(options.env);
+  // Resolve via the user's login+interactive shell so spawned tools (xcbeautify,
+  // xcodegen, tuist, mise/asdf shims, …) are found on PATH the same way they are
+  // in Terminal. getShellEnv() is cached and warmed at activation; this awaits
+  // the warm-up promise if the first exec() lands before it resolves.
+  const shellEnv = await getShellEnv();
+  const env = { ...shellEnv, ...prepareEnvVars(options.env) };
 
   let result: any;
   try {
     result = await execa(options.command, options.args, {
       cwd: cwd,
       env: env,
+      extendEnv: false,
     });
   } catch (e: any) {
     const errorMessage: string = e?.shortMessage ?? e?.message ?? "[unknown error]";


### PR DESCRIPTION
exec() now resolves env via getShellEnv() so install checks (xcbeautify, xcodegen, tuist, xcode-build-server) see the same PATH as the user's terminal. Fixes #241, where xcbeautify was silently skipped because the extension-host PATH lacked /opt/homebrew/bin.