### PR TITLE
Honor scheme LaunchAction args/env/language/region when running

### DIFF
--- a/src/build/manager.ts
+++ b/src/build/manager.ts
@@ -45,6 +45,7 @@ import {
   ensureAppPathExists,
   generateBuildServerConfigOnBuild,
   getCurrentXcodeWorkspacePath,
+  getSchemeLaunchSettings,
   getSwiftPMDirectory,
   getWorkspacePath,
   getXcodeBuildDestinationString,
@@ -357,8 +358,9 @@ export class BuildManager {
 
     const sdk = destination.platform;
 
-    const launchArgs = getWorkspaceConfig("build.launchArgs") ?? [];
-    const launchEnv = getWorkspaceConfig("build.launchEnv") ?? {};
+    const schemeSettings = await getSchemeLaunchSettings({ xcworkspace: xcworkspace, scheme: scheme });
+    const launchArgs = [...schemeSettings.args, ...(getWorkspaceConfig("build.launchArgs") ?? [])];
+    const launchEnv = { ...schemeSettings.env, ...getWorkspaceConfig("build.launchEnv") };
 
     await this.runSchemeTask({
       name: "Run",
@@ -448,8 +450,9 @@ export class BuildManager {
 
     const sdk = destination.platform;
 
-    const launchArgs = getWorkspaceConfig("build.launchArgs") ?? [];
-    const launchEnv = getWorkspaceConfig("build.launchEnv") ?? {};
+    const schemeSettings = await getSchemeLaunchSettings({ xcworkspace: xcworkspace, scheme: scheme });
+    const launchArgs = [...schemeSettings.args, ...(getWorkspaceConfig("build.launchArgs") ?? [])];
+    const launchEnv = { ...schemeSettings.env, ...getWorkspaceConfig("build.launchEnv") };
 
     await this.runSchemeTask({
       name: options.debug ? "Debug" : "Launch",

--- a/src/build/utils.spec.ts
+++ b/src/build/utils.spec.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { LaunchAction, SchemeDocument } from "../common/xcode/xcscheme";
+import { launchActionToSettings } from "./utils";
+
+const FIXTURE_DIR = path.resolve(__dirname, "../../tests/xcscheme-data");
+
+function loadLaunchAction(fixture: string): LaunchAction {
+  const xml = readFileSync(path.join(FIXTURE_DIR, fixture), "utf8");
+  const doc = SchemeDocument.parse(xml);
+  const action = doc.launchAction();
+  if (!action) throw new Error(`Fixture ${fixture} has no <LaunchAction>`);
+  return action;
+}
+
+describe("launchActionToSettings", () => {
+  it("returns empty settings for a bare LaunchAction", () => {
+    const action = new LaunchAction();
+    expect(launchActionToSettings(action)).toEqual({ args: [], env: {} });
+  });
+
+  it("auto-injects -AppleLanguages and -AppleLocale from language + region", () => {
+    const action = new LaunchAction();
+    action.language = "he";
+    action.region = "IL";
+    expect(launchActionToSettings(action).args).toEqual(["-AppleLanguages", "(he)", "-AppleLocale", "he_IL"]);
+  });
+
+  it("emits -AppleLanguages but not -AppleLocale when only language is set", () => {
+    const action = new LaunchAction();
+    action.language = "ar";
+    expect(launchActionToSettings(action).args).toEqual(["-AppleLanguages", "(ar)"]);
+  });
+
+  it("emits no locale flags when only region is set (bare region is not a valid locale id)", () => {
+    const action = new LaunchAction();
+    action.region = "JP";
+    expect(launchActionToSettings(action).args).toEqual([]);
+  });
+
+  it("tokenizes <CommandLineArgument> rows on whitespace", () => {
+    const action = new LaunchAction();
+    action.addCommandLineArgument({ argument: "-AppleLanguages (he)" });
+    action.addCommandLineArgument({ argument: "--flag" });
+    expect(launchActionToSettings(action).args).toEqual(["-AppleLanguages", "(he)", "--flag"]);
+  });
+
+  it("skips disabled CommandLineArguments", () => {
+    const action = new LaunchAction();
+    action.addCommandLineArgument({ argument: "--keep" });
+    action.addCommandLineArgument({ argument: "--skip", isEnabled: false });
+    expect(launchActionToSettings(action).args).toEqual(["--keep"]);
+  });
+
+  it("collects enabled EnvironmentVariables and drops disabled ones", () => {
+    const action = new LaunchAction();
+    action.addEnvironmentVariable({ key: "KEEP", value: "1" });
+    action.addEnvironmentVariable({ key: "SKIP", value: "x", isEnabled: false });
+    expect(launchActionToSettings(action).env).toEqual({ KEEP: "1" });
+  });
+
+  it("extracts the discussion #197 wikipedia-ios-rtl fixture end-to-end", () => {
+    const action = loadLaunchAction("wikipedia-ios-rtl.xcscheme");
+    const { args, env } = launchActionToSettings(action);
+    // The fixture has language="he" region="IL" *and* explicit -AppleLanguages /
+    // -AppleLocale CLI args. Both flow through (Xcode keeps both; Foundation
+    // reads the first match).
+    expect(args).toContain("-WMFVisualTestBatchRecordMode");
+    expect(args.filter((a) => a === "-AppleLanguages")).toHaveLength(2);
+    expect(args.filter((a) => a === "-AppleLocale")).toHaveLength(2);
+    expect(args).toContain("(he)");
+    expect(args).toContain("he_IL");
+    expect(env).toEqual({});
+  });
+
+  it("extracts EnvironmentVariables from the signal-ios-staging fixture", () => {
+    const action = loadLaunchAction("signal-ios-staging.xcscheme");
+    const { env } = launchActionToSettings(action);
+    expect(env.OS_ACTIVITY_MODE).toBe("disable");
+    expect(env.USE_STAGING).toBe("1");
+  });
+});

--- a/src/build/utils.ts
+++ b/src/build/utils.ts
@@ -21,6 +21,8 @@ import { type QuickPickItem, showQuickPick } from "../common/quick-pick";
 import type { TaskTerminal } from "../common/tasks/types";
 import { assertUnreachable } from "../common/types";
 import type { WorkspaceStateService } from "../common/workspace-state";
+import { XcodeWorkspace } from "../common/xcode/workspace";
+import { LaunchAction } from "../common/xcode/xcscheme";
 import type { DestinationPlatform } from "../destination/constants";
 import type { DestinationsManager } from "../destination/manager";
 import type { Destination } from "../destination/types";
@@ -871,4 +873,90 @@ export async function findXcodeWorkspaceInDirectory(directory: string): Promise<
     matcher: (file) => file.name.endsWith(".xcworkspace") || file.name === "Package.swift",
   });
   return paths.length > 0 ? paths[0] : undefined;
+}
+
+/**
+ * Translate a scheme's <LaunchAction> into launch-time argv + env, mirroring
+ * what Xcode itself injects when you press Run:
+ *
+ *  - enabled <CommandLineArgument>s are appended (whitespace-split, the way
+ *    Xcode tokenizes each row so that `-AppleLanguages (he)` becomes two argv)
+ *  - enabled <EnvironmentVariable>s become entries in `env`
+ *  - the `language` / `region` attrs (Edit Scheme → Options → App Language /
+ *    App Region) become argv flags Foundation reads at launch via
+ *    NSArgumentDomain:
+ *      - `language` alone     → `-AppleLanguages (<lang>)`
+ *      - `language + region`  → `-AppleLanguages (<lang>) -AppleLocale <lang>_<region>`
+ *      - `region` alone       → nothing (a bare region code like "IL" is not
+ *                                a valid POSIX locale identifier; Xcode would
+ *                                pair it with the device's system language,
+ *                                which we can't know here. The user can add
+ *                                an explicit `-AppleLocale` CLI arg if needed.)
+ *    Discussion #197 use case.
+ */
+export function launchActionToSettings(action: LaunchAction): {
+  args: string[];
+  env: Record<string, string>;
+} {
+  const args: string[] = [];
+
+  for (const arg of action.commandLineArguments()) {
+    if (arg.isEnabled === false) continue;
+    const raw = arg.argument;
+    if (!raw) continue;
+    // Xcode splits each row on whitespace (no shell-style quote handling), so
+    // `-AppleLanguages (he)` becomes `["-AppleLanguages", "(he)"]`.
+    for (const token of raw.trim().split(/\s+/)) {
+      if (token) args.push(token);
+    }
+  }
+
+  const language = action.language;
+  const region = action.region;
+  if (language) {
+    args.push("-AppleLanguages", `(${language})`);
+  }
+  if (language && region) {
+    args.push("-AppleLocale", `${language}_${region}`);
+  }
+
+  const env: Record<string, string> = {};
+  for (const ev of action.environmentVariables()) {
+    if (ev.isEnabled === false) continue;
+    const key = ev.key;
+    const value = ev.value;
+    if (key && value !== undefined) {
+      env[key] = value;
+    }
+  }
+
+  return { args, env };
+}
+
+/**
+ * Load the scheme file for `scheme` inside `xcworkspace` and extract its
+ * <LaunchAction> args/env. Returns empty values if the scheme can't be found,
+ * has no on-disk file (default scheme), or has no <LaunchAction>.
+ */
+export async function getSchemeLaunchSettings(options: {
+  xcworkspace: string;
+  scheme: string;
+}): Promise<{ args: string[]; env: Record<string, string> }> {
+  try {
+    const workspace = await XcodeWorkspace.parseWorkspace(options.xcworkspace);
+    const scheme = await workspace.getScheme({ name: options.scheme });
+    const doc = await scheme?.getScheme();
+    const action = doc?.launchAction();
+    if (!action) {
+      return { args: [], env: {} };
+    }
+    return launchActionToSettings(action);
+  } catch (error) {
+    commonLogger.warn("Failed to read scheme launch settings; continuing without them", {
+      error: error,
+      scheme: options.scheme,
+      xcworkspace: options.xcworkspace,
+    });
+    return { args: [], env: {} };
+  }
 }


### PR DESCRIPTION
Closes #246. Editing a scheme's launch args, env vars, App Language or App Region in Xcode now takes effect when running via Sweetpad. Workspace `build.launchArgs`/`launchEnv` are appended after the scheme values.