### PR TITLE
Add opt-in hot reload via InjectionNext for simulator/macOS builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 New features, improvements and bug fixes for SweetPad are documented in this file.
 
+## [0.1.93] - 2026-05-23
+
+- Add opt-in hot reload via InjectionNext for simulator and macOS builds — source edits refresh the running app without a rebuild
+
 ## [0.1.92] - 2026-05-21
 
 - Fix extension load failure on older VS Code versions by lowering ES2024 `await using` syntax in the bundle ([#252](https://github.com/sweetpad-dev/sweetpad/issues/252))

--- a/package.json
+++ b/package.json
@@ -1153,6 +1153,16 @@
           "type": "boolean",
           "default": false,
           "description": "Run the in-extension JSON-RPC server over a Unix socket so the bundled `sweetpad` CLI (and AI agents) can read state and trigger builds from outside VS Code. See docs/dev/agent-cli.md."
+        },
+        "sweetpad.hotReload.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Launch the simulator (or macOS) build with InjectionNext pre-injected so file saves hot-reload into the running app. Requires InjectionNext.app — install it via the Tools view (opens the GitHub releases page; drag the app to /Applications). Adds `-Xlinker -interposable` and `EMIT_FRONTEND_COMMAND_LINES=YES` to the build, and sets `DYLD_INSERT_LIBRARIES` plus `INJECTION_PROJECT_ROOT` on the launched process. watchOS and physical devices are not supported."
+        },
+        "sweetpad.hotReload.dylibPath": {
+          "type": "string",
+          "default": null,
+          "description": "Override the InjectionNext `lib*Injection.dylib` path used for `DYLD_INSERT_LIBRARIES`. By default SweetPad resolves the right per-platform dylib inside `/Applications/InjectionNext.app/Contents/Resources/` (e.g. `libiphonesimulatorInjection.dylib` for iOS Simulator)."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sweetpad",
   "displayName": "SweetPad (iOS/Swift development)",
-  "version": "0.1.92",
+  "version": "0.1.93",
   "description": "Develop Swift/iOS projects in VS Code",
   "categories": [
     "Extension Packs",

--- a/src/build/hot-reload.spec.ts
+++ b/src/build/hot-reload.spec.ts
@@ -1,0 +1,192 @@
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  dylibNameFor,
+  findPackageResolvedFiles,
+  pinsContainInject,
+  platformDirNameFor,
+  prependPath,
+  sdkSupportsHotReload,
+} from "./hot-reload";
+
+describe("dylibNameFor", () => {
+  it("maps each supported destination to its lib*Injection.dylib filename", () => {
+    expect(dylibNameFor("iOSSimulator")).toBe("libiphonesimulatorInjection.dylib");
+    expect(dylibNameFor("visionOSSimulator")).toBe("libxrsimulatorInjection.dylib");
+    expect(dylibNameFor("tvOSSimulator")).toBe("libappletvsimulatorInjection.dylib");
+    expect(dylibNameFor("macOS")).toBe("libmacosxInjection.dylib");
+  });
+
+  it("returns null for watchOS and every physical device (no injection dylib ships)", () => {
+    expect(dylibNameFor("watchOSSimulator")).toBeNull();
+    expect(dylibNameFor("iOSDevice")).toBeNull();
+    expect(dylibNameFor("tvOSDevice")).toBeNull();
+    expect(dylibNameFor("watchOSDevice")).toBeNull();
+    expect(dylibNameFor("visionOSDevice")).toBeNull();
+  });
+});
+
+describe("platformDirNameFor", () => {
+  it("maps each supported destination to its Xcode <Platform>.platform dir name", () => {
+    expect(platformDirNameFor("iOSSimulator")).toBe("iPhoneSimulator");
+    expect(platformDirNameFor("visionOSSimulator")).toBe("XRSimulator");
+    expect(platformDirNameFor("tvOSSimulator")).toBe("AppleTVSimulator");
+    expect(platformDirNameFor("macOS")).toBe("MacOSX");
+  });
+
+  it("returns null for destinations we don't compute XCTest search paths for", () => {
+    expect(platformDirNameFor("watchOSSimulator")).toBeNull();
+    expect(platformDirNameFor("iOSDevice")).toBeNull();
+    expect(platformDirNameFor("tvOSDevice")).toBeNull();
+    expect(platformDirNameFor("watchOSDevice")).toBeNull();
+    expect(platformDirNameFor("visionOSDevice")).toBeNull();
+  });
+});
+
+describe("sdkSupportsHotReload", () => {
+  it.each(["iphonesimulator", "appletvsimulator", "xrsimulator", "macosx"])("accepts %s", (sdk) => {
+    expect(sdkSupportsHotReload(sdk)).toBe(true);
+  });
+
+  it.each(["iphoneos", "appletvos", "xros", "watchos", "watchsimulator", ""])("rejects %s", (sdk) => {
+    expect(sdkSupportsHotReload(sdk)).toBe(false);
+  });
+});
+
+describe("prependPath", () => {
+  it("returns the value alone when no existing path is set", () => {
+    expect(prependPath(undefined, "/a")).toBe("/a");
+  });
+
+  it("returns the value alone when the existing path is empty", () => {
+    expect(prependPath("", "/a")).toBe("/a");
+  });
+
+  it("prepends with a colon separator and preserves the existing order", () => {
+    expect(prependPath("/orig", "/new")).toBe("/new:/orig");
+    expect(prependPath("/x:/y", "/z")).toBe("/z:/x:/y");
+  });
+});
+
+describe("pinsContainInject", () => {
+  it("returns false for non-object input", () => {
+    expect(pinsContainInject(null)).toBe(false);
+    expect(pinsContainInject(undefined)).toBe(false);
+    expect(pinsContainInject(42)).toBe(false);
+    expect(pinsContainInject("string")).toBe(false);
+  });
+
+  it("returns false when pins is missing or not an array", () => {
+    expect(pinsContainInject({})).toBe(false);
+    expect(pinsContainInject({ pins: null })).toBe(false);
+    expect(pinsContainInject({ pins: "nope" })).toBe(false);
+  });
+
+  it("returns false when no pin matches the Inject repo", () => {
+    expect(
+      pinsContainInject({
+        pins: [
+          { identity: "swift-foo", location: "https://github.com/apple/swift-foo.git" },
+          { location: "https://github.com/other/Inject-Like" },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("matches the canonical repo URL with and without the .git suffix", () => {
+    expect(
+      pinsContainInject({
+        pins: [{ location: "https://github.com/krzysztofzablocki/Inject" }],
+      }),
+    ).toBe(true);
+
+    expect(
+      pinsContainInject({
+        pins: [{ location: "https://github.com/krzysztofzablocki/Inject.git" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive on the owner/repo segment", () => {
+    expect(
+      pinsContainInject({
+        pins: [{ location: "https://github.com/KrzysztofZablocki/INJECT.git" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("skips malformed pin entries and still finds a valid match later in the array", () => {
+    expect(
+      pinsContainInject({
+        pins: [
+          null,
+          "string",
+          { location: 42 },
+          { location: "https://github.com/krzysztofzablocki/Inject.git" },
+        ],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("findPackageResolvedFiles", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "sweetpad-hotreload-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns an empty list when the workspace has no Package.resolved anywhere", async () => {
+    expect(await findPackageResolvedFiles(tmpDir)).toEqual([]);
+  });
+
+  it("returns the Package.resolved at the workspace root", async () => {
+    const root = path.join(tmpDir, "Package.resolved");
+    await fs.writeFile(root, "{}");
+    expect(await findPackageResolvedFiles(tmpDir)).toEqual([root]);
+  });
+
+  it("finds Package.resolved nested under a .xcworkspace", async () => {
+    const dir = path.join(tmpDir, "App.xcworkspace", "xcshareddata", "swiftpm");
+    await fs.mkdir(dir, { recursive: true });
+    const file = path.join(dir, "Package.resolved");
+    await fs.writeFile(file, "{}");
+    expect(await findPackageResolvedFiles(tmpDir)).toEqual([file]);
+  });
+
+  it("finds Package.resolved nested under an .xcodeproj's project.xcworkspace", async () => {
+    const dir = path.join(tmpDir, "App.xcodeproj", "project.xcworkspace", "xcshareddata", "swiftpm");
+    await fs.mkdir(dir, { recursive: true });
+    const file = path.join(dir, "Package.resolved");
+    await fs.writeFile(file, "{}");
+    expect(await findPackageResolvedFiles(tmpDir)).toEqual([file]);
+  });
+
+  it("returns every Package.resolved it finds when several locations exist", async () => {
+    const root = path.join(tmpDir, "Package.resolved");
+    await fs.writeFile(root, "{}");
+
+    const wsDir = path.join(tmpDir, "App.xcworkspace", "xcshareddata", "swiftpm");
+    await fs.mkdir(wsDir, { recursive: true });
+    const wsFile = path.join(wsDir, "Package.resolved");
+    await fs.writeFile(wsFile, "{}");
+
+    expect((await findPackageResolvedFiles(tmpDir)).toSorted()).toEqual([root, wsFile].toSorted());
+  });
+
+  it("returns an empty list when the workspace directory does not exist", async () => {
+    expect(await findPackageResolvedFiles(path.join(tmpDir, "missing"))).toEqual([]);
+  });
+
+  it("ignores .xcworkspace and .xcodeproj entries that don't actually contain Package.resolved", async () => {
+    await fs.mkdir(path.join(tmpDir, "Empty.xcworkspace"));
+    await fs.mkdir(path.join(tmpDir, "Empty.xcodeproj"));
+    expect(await findPackageResolvedFiles(tmpDir)).toEqual([]);
+  });
+});

--- a/src/build/hot-reload.ts
+++ b/src/build/hot-reload.ts
@@ -1,0 +1,319 @@
+import { existsSync, promises as fs } from "node:fs";
+import path from "node:path";
+
+import { getWorkspaceConfig } from "../common/config";
+import { exec } from "../common/exec";
+import { commonLogger } from "../common/logger";
+import type { TaskTerminal } from "../common/tasks/types";
+import type { WorkspaceStateService } from "../common/workspace-state";
+import type { DestinationType } from "../destination/types";
+import { getWorkspacePath } from "./utils";
+
+const INJECT_PACKAGE_URL = "https://github.com/krzysztofzablocki/Inject";
+const INJECT_WARNING_MAX = 3;
+
+const INJECTIONNEXT_APP = "/Applications/InjectionNext.app";
+const INJECTIONNEXT_RESOURCES = `${INJECTIONNEXT_APP}/Contents/Resources`;
+
+/**
+ * Map a destination type to the InjectionNext dylib that ships inside InjectionNext.app.
+ * We use the lib*Injection.dylib files rather than the *Injection.bundle directories
+ * because DYLD_INSERT_LIBRARIES needs an actual Mach-O path. Returns null for physical
+ * devices (codesigning strips DYLD_INSERT_LIBRARIES) and for watchOS (InjectionNext
+ * does not ship a watchOS injection dylib).
+ */
+export function dylibNameFor(type: DestinationType): string | null {
+  switch (type) {
+    case "iOSSimulator":
+      return "libiphonesimulatorInjection.dylib";
+    case "visionOSSimulator":
+      return "libxrsimulatorInjection.dylib";
+    case "tvOSSimulator":
+      return "libappletvsimulatorInjection.dylib";
+    case "macOS":
+      return "libmacosxInjection.dylib";
+    case "watchOSSimulator":
+    case "iOSDevice":
+    case "tvOSDevice":
+    case "watchOSDevice":
+    case "visionOSDevice":
+      return null;
+  }
+}
+
+/**
+ * Xcode's "<Platform>.platform" directory name for a given destination, used to locate
+ * XCTest.framework and libXCTestSwiftSupport.dylib that the injection dylib depends on.
+ */
+export function platformDirNameFor(type: DestinationType): string | null {
+  switch (type) {
+    case "iOSSimulator":
+      return "iPhoneSimulator";
+    case "visionOSSimulator":
+      return "XRSimulator";
+    case "tvOSSimulator":
+      return "AppleTVSimulator";
+    case "macOS":
+      return "MacOSX";
+    default:
+      return null;
+  }
+}
+
+let cachedDeveloperDir: string | null | undefined = undefined;
+
+/**
+ * Resolve the active Xcode developer dir (the prefix used by xcodebuild and friends),
+ * preferring the DEVELOPER_DIR env var if set, otherwise falling back to `xcode-select -p`.
+ * Cached for the process lifetime.
+ */
+async function getXcodeDeveloperDir(): Promise<string | null> {
+  if (cachedDeveloperDir !== undefined) return cachedDeveloperDir;
+  if (process.env.DEVELOPER_DIR) {
+    cachedDeveloperDir = process.env.DEVELOPER_DIR;
+    return cachedDeveloperDir;
+  }
+  try {
+    const out = await exec({ command: "xcode-select", args: ["-p"] });
+    cachedDeveloperDir = out.trim() || null;
+    return cachedDeveloperDir;
+  } catch (error) {
+    commonLogger.warn("Hot reload: failed to resolve Xcode developer dir via xcode-select", { error: error });
+    cachedDeveloperDir = null;
+    return null;
+  }
+}
+
+export function isHotReloadEnabled(): boolean {
+  return getWorkspaceConfig("hotReload.enabled") ?? false;
+}
+
+/**
+ * Whether InjectionNext can hot-reload binaries built for this SDK. Limited to the
+ * simulator slices and macOS — physical-device builds strip DYLD_INSERT_LIBRARIES via
+ * codesigning, and InjectionNext doesn't ship a watchOS dylib. Used to skip the
+ * `-Xlinker -interposable` / EMIT_FRONTEND_COMMAND_LINES build settings on unsupported
+ * SDKs so they don't pay for an injection they can never receive.
+ */
+export function sdkSupportsHotReload(sdk: string): boolean {
+  return sdk === "iphonesimulator" || sdk === "appletvsimulator" || sdk === "xrsimulator" || sdk === "macosx";
+}
+
+/**
+ * Resolve the absolute path to the InjectionNext dylib for a destination type, or null
+ * when hot reload is off, the dylib does not exist, or the destination is unsupported.
+ */
+export function resolveInjectionDylib(destinationType: DestinationType): string | null {
+  if (!isHotReloadEnabled()) return null;
+
+  const override = getWorkspaceConfig("hotReload.dylibPath");
+  if (override) {
+    if (!existsSync(override)) {
+      commonLogger.warn("Hot reload: configured dylibPath does not exist", { path: override });
+      return null;
+    }
+    return override;
+  }
+
+  const dylibName = dylibNameFor(destinationType);
+  if (!dylibName) {
+    if (destinationType === "watchOSSimulator") {
+      commonLogger.warn("Hot reload: InjectionNext does not ship a watchOS dylib, skipping injection", {
+        destination: destinationType,
+      });
+    } else {
+      commonLogger.warn("Hot reload: unsupported destination, skipping injection", {
+        destination: destinationType,
+      });
+    }
+    return null;
+  }
+
+  const dylibPath = path.join(INJECTIONNEXT_RESOURCES, dylibName);
+  if (!existsSync(dylibPath)) {
+    commonLogger.warn("Hot reload: InjectionNext.app is not installed", {
+      expected: dylibPath,
+      hint: "Install via Tools view or download from https://github.com/johnno1962/InjectionNext/releases and drag InjectionNext.app to /Applications.",
+    });
+    return null;
+  }
+  return dylibPath;
+}
+
+/**
+ * Resolve the Platform-specific XCTest search paths for a destination, so dyld can find
+ * @rpath/XCTest.framework and @rpath/libXCTestSwiftSupport.dylib that the injection dylib
+ * links against. The InjectionNext binaries were built against /Applications/Xcode.app
+ * paths that won't exist on machines with a versioned or relocated Xcode install.
+ */
+async function getXctestSearchPaths(
+  destinationType: DestinationType,
+): Promise<{ frameworkPath: string; libraryPath: string } | null> {
+  const platform = platformDirNameFor(destinationType);
+  if (!platform) return null;
+  const developerDir = await getXcodeDeveloperDir();
+  if (!developerDir) return null;
+  const platformDev = path.join(developerDir, "Platforms", `${platform}.platform`, "Developer");
+  // XCTest lives in Library/Frameworks but XCTestCore + XCTAutomationSupport are in
+  // Library/PrivateFrameworks; we need both on DYLD_FRAMEWORK_PATH for the injection
+  // dylib's whole dep graph to resolve.
+  return {
+    frameworkPath: [
+      path.join(platformDev, "Library", "Frameworks"),
+      path.join(platformDev, "Library", "PrivateFrameworks"),
+    ].join(":"),
+    libraryPath: path.join(platformDev, "usr", "lib"),
+  };
+}
+
+export function prependPath(existing: string | undefined, value: string): string {
+  return existing ? `${value}:${existing}` : value;
+}
+
+/**
+ * Enumerate likely Package.resolved locations for the current workspace:
+ *   - <workspace>/Package.resolved                                    (pure SPM root)
+ *   - <workspace>/*.xcworkspace/xcshareddata/swiftpm/Package.resolved
+ *   - <workspace>/*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+ */
+export async function findPackageResolvedFiles(workspace: string): Promise<string[]> {
+  const out: string[] = [];
+  const rootResolved = path.join(workspace, "Package.resolved");
+  if (existsSync(rootResolved)) out.push(rootResolved);
+
+  let entries: string[] = [];
+  try {
+    entries = await fs.readdir(workspace);
+  } catch {
+    return out;
+  }
+
+  for (const entry of entries) {
+    if (entry.endsWith(".xcworkspace")) {
+      const p = path.join(workspace, entry, "xcshareddata", "swiftpm", "Package.resolved");
+      if (existsSync(p)) out.push(p);
+    } else if (entry.endsWith(".xcodeproj")) {
+      const p = path.join(workspace, entry, "project.xcworkspace", "xcshareddata", "swiftpm", "Package.resolved");
+      if (existsSync(p)) out.push(p);
+    }
+  }
+  return out;
+}
+
+export function pinsContainInject(json: unknown): boolean {
+  if (!json || typeof json !== "object") return false;
+  const pins = (json as { pins?: unknown }).pins;
+  if (!Array.isArray(pins)) return false;
+  return pins.some((pin) => {
+    if (!pin || typeof pin !== "object") return false;
+    const location = (pin as { location?: unknown }).location;
+    if (typeof location !== "string") return false;
+    return /krzysztofzablocki\/Inject(\.git)?$/i.test(location);
+  });
+}
+
+/**
+ * Print to the run task's terminal if hot reload is on but the project doesn't depend
+ * on the Inject package. SwiftUI projects need it to redraw on injection; UIKit-only
+ * projects can ignore the warning. Silent when no Package.resolved exists at all
+ * (likely a pre-resolve state, or a project that doesn't use SPM yet).
+ *
+ * Capped at INJECT_WARNING_MAX shows per workspace so it doesn't nag forever for
+ * UIKit-only projects that legitimately don't need Inject.
+ */
+async function warnIfInjectMissing(terminal: TaskTerminal, state: WorkspaceStateService): Promise<void> {
+  const shown = state.get("hotReload.injectWarningShownCount") ?? 0;
+  if (shown >= INJECT_WARNING_MAX) return;
+
+  let workspace: string;
+  try {
+    workspace = getWorkspacePath();
+  } catch {
+    return;
+  }
+
+  const files = await findPackageResolvedFiles(workspace);
+  if (files.length === 0) return;
+
+  for (const file of files) {
+    try {
+      const text = await fs.readFile(file, "utf-8");
+      if (pinsContainInject(JSON.parse(text))) return;
+    } catch {
+      // Unreadable / not JSON — skip.
+    }
+  }
+
+  const remaining = INJECT_WARNING_MAX - shown - 1;
+  const suffix = remaining > 0 ? ` (${remaining} reminder${remaining === 1 ? "" : "s"} left)` : " (final reminder)";
+
+  terminal.write(`[sweetpad] Hot reload: \`Inject\` package not found in Package.resolved.${suffix}`, {
+    color: "yellow",
+    newLine: true,
+  });
+  terminal.write(
+    "[sweetpad] SwiftUI views won't refresh on save until you add Inject as a Swift Package dependency",
+    { color: "yellow", newLine: true },
+  );
+  terminal.write(`[sweetpad]   ${INJECT_PACKAGE_URL}`, { color: "yellow", newLine: true });
+  terminal.write(
+    "[sweetpad] and annotate views with `@ObserveInjection var inject` + `.enableInjection()`.",
+    { color: "yellow", newLine: true },
+  );
+  terminal.write("[sweetpad] UIKit-only apps can ignore this warning.", {
+    color: "yellow",
+    newLine: true,
+  });
+
+  state.update("hotReload.injectWarningShownCount", shown + 1);
+}
+
+/**
+ * Return a launchEnv augmented with DYLD_INSERT_LIBRARIES, INJECTION_PROJECT_ROOT, and
+ * the DYLD_FRAMEWORK_PATH / DYLD_LIBRARY_PATH needed for the injection dylib's XCTest
+ * dependencies to resolve. Pass-through when hot reload is off or unsupported.
+ */
+export async function withHotReloadLaunchEnv(
+  terminal: TaskTerminal,
+  state: WorkspaceStateService,
+  launchEnv: Record<string, string>,
+  destinationType: DestinationType,
+): Promise<Record<string, string>> {
+  const dylib = resolveInjectionDylib(destinationType);
+  if (!dylib) return launchEnv;
+
+  await warnIfInjectMissing(terminal, state);
+
+  const env: Record<string, string> = {
+    ...launchEnv,
+    DYLD_INSERT_LIBRARIES: dylib,
+    INJECTION_PROJECT_ROOT: getWorkspacePath(),
+  };
+
+  const xctest = await getXctestSearchPaths(destinationType);
+  if (xctest) {
+    env.DYLD_FRAMEWORK_PATH = prependPath(launchEnv.DYLD_FRAMEWORK_PATH, xctest.frameworkPath);
+    env.DYLD_LIBRARY_PATH = prependPath(launchEnv.DYLD_LIBRARY_PATH, xctest.libraryPath);
+  }
+  return env;
+}
+
+/**
+ * Best-effort start of the InjectionNext menu-bar app before launch. Silent if the app
+ * isn't installed (the launch path already warned via resolveInjectionDylib).
+ */
+export async function ensureInjectionAppRunning(): Promise<void> {
+  if (!isHotReloadEnabled()) return;
+  if (!existsSync(INJECTIONNEXT_APP)) return;
+  try {
+    await exec({ command: "pgrep", args: ["-x", "InjectionNext"] });
+    return;
+  } catch {
+    // pgrep exits non-zero when no match; fall through to launch.
+  }
+  try {
+    await exec({ command: "open", args: ["-g", "-a", INJECTIONNEXT_APP] });
+  } catch (error) {
+    commonLogger.warn("Hot reload: failed to auto-start InjectionNext", { error: error });
+  }
+}

--- a/src/build/manager.ts
+++ b/src/build/manager.ts
@@ -35,6 +35,12 @@ import type { ProgressStatusBar } from "../system/status-bar";
 import { BUILD_TASK_PROBLEM_MATCHERS } from "./constants";
 import type { DiagnosticsManager } from "./diagnostics";
 import type { ParsedDiagnostic } from "./diagnostics-parser";
+import {
+  ensureInjectionAppRunning,
+  isHotReloadEnabled,
+  sdkSupportsHotReload,
+  withHotReloadLaunchEnv,
+} from "./hot-reload";
 import type { BuildTreeItem } from "./tree";
 import {
   XcodeCommandBuilder,
@@ -586,6 +592,8 @@ export class BuildManager {
     }
 
     this.progress.updateText(`Running "${options.scheme}" on Mac`);
+    await ensureInjectionAppRunning();
+    const launchEnv = await withHotReloadLaunchEnv(terminal, this.workspace, options.launchEnv, "macOS");
     await terminal.runGroup(async (group) => {
       const logSidecar = new MacOSLogSidecar(group, {
         bundleId: buildSettings.bundleIdentifier,
@@ -598,7 +606,7 @@ export class BuildManager {
         args: options.launchArgs,
         // NSUnbufferedIO is a no-op when stdout is a tty (the v3/node-pty path), but acts as a
         // safety net for the v2 fallback where stdout is a plain pipe and Foundation block-buffers print().
-        env: { NSUnbufferedIO: "YES", ...options.launchEnv },
+        env: { NSUnbufferedIO: "YES", ...launchEnv },
         pty: true,
       });
       await main.wait();
@@ -690,6 +698,13 @@ export class BuildManager {
 
     // Run app
     this.progress.updateText(`Running "${options.scheme}" on "${simulator.name}"`);
+    await ensureInjectionAppRunning();
+    const childEnv = await withHotReloadLaunchEnv(
+      terminal,
+      this.workspace,
+      options.launchEnv,
+      options.destination.type,
+    );
     await terminal.runGroup(async (group) => {
       const logSidecar = new SimulatorLogSidecar(group, {
         simulatorUdid: simulator.udid,
@@ -702,7 +717,7 @@ export class BuildManager {
         command: "xcrun",
         args: launchArgs,
         // simctl strips SIMCTL_CHILD_ and passes the rest to the launched app.
-        env: Object.fromEntries(Object.entries(options.launchEnv).map(([k, v]) => [`SIMCTL_CHILD_${k}`, v])),
+        env: Object.fromEntries(Object.entries(childEnv).map(([k, v]) => [`SIMCTL_CHILD_${k}`, v])),
         pty: true,
       });
       await main.wait();
@@ -933,6 +948,17 @@ export class BuildManager {
       // project's ARCHS setting.
       // It speeds up compile times, especially in Debug, because Xcode skips generating unused slices.
       command.addBuildSettings("ONLY_ACTIVE_ARCH", "YES");
+    }
+
+    // InjectionNext needs `-Xlinker -interposable` so dyld can swap symbols at runtime,
+    // and EMIT_FRONTEND_COMMAND_LINES=YES so it can recover compile commands from the
+    // build logs when no Xcode IDE is supervising the build (required for Xcode 16.3+).
+    // $(inherited) keeps whatever the project already sets for OTHER_LDFLAGS. Skipped
+    // for SDKs that InjectionNext can't inject into (physical devices, watchOS), so
+    // device builds don't pay for the extra relocations.
+    if (isHotReloadEnabled() && sdkSupportsHotReload(options.sdk)) {
+      command.addBuildSettings("OTHER_LDFLAGS", "$(inherited) -Xlinker -interposable");
+      command.addBuildSettings("EMIT_FRONTEND_COMMAND_LINES", "YES");
     }
 
     command.addParameters("-scheme", options.scheme);

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -47,6 +47,8 @@ type Config = {
   "tuist.generate.env": { [key: string]: string | null };
   "testing.configuration": string;
   "server.enabled": boolean;
+  "hotReload.enabled": boolean;
+  "hotReload.dylibPath": string | null;
 };
 
 type ConfigKey = keyof Config;

--- a/src/common/workspace-state.ts
+++ b/src/common/workspace-state.ts
@@ -48,6 +48,7 @@ export type WorkspaceTypes = {
   "testing.xcodeConfiguration": string;
   "testing.xcodeDestination": SelectedDestination;
   "testing.xcodeScheme": string;
+  "hotReload.injectWarningShownCount": number;
 };
 
 export type WorkspaceStateKey = keyof WorkspaceTypes;

--- a/src/tools/commands.ts
+++ b/src/tools/commands.ts
@@ -6,10 +6,19 @@ import type { ToolTreeItem } from "./tree.js";
 import { askTool } from "./utils.js";
 
 /**
- * Command to install tool from the tool tree view in the sidebar using brew
+ * Command to install a tool from the Tools view. Either runs an install command in a
+ * task terminal (for Homebrew-installable tools) or opens an external URL (for tools
+ * like InjectionNext that ship as a .app outside any package manager).
  */
 export async function installToolCommand(deps: AppDeps, item?: ToolTreeItem) {
   const tool = item?.tool ?? (await askTool({ title: "Select tool to install" }));
+  const install = tool.install;
+
+  if (install.type === "openUrl") {
+    await vscode.env.openExternal(vscode.Uri.parse(install.url));
+    deps.toolsManager.refresh();
+    return;
+  }
 
   deps.progressStatusBar.updateText("Installing tool");
   await runTask(deps.execution, {
@@ -19,8 +28,8 @@ export async function installToolCommand(deps: AppDeps, item?: ToolTreeItem) {
     lock: "sweetpad.tools.install",
     callback: async (terminal) => {
       await terminal.execute({
-        command: tool.install.command,
-        args: tool.install.args,
+        command: install.command,
+        args: install.args,
         env: {
           // We don't run the command in ptty, that's why we need to tell homebrew to use color
           // output explicitly

--- a/src/tools/constants.ts
+++ b/src/tools/constants.ts
@@ -1,3 +1,7 @@
+export type ToolInstall =
+  | { type: "shell"; command: string; args: string[] }
+  | { type: "openUrl"; url: string };
+
 export type Tool = {
   id: string;
   label: string;
@@ -5,10 +9,7 @@ export type Tool = {
     command: string;
     args: string[];
   };
-  install: {
-    command: string;
-    args: string[];
-  };
+  install: ToolInstall;
   documentation: string;
 };
 
@@ -21,6 +22,7 @@ export const TOOLS: Tool[] = [
       args: ["--version"],
     },
     install: {
+      type: "shell",
       command: "/bin/bash",
       args: ["-c", "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"],
     },
@@ -34,6 +36,7 @@ export const TOOLS: Tool[] = [
       args: ["--version"],
     },
     install: {
+      type: "shell",
       command: "brew",
       args: ["install", "swift-format"],
     },
@@ -47,6 +50,7 @@ export const TOOLS: Tool[] = [
       args: ["--version"],
     },
     install: {
+      type: "shell",
       command: "brew",
       args: ["install", "xcodegen"],
     },
@@ -60,6 +64,7 @@ export const TOOLS: Tool[] = [
       args: ["--version"],
     },
     install: {
+      type: "shell",
       command: "brew",
       args: ["install", "swiftlint"],
     },
@@ -73,6 +78,7 @@ export const TOOLS: Tool[] = [
       args: ["--version"],
     },
     install: {
+      type: "shell",
       command: "brew",
       args: ["install", "xcbeautify"],
     },
@@ -86,6 +92,7 @@ export const TOOLS: Tool[] = [
       args: ["--help"],
     },
     install: {
+      type: "shell",
       command: "brew",
       args: ["install", "xcode-build-server"],
     },
@@ -99,6 +106,7 @@ export const TOOLS: Tool[] = [
       args: ["--version"],
     },
     install: {
+      type: "shell",
       command: "brew",
       args: ["install", "ios-deploy"],
     },
@@ -112,9 +120,25 @@ export const TOOLS: Tool[] = [
       args: ["version"],
     },
     install: {
+      type: "shell",
       command: "brew",
       args: ["install", "--cask", "tuist"],
     },
     documentation: "https://docs.tuist.io/",
+  },
+  {
+    id: "injectionnext",
+    label: "InjectionNext",
+    check: {
+      command: "test",
+      args: ["-d", "/Applications/InjectionNext.app"],
+    },
+    // InjectionNext is not on Homebrew; the install action opens the GitHub releases
+    // page so the user can grab the ZIP and drop InjectionNext.app into /Applications.
+    install: {
+      type: "openUrl",
+      url: "https://github.com/johnno1962/InjectionNext/releases/latest",
+    },
+    documentation: "https://github.com/johnno1962/InjectionNext",
   },
 ];

--- a/src/tools/tree.ts
+++ b/src/tools/tree.ts
@@ -56,8 +56,6 @@ export class ToolTreeProvider implements vscode.TreeDataProvider<ToolTreeItem> {
 }
 
 export class ToolTreeItem extends vscode.TreeItem {
-  commandName: string;
-  commandArgs: string[];
   documentation: string;
   tool: Tool;
 
@@ -71,8 +69,6 @@ export class ToolTreeItem extends vscode.TreeItem {
 
     this.contextValue = options.isInstalled ? "installed" : "notInstalled";
     this.documentation = options.tool.documentation;
-    this.commandName = options.tool.install.command;
-    this.commandArgs = options.tool.install.args;
     this.tool = options.tool;
 
     if (options.isInstalled) {


### PR DESCRIPTION
Opt-in `sweetpad.hotReload.enabled` toggle that launches simulator and macOS builds with InjectionNext pre-injected, so code edits hot-reload into the running app without a rebuild. Device and watchOS targets are no-ops; SwiftUI projects need the `Inject` Swift package (a one-time warning fires if missing).