### PR TITLE
Programmatic build diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,55 +194,6 @@
           "beginsPattern": "^🍭 SweetPad: watch marker",
           "endsPattern": "^🍩 SweetPad: watch marker"
         }
-      },
-      {
-        "name": "sweetpad-xcodebuild-default",
-        "owner": "sweetpad",
-        "label": "SweetPad xcodebuild (default)",
-        "fileLocation": [
-          "absolute"
-        ],
-        "pattern": [
-          {
-            "regexp": "^(.*):(\\d+):(\\d+):\\s+(error|warning):\\s+(.*)$",
-            "file": 1,
-            "line": 2,
-            "column": 3,
-            "severity": 4,
-            "message": 5
-          }
-        ]
-      },
-      {
-        "name": "sweetpad-xcbeautify-errors",
-        "owner": "sweetpad",
-        "label": "SweetPad xcbeautify (errors)",
-        "fileLocation": [
-          "absolute"
-        ],
-        "pattern": {
-          "regexp": "^(?:❌|\\[x\\])\\s*(\\/[^:]+):(\\d+):(\\d+):\\s*(.*)$",
-          "file": 1,
-          "line": 2,
-          "column": 3,
-          "message": 4
-        },
-        "severity": "error"
-      },
-      {
-        "name": "sweetpad-xcbeautify-warnings",
-        "owner": "sweetpad",
-        "fileLocation": [
-          "absolute"
-        ],
-        "pattern": {
-          "regexp": "^(?:⚠️|\\[!\\])\\s*(\\/[^:]+):(\\d+):(\\d+):\\s*(.*)$",
-          "file": 1,
-          "line": 2,
-          "column": 3,
-          "message": 4
-        },
-        "severity": "warning"
       }
     ],
     "debuggers": [

--- a/src/build/constants.ts
+++ b/src/build/constants.ts
@@ -1,6 +1,12 @@
-export const DEFAULT_BUILD_PROBLEM_MATCHERS = [
-  "$sweetpad-watch",
-  "$sweetpad-xcodebuild-default",
-  "$sweetpad-xcbeautify-errors",
-  "$sweetpad-xcbeautify-warnings",
-];
+/**
+ * Problem matchers attached to every sweetpad build task. Defined in
+ * package.json.
+ *
+ * `sweetpad-watch` is a background-task lifecycle matcher — it watches for
+ * the 🍭/🍩 markers `writeWatchMarkers` emits to detect when a background
+ * task has reached steady state. It carries no diagnostic patterns.
+ *
+ * Build-output diagnostics are produced programmatically by
+ * `DiagnosticsManager` in `src/build/diagnostics.ts`, not by problem matchers.
+ */
+export const BUILD_TASK_PROBLEM_MATCHERS = ["$sweetpad-watch"];

--- a/src/build/diagnostics-parser.spec.ts
+++ b/src/build/diagnostics-parser.spec.ts
@@ -1,0 +1,237 @@
+import { parseDiagnosticLine } from "./diagnostics-parser";
+
+describe("parseDiagnosticLine", () => {
+  describe("xcbeautify error format", () => {
+    it("parses the unicode emoji form", () => {
+      const result = parseDiagnosticLine("❌ /path/to/Foo.swift:10:5: cannot find 'bar' in scope");
+      expect(result).toEqual({
+        file: "/path/to/Foo.swift",
+        line: 10,
+        column: 5,
+        severity: "error",
+        message: "cannot find 'bar' in scope",
+        source: "xcbeautify",
+      });
+    });
+
+    it("parses the ascii form [x]", () => {
+      const result = parseDiagnosticLine("[x] /path/to/Foo.swift:42:9: use of undeclared identifier 'q'");
+      expect(result).toEqual({
+        file: "/path/to/Foo.swift",
+        line: 42,
+        column: 9,
+        severity: "error",
+        message: "use of undeclared identifier 'q'",
+        source: "xcbeautify",
+      });
+    });
+
+    it("tolerates no space between the prefix and the path", () => {
+      const result = parseDiagnosticLine("❌/path/to/Foo.swift:1:1: boom");
+      expect(result?.severity).toBe("error");
+      expect(result?.file).toBe("/path/to/Foo.swift");
+    });
+
+    it("tolerates extra whitespace between the prefix and the path", () => {
+      const result = parseDiagnosticLine("[x]   /path/to/Foo.swift:1:1: boom");
+      expect(result?.severity).toBe("error");
+    });
+
+    it("preserves colons inside the diagnostic message", () => {
+      const result = parseDiagnosticLine("❌ /path/to/Foo.swift:10:5: expected ':' after type name");
+      expect(result?.message).toBe("expected ':' after type name");
+    });
+  });
+
+  describe("xcbeautify warning format", () => {
+    it("parses the unicode emoji form", () => {
+      const result = parseDiagnosticLine("⚠️  /path/to/Foo.swift:12:1: variable 'x' was never used");
+      expect(result).toEqual({
+        file: "/path/to/Foo.swift",
+        line: 12,
+        column: 1,
+        severity: "warning",
+        message: "variable 'x' was never used",
+        source: "xcbeautify",
+      });
+    });
+
+    it("parses the ascii form [!]", () => {
+      const result = parseDiagnosticLine("[!] /path/to/Foo.swift:7:14: deprecated API");
+      expect(result).toEqual({
+        file: "/path/to/Foo.swift",
+        line: 7,
+        column: 14,
+        severity: "warning",
+        message: "deprecated API",
+        source: "xcbeautify",
+      });
+    });
+  });
+
+  describe("raw xcodebuild format", () => {
+    it("parses an error line", () => {
+      const result = parseDiagnosticLine("/path/to/Foo.swift:10:5: error: cannot find 'bar' in scope");
+      expect(result).toEqual({
+        file: "/path/to/Foo.swift",
+        line: 10,
+        column: 5,
+        severity: "error",
+        message: "cannot find 'bar' in scope",
+        source: "xcodebuild",
+      });
+    });
+
+    it("parses a warning line", () => {
+      const result = parseDiagnosticLine("/path/to/Foo.swift:12:1: warning: variable 'x' was never used");
+      expect(result).toEqual({
+        file: "/path/to/Foo.swift",
+        line: 12,
+        column: 1,
+        severity: "warning",
+        message: "variable 'x' was never used",
+        source: "xcodebuild",
+      });
+    });
+
+    it("ignores `note:` continuation lines", () => {
+      // xcodebuild emits notes as `file:line:col: note: msg` — we deliberately
+      // don't surface them as standalone diagnostics; future work could attach
+      // them as relatedInformation on the preceding error.
+      const result = parseDiagnosticLine("/path/to/Foo.swift:10:5: note: see declaration of 'bar'");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("path handling", () => {
+    it("rejects relative paths", () => {
+      // The fileLocation in the old problem matcher was "absolute"; matching
+      // unanchored paths would let `note: src/Foo.swift:1:2: error: bar`-style
+      // lines sneak through.
+      const result = parseDiagnosticLine("src/Foo.swift:10:5: error: bad");
+      expect(result).toBeNull();
+    });
+
+    it("accepts deeply nested absolute paths", () => {
+      const result = parseDiagnosticLine(
+        "/Users/me/Library/Developer/Xcode/DerivedData/App-abc/SourcePackages/Foo.swift:1:1: error: x",
+      );
+      expect(result?.file).toBe("/Users/me/Library/Developer/Xcode/DerivedData/App-abc/SourcePackages/Foo.swift");
+    });
+
+    it("accepts paths with spaces", () => {
+      const result = parseDiagnosticLine("/Users/me/My Project/Foo.swift:3:4: error: oops");
+      expect(result?.file).toBe("/Users/me/My Project/Foo.swift");
+      expect(result?.line).toBe(3);
+      expect(result?.column).toBe(4);
+    });
+
+    it("does not match when the path contains a colon", () => {
+      // Colons inside paths break the regex (and shouldn't occur on macOS) —
+      // documenting the limit so a future contributor doesn't think it's a bug.
+      const result = parseDiagnosticLine("/weird:path/Foo.swift:10:5: error: bad");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("non-matching lines", () => {
+    it("returns null for an empty line", () => {
+      expect(parseDiagnosticLine("")).toBeNull();
+    });
+
+    it("returns null for whitespace-only lines", () => {
+      expect(parseDiagnosticLine("   \t  ")).toBeNull();
+    });
+
+    it("returns null for ordinary build progress lines", () => {
+      expect(parseDiagnosticLine("Compile Foo.swift (in target 'App')")).toBeNull();
+      expect(parseDiagnosticLine("** BUILD SUCCEEDED **")).toBeNull();
+      expect(parseDiagnosticLine("CompileSwiftSources normal x86_64")).toBeNull();
+    });
+
+    it("returns null when the emoji prefix appears mid-line", () => {
+      // Anchor is required — otherwise xcbeautify summary lines like
+      // "Build failed ❌ 1 error" would match.
+      expect(parseDiagnosticLine("Build failed ❌ /path/Foo.swift:1:1: msg")).toBeNull();
+    });
+  });
+
+  describe("input sanitization", () => {
+    it("strips trailing CR (CRLF terminators)", () => {
+      const result = parseDiagnosticLine("/path/to/Foo.swift:10:5: error: msg\r");
+      expect(result?.message).toBe("msg");
+    });
+
+    it("strips ANSI color escape sequences", () => {
+      // v3's line buffer strips ANSI before us, but v2 does not — defend either way.
+      const line = "\x1b[31m❌\x1b[0m /path/to/Foo.swift:10:5: \x1b[1mboom\x1b[0m";
+      const result = parseDiagnosticLine(line);
+      expect(result).toEqual({
+        file: "/path/to/Foo.swift",
+        line: 10,
+        column: 5,
+        severity: "error",
+        message: "boom",
+        source: "xcbeautify",
+      });
+    });
+
+    it("trims leading whitespace", () => {
+      const result = parseDiagnosticLine("   /path/to/Foo.swift:10:5: error: msg");
+      expect(result?.file).toBe("/path/to/Foo.swift");
+    });
+
+    it("handles multi-digit line and column numbers", () => {
+      const result = parseDiagnosticLine("/path/Foo.swift:1234:567: error: msg");
+      expect(result?.line).toBe(1234);
+      expect(result?.column).toBe(567);
+    });
+  });
+
+  describe("mode parameter", () => {
+    const xcbeautifyLine = "❌ /path/Foo.swift:10:5: cannot find 'bar' in scope";
+    const xcodebuildLine = "/path/Foo.swift:10:5: error: cannot find 'bar' in scope";
+
+    describe("mode = 'xcbeautify'", () => {
+      it("matches xcbeautify-formatted lines", () => {
+        const result = parseDiagnosticLine(xcbeautifyLine, "xcbeautify");
+        expect(result?.source).toBe("xcbeautify");
+      });
+
+      it("ignores raw xcodebuild lines (which xcbeautify would have reformatted)", () => {
+        // When xcbeautify is in the pipeline, both forms can appear in the
+        // captured stream — the raw one is a near-duplicate of the formatted
+        // one (often differing only by message casing). Filtering it out at
+        // parse time avoids two diagnostics for the same error.
+        const result = parseDiagnosticLine(xcodebuildLine, "xcbeautify");
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("mode = 'xcodebuild'", () => {
+      it("matches raw xcodebuild lines", () => {
+        const result = parseDiagnosticLine(xcodebuildLine, "xcodebuild");
+        expect(result?.source).toBe("xcodebuild");
+      });
+
+      it("ignores xcbeautify-formatted lines (xcbeautify is not in the pipeline)", () => {
+        const result = parseDiagnosticLine(xcbeautifyLine, "xcodebuild");
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("mode = 'auto' (default)", () => {
+      it("matches both formats", () => {
+        expect(parseDiagnosticLine(xcbeautifyLine, "auto")?.source).toBe("xcbeautify");
+        expect(parseDiagnosticLine(xcodebuildLine, "auto")?.source).toBe("xcodebuild");
+      });
+
+      it("is the default when no mode is provided", () => {
+        // All 22 existing tests above implicitly verify this; this is a
+        // belt-and-braces assertion against accidental default changes.
+        expect(parseDiagnosticLine(xcbeautifyLine)?.source).toBe("xcbeautify");
+        expect(parseDiagnosticLine(xcodebuildLine)?.source).toBe("xcodebuild");
+      });
+    });
+  });
+});

--- a/src/build/diagnostics-parser.ts
+++ b/src/build/diagnostics-parser.ts
@@ -1,0 +1,158 @@
+/**
+ * Pure parser for diagnostic lines emitted by `xcodebuild` and `xcbeautify`.
+ *
+ * Kept free of vscode imports so it can be unit-tested without mocking the
+ * editor surface. The `DiagnosticsManager` is the one that translates these
+ * results into `vscode.Diagnostic` instances and pushes them to a
+ * `DiagnosticCollection`.
+ *
+ * Three formats are recognized:
+ *
+ *  1. xcbeautify error    `❌` or `[x]` prefix, e.g.
+ *       ❌ /path/Foo.swift:10:5: cannot find 'bar' in scope
+ *
+ *  2. xcbeautify warning  `⚠️` or `[!]` prefix, e.g.
+ *       ⚠️ /path/Foo.swift:12:1: variable 'x' was never used
+ *
+ *  3. raw xcodebuild      `file:line:column: error|warning: msg`, e.g.
+ *       /path/Foo.swift:10:5: error: cannot find 'bar' in scope
+ *
+ * Anchored to absolute paths (leading `/`) on purpose — xcodebuild emits
+ * absolute paths in its `-resultBundlePath` flow, and anchoring keeps the
+ * regex from accidentally matching lines like `note: foo:1:2: error: bar`.
+ */
+
+export type DiagnosticSeverity = "error" | "warning";
+export type DiagnosticSource = "xcodebuild" | "xcbeautify";
+
+/**
+ * Which line formats the parser should try:
+ *
+ *  - "xcbeautify": only the `❌`/`[x]` and `⚠️`/`[!]` prefixed forms. Set
+ *    this when xcbeautify is in the pipeline — xcodebuild's raw lines are
+ *    consumed and reformatted by xcbeautify, but in some versions the raw
+ *    line *also* leaks through with slightly different casing, which
+ *    produces a near-duplicate diagnostic if both parsers run.
+ *  - "xcodebuild": only the canonical `path:line:col: error|warning: msg`
+ *    form. Set this when xcbeautify is *not* in the pipeline — the raw
+ *    lines are all we get.
+ *  - "auto": try every pattern. The right choice for unit tests and any
+ *    caller that doesn't know what produced the line.
+ */
+export type ParseMode = "xcbeautify" | "xcodebuild" | "auto";
+
+export type ParsedDiagnostic = {
+  file: string;
+  line: number;
+  column: number;
+  severity: DiagnosticSeverity;
+  message: string;
+  source: DiagnosticSource;
+};
+
+// Matches `\x1b[...m` SGR escape sequences (the "set graphics rendition"
+// family — colors, bold, reset, etc.). xcbeautify color-codes its prefixes
+// and messages; we strip them so the diagnostic regexes see plain text.
+//   Example match: "\x1b[31m" (red), "\x1b[1;33m" (bold yellow), "\x1b[0m" (reset)
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — matches ANSI escape sequences
+const ANSI_STRIP_REGEX = /\x1b\[[0-9;]*m/g;
+
+// xcbeautify error lines.
+//   Example:  ❌ /Users/me/App/Sources/Foo.swift:10:5: cannot find 'bar' in scope
+//   Example:  [x] /Users/me/App/Sources/Foo.swift:10:5: cannot find 'bar' in scope
+//
+// Pattern breakdown:
+//   ^                      anchor to start of line — prevents mid-line matches
+//                          like "Build failed ❌ foo.swift:1:1: msg"
+//   (?:❌|\[x\])           non-capturing: the emoji form OR the ascii `[x]` form
+//                          (xcbeautify picks one based on the --disable-colored-output
+//                          flag and the terminal's locale)
+//   \s*                    flexible spacing — xcbeautify usually emits one space,
+//                          but the emoji is double-width and some terminals add padding
+//   (\/[^:]+)              group 1, file path: must start with `/` (absolute) and
+//                          contain no `:` so the next `:` belongs to the line number,
+//                          not the path. Tradeoff: paths with `:` won't match — fine
+//                          on macOS where `:` is illegal in filenames.
+//   :(\d+):(\d+)           groups 2 and 3, line and column (1-based, like Xcode shows)
+//   :\s*                   separator before the message; `\s*` because the message
+//                          may be glued straight to the colon in some xcbeautify versions
+//   (.*)                   group 4, the diagnostic message (rest of the line)
+//   $                      anchor to end — required because earlier `.trim()` strips CR
+const XCBEAUTIFY_ERROR_REGEX = /^(?:❌|\[x\])\s*(\/[^:]+):(\d+):(\d+):\s*(.*)$/;
+
+// xcbeautify warning lines — same shape as the error pattern with a different prefix.
+//   Example:  ⚠️ /Users/me/App/Sources/Foo.swift:12:1: variable 'x' was never used
+//   Example:  [!] /Users/me/App/Sources/Foo.swift:12:1: variable 'x' was never used
+// Severity is implied by which regex matched, not captured in a group.
+const XCBEAUTIFY_WARNING_REGEX = /^(?:⚠️|\[!\])\s*(\/[^:]+):(\d+):(\d+):\s*(.*)$/;
+
+// Raw xcodebuild diagnostic lines (no xcbeautify in the pipeline). Format is
+// Clang/Swift's canonical `path:line:col: severity: message`.
+//   Example:  /Users/me/App/Sources/Foo.swift:10:5: error: cannot find 'bar' in scope
+//   Example:  /Users/me/App/Sources/Foo.swift:12:1: warning: variable 'x' was never used
+//
+// Pattern breakdown:
+//   ^(\/[^:]+):(\d+):(\d+)   same file/line/col shape as the xcbeautify patterns
+//   :\s+                     separator before the severity word — note `\s+` (one or
+//                            more) here, vs `\s*` in the xcbeautify patterns: raw
+//                            xcodebuild always emits a space, xcbeautify sometimes doesn't
+//   (error|warning)          group 4, the severity word — note we *don't* match `note:`
+//                            here, so xcodebuild's note continuation lines (e.g.
+//                            "Foo.swift:10:5: note: see declaration of 'bar'") are
+//                            deliberately skipped. They could be attached as
+//                            relatedInformation on the preceding diagnostic later.
+//   :\s+(.*)$                separator, then group 5 — the rest of the message
+const XCODEBUILD_REGEX = /^(\/[^:]+):(\d+):(\d+):\s+(error|warning):\s+(.*)$/;
+
+export function parseDiagnosticLine(rawLine: string, mode: ParseMode = "auto"): ParsedDiagnostic | null {
+  // `\r` would block the `$` anchor; strip CR + any stray ANSI (the v3 task
+  // terminal already strips ANSI before invoking onOutputLine, but the v2
+  // fallback does not).
+  const line = rawLine.replace(ANSI_STRIP_REGEX, "").replace(/\r$/, "").trim();
+  if (line.length === 0) return null;
+
+  const tryXcbeautify = mode === "xcbeautify" || mode === "auto";
+  const tryXcodebuild = mode === "xcodebuild" || mode === "auto";
+
+  if (tryXcbeautify) {
+    const errMatch = XCBEAUTIFY_ERROR_REGEX.exec(line);
+    if (errMatch) {
+      return {
+        file: errMatch[1],
+        line: Number.parseInt(errMatch[2], 10),
+        column: Number.parseInt(errMatch[3], 10),
+        severity: "error",
+        message: errMatch[4].trim(),
+        source: "xcbeautify",
+      };
+    }
+
+    const warnMatch = XCBEAUTIFY_WARNING_REGEX.exec(line);
+    if (warnMatch) {
+      return {
+        file: warnMatch[1],
+        line: Number.parseInt(warnMatch[2], 10),
+        column: Number.parseInt(warnMatch[3], 10),
+        severity: "warning",
+        message: warnMatch[4].trim(),
+        source: "xcbeautify",
+      };
+    }
+  }
+
+  if (tryXcodebuild) {
+    const rawMatch = XCODEBUILD_REGEX.exec(line);
+    if (rawMatch) {
+      return {
+        file: rawMatch[1],
+        line: Number.parseInt(rawMatch[2], 10),
+        column: Number.parseInt(rawMatch[3], 10),
+        severity: rawMatch[4] as DiagnosticSeverity,
+        message: rawMatch[5].trim(),
+        source: "xcodebuild",
+      };
+    }
+  }
+
+  return null;
+}

--- a/src/build/diagnostics.ts
+++ b/src/build/diagnostics.ts
@@ -1,0 +1,180 @@
+import * as vscode from "vscode";
+
+import { commonLogger } from "../common/logger";
+import { type ParseMode, parseDiagnosticLine, type ParsedDiagnostic } from "./diagnostics-parser";
+
+/**
+ * Source identifiers used by sourcekit-lsp (via the swiftlang.swift-vscode
+ * extension) when it publishes diagnostics. We compare against these in
+ * `isAlreadyReportedByLsp` to avoid duplicating errors that the LSP has
+ * already surfaced in the Problems panel.
+ *
+ * Kept as a list because the value has drifted between releases — older
+ * builds tagged everything `SourceKit`, newer ones use `sourcekit-lsp`.
+ */
+const LSP_SOURCES = new Set(["sourcekit-lsp", "SourceKit", "swift"]);
+
+const SWIFT_FILE_REGEX = /\.swift$/i;
+
+/**
+ * Owns the `sweetpad` DiagnosticCollection and the lifecycle of build-time
+ * diagnostics:
+ *
+ *  - `beginBuild()` clears the collection (matching VS Code's existing
+ *    problem-matcher contract: each build starts from a clean slate) and
+ *    returns an Accumulator the build flow feeds lines into.
+ *  - `flush()` publishes the freshly-parsed diagnostics, filtering out
+ *    entries sourcekit-lsp has already reported at the same position
+ *    (Swift files only — ObjC, headers, plist, linker output stay).
+ *  - `onDidChangeTextDocument` drops entries for any file the user starts
+ *    editing. sourcekit-lsp takes over for the open file; keeping the
+ *    build-time entries around just produces ghost errors at the wrong
+ *    line as text shifts (issue #171).
+ *
+ * The collection is reused across builds rather than recreated — VS Code
+ * keys diagnostics by collection identity in the Problems panel and we want
+ * "sweetpad" to stay a stable grouping.
+ */
+export class DiagnosticsManager implements vscode.Disposable {
+  private readonly collection: vscode.DiagnosticCollection;
+  private readonly subscriptions: vscode.Disposable[] = [];
+
+  constructor() {
+    this.collection = vscode.languages.createDiagnosticCollection("sweetpad");
+
+    this.subscriptions.push(
+      vscode.workspace.onDidChangeTextDocument((event) => {
+        if (event.contentChanges.length === 0) return;
+        if (this.collection.get(event.document.uri)?.length) {
+          this.collection.delete(event.document.uri);
+        }
+      }),
+    );
+  }
+
+  /**
+   * Open a per-build accumulator. Clears the existing diagnostic set so the
+   * upcoming build starts from a blank Problems panel. Call `recordLine` on
+   * the returned accumulator for every line of build output, then `flush`
+   * exactly once at the end (success or failure — failed builds are when we
+   * most want the diagnostics published).
+   *
+   * `mode` selects which line formats the parser should accept — set it to
+   * match what's actually in the build pipeline. See `ParseMode` in
+   * `./diagnostics-parser` for the trade-off.
+   */
+  beginBuild(options: { mode: ParseMode }): DiagnosticAccumulator {
+    this.collection.clear();
+    return new DiagnosticAccumulator(this.collection, options.mode);
+  }
+
+  dispose(): void {
+    for (const sub of this.subscriptions) sub.dispose();
+    this.collection.dispose();
+  }
+}
+
+export class DiagnosticAccumulator {
+  private readonly perFile = new Map<string, ParsedDiagnostic[]>();
+  private flushed = false;
+
+  constructor(
+    private readonly collection: vscode.DiagnosticCollection,
+    private readonly mode: ParseMode,
+  ) {}
+
+  /**
+   * Feed one line of build output to the parser. Lines that don't match any
+   * known diagnostic format are silently ignored — this is the hot path for
+   * every line xcodebuild prints, so the parser is intentionally cheap.
+   *
+   * Deduplicates by position: same `(file, line, column, severity)` keeps
+   * the first diagnostic seen and drops later ones. The Swift compiler can
+   * emit the same error twice from the frontend and the driver with
+   * slightly different message casing (lowercase original vs capitalized
+   * "rendered" form), and xcbeautify can re-emit a formatted copy of a raw
+   * line. Two genuinely distinct diagnostics at the exact same column with
+   * the same severity are vanishingly rare; the cost of collapsing them is
+   * much lower than the cost of showing a near-duplicate in the panel.
+   */
+  recordLine(rawLine: string): void {
+    const diag = parseDiagnosticLine(rawLine, this.mode);
+    if (!diag) return;
+
+    const bucket = this.perFile.get(diag.file);
+    if (!bucket) {
+      this.perFile.set(diag.file, [diag]);
+      return;
+    }
+
+    const isDuplicate = bucket.some(
+      (existing) =>
+        existing.line === diag.line && existing.column === diag.column && existing.severity === diag.severity,
+    );
+    if (!isDuplicate) bucket.push(diag);
+  }
+
+  /**
+   * Publish the accumulated diagnostics. Idempotent — calling twice is a no-op.
+   */
+  flush(): void {
+    if (this.flushed) return;
+    this.flushed = true;
+
+    for (const [file, diags] of this.perFile) {
+      const uri = vscode.Uri.file(file);
+      const surviving = diags.filter((d) => !isAlreadyReportedByLsp(uri, d));
+      if (surviving.length > 0) {
+        this.collection.set(uri, surviving.map((parsed) => toVscodeDiagnostic(parsed)));
+      }
+    }
+  }
+}
+
+function toVscodeDiagnostic(parsed: ParsedDiagnostic): vscode.Diagnostic {
+  // VS Code positions are zero-based, xcodebuild's are one-based. Clamp to 0
+  // so an off-by-one (or `column: 0` from a tool that emits that) doesn't
+  // create a negative position which VS Code rejects silently.
+  const line = Math.max(0, parsed.line - 1);
+  const column = Math.max(0, parsed.column - 1);
+  const range = new vscode.Range(line, column, line, column);
+  const severity = parsed.severity === "error" ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Warning;
+  const diagnostic = new vscode.Diagnostic(range, parsed.message, severity);
+  diagnostic.source = "sweetpad";
+  return diagnostic;
+}
+
+function isAlreadyReportedByLsp(uri: vscode.Uri, parsed: ParsedDiagnostic): boolean {
+  // Only filter Swift files. Errors in ObjC, headers, plist, linker output,
+  // or SPM checkouts (which sourcekit-lsp typically doesn't index) come
+  // exclusively from xcodebuild and must not be dropped.
+  if (!SWIFT_FILE_REGEX.test(uri.fsPath)) return false;
+
+  let existing: readonly vscode.Diagnostic[];
+  try {
+    existing = vscode.languages.getDiagnostics(uri);
+  } catch (error) {
+    // Defensive: in older VS Code versions getDiagnostics for unknown URIs
+    // has been observed to throw. The cost of letting a duplicate through
+    // is much lower than losing a real error.
+    commonLogger.debug("getDiagnostics threw, skipping LSP overlap filter", {
+      uri: uri.toString(),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+
+  const targetLine = Math.max(0, parsed.line - 1);
+  const expectedSeverity =
+    parsed.severity === "error" ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Warning;
+  return existing.some(
+    (d) =>
+      d.source !== undefined &&
+      LSP_SOURCES.has(d.source) &&
+      d.range.start.line === targetLine &&
+      // Match severity too — if the LSP reported a warning and xcodebuild
+      // reports an error at the same line (e.g. -Werror promoted it),
+      // surface the error.
+      d.severity === expectedSeverity,
+  );
+}

--- a/src/build/manager-integration.spec.ts
+++ b/src/build/manager-integration.spec.ts
@@ -81,6 +81,12 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
       refreshSimulators: vi.fn().mockResolvedValue([]),
       getDestinations: vi.fn().mockResolvedValue([]),
     } as any;
+    const mockDiagnostics = {
+      beginBuild: vi.fn().mockReturnValue({
+        recordLine: vi.fn(),
+        flush: vi.fn(),
+      }),
+    } as any;
     buildManager = new BuildManager({
       workspace: mockWorkspace,
       progress: mockProgress,
@@ -88,6 +94,7 @@ describe("BuildManager - iOS Device Deployment Integration", () => {
       tunnel: mockTunnel,
       vscodeContext: mockVscodeContext,
       destinations: mockDestinations,
+      diagnostics: mockDiagnostics,
     });
     mockTerminal = createMockTerminal();
 

--- a/src/build/manager.ts
+++ b/src/build/manager.ts
@@ -32,7 +32,8 @@ import { MacOSLogSidecar, Pymd3Sidecar, SimulatorLogSidecar } from "../run/sidec
 import type { SimulatorDestination } from "../simulators/types";
 import { getSimulatorByUdid } from "../simulators/utils";
 import type { ProgressStatusBar } from "../system/status-bar";
-import { DEFAULT_BUILD_PROBLEM_MATCHERS } from "./constants";
+import { BUILD_TASK_PROBLEM_MATCHERS } from "./constants";
+import type { DiagnosticsManager } from "./diagnostics";
 import type { BuildTreeItem } from "./tree";
 import {
   XcodeCommandBuilder,
@@ -78,6 +79,7 @@ export class BuildManager {
   private tunnel: TunnelManager;
   private vscodeContext: vscode.ExtensionContext;
   private destinations: DestinationsManager;
+  private diagnostics: DiagnosticsManager;
   private runningSchemes: Set<string> = new Set();
 
   constructor(options: {
@@ -87,6 +89,7 @@ export class BuildManager {
     tunnel: TunnelManager;
     vscodeContext: vscode.ExtensionContext;
     destinations: DestinationsManager;
+    diagnostics: DiagnosticsManager;
   }) {
     this.workspace = options.workspace;
     this.progress = options.progress;
@@ -94,6 +97,7 @@ export class BuildManager {
     this.tunnel = options.tunnel;
     this.vscodeContext = options.vscodeContext;
     this.destinations = options.destinations;
+    this.diagnostics = options.diagnostics;
   }
 
   async start(): Promise<void> {
@@ -266,7 +270,7 @@ export class BuildManager {
         name: options.name,
         lock: "sweetpad.build",
         terminateLocked: true,
-        problemMatchers: DEFAULT_BUILD_PROBLEM_MATCHERS,
+        problemMatchers: BUILD_TASK_PROBLEM_MATCHERS,
         metadata: { scheme: options.scheme },
         callback: options.callback,
       });
@@ -947,14 +951,20 @@ export class BuildManager {
       assertUnreachable(workspaceType);
     }
 
-    await terminal.execute({
-      command: commandParts[0],
-      args: commandParts.slice(1),
-      pipes: pipes,
-      env: env,
-      cwd: cwd,
-      closeStdin: true,
-    });
+    const diagnostics = this.diagnostics.beginBuild({ mode: useXcbeautify ? "xcbeautify" : "xcodebuild" });
+    try {
+      await terminal.execute({
+        command: commandParts[0],
+        args: commandParts.slice(1),
+        pipes: pipes,
+        env: env,
+        cwd: cwd,
+        closeStdin: true,
+        onOutputLine: async ({ value }) => diagnostics.recordLine(value),
+      });
+    } finally {
+      diagnostics.flush();
+    }
 
     await restartSwiftLSP();
   }

--- a/src/build/provider.ts
+++ b/src/build/provider.ts
@@ -15,7 +15,7 @@ import type { WorkspaceStateService } from "../common/workspace-state";
 import type { DestinationsManager } from "../destination/manager";
 import type { Destination } from "../destination/types";
 import type { ProgressStatusBar } from "../system/status-bar";
-import { DEFAULT_BUILD_PROBLEM_MATCHERS } from "./constants";
+import { BUILD_TASK_PROBLEM_MATCHERS } from "./constants";
 import type { BuildManager } from "./manager";
 import {
   askConfiguration,
@@ -648,7 +648,7 @@ export class XcodeBuildTaskProvider implements vscode.TaskProvider {
             throw new Error(`Task executor ${executorName} is not supported`);
         }
       }),
-      DEFAULT_BUILD_PROBLEM_MATCHERS, // problemMatchers
+      BUILD_TASK_PROBLEM_MATCHERS, // problemMatchers
     );
     setTaskPresentationOptions(task);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import {
   switchWorktreeCommand,
   testCommand,
 } from "./build/commands.js";
+import { DiagnosticsManager } from "./build/diagnostics.js";
 import { LspDiagnosticsService } from "./build/lsp-diagnostics.js";
 import { BuildManager } from "./build/manager.js";
 import { XcodeBuildTaskProvider } from "./build/provider.js";
@@ -121,6 +122,7 @@ export function activate(context: vscode.ExtensionContext) {
     workspace: workspace,
   });
   const lspDiagnostics = new LspDiagnosticsService(workspace);
+  const diagnostics = new DiagnosticsManager();
   const buildManager = new BuildManager({
     workspace: workspace,
     progress: progressStatusBar,
@@ -128,6 +130,7 @@ export function activate(context: vscode.ExtensionContext) {
     tunnel: tunnelManager,
     vscodeContext: context,
     destinations: destinationsManager,
+    diagnostics: diagnostics,
   });
   const toolsManager = new ToolsManager();
   const testingManager = new TestingManager({
@@ -304,6 +307,7 @@ export function activate(context: vscode.ExtensionContext) {
   lspDiagnostics.reattachIfEnabled();
   lspDiagnostics.showPostReloadNotificationIfPending();
   d(lspDiagnostics);
+  d(diagnostics);
 }
 
 export function deactivate() {}


### PR DESCRIPTION
Parses xcodebuild/xcbeautify output programmatically and writes to its own DiagnosticCollection. Closes #221 (Swift-file errors already reported by sourcekit-lsp at the same line+severity are filtered out; ObjC/headers/plist/linker errors stay). Helps #171 (entries clear when the file is edited and on every new build; closed-file branch switches still require a rebuild).