### PR TITLE
Hide SweetPad UI in non-Swift workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,14 +23,13 @@
     "vscode": "^1.85.0"
   },
   "activationEvents": [
-    "onCommand:workbench.action.tasks.runTask",
-    "onDebug",
     "onLanguage:swift",
     "workspaceContains:**/*.xcodeproj",
     "workspaceContains:**/*.xcworkspace",
     "workspaceContains:**/Package.swift",
     "workspaceContains:**/Podfile",
-    "workspaceContains:**/project.yml"
+    "workspaceContains:**/project.yml",
+    "workspaceContains:**/Project.swift"
   ],
   "extensionDependencies": [
     "vadimcn.vscode-lldb"

--- a/src/build/diagnostics.ts
+++ b/src/build/diagnostics.ts
@@ -125,7 +125,10 @@ export class DiagnosticAccumulator {
       const uri = vscode.Uri.file(file);
       const surviving = diags.filter((d) => !isAlreadyReportedByLsp(uri, d));
       if (surviving.length > 0) {
-        this.collection.set(uri, surviving.map((parsed) => toVscodeDiagnostic(parsed)));
+        this.collection.set(
+          uri,
+          surviving.map((parsed) => toVscodeDiagnostic(parsed)),
+        );
       }
     }
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,12 +93,15 @@ import { TuistGenWatcher } from "./tuist/watcher.js";
 import { xcodgenGenerateCommand } from "./xcodegen/commands.js";
 import { XcodeGenWatcher } from "./xcodegen/watcher.js";
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   // Sentry 🚨
   errorReporting.logSetup();
 
   // 🪵🪓
   Logger.setup();
+
+  // An activation event matched this workspace — reveal SweetPad UI.
+  await vscode.commands.executeCommand("setContext", "sweetpad.enabled", true);
 
   warmShellEnv();
 


### PR DESCRIPTION
Drops the over-broad `onDebug` and `onCommand:workbench.action.tasks.runTask` activation events, adds `Project.swift` for Tuist roots, and sets the `sweetpad.enabled` context on activation so the activity bar view appears only when SweetPad is active in the workspace. Fixes #247.