### PR TITLE
Close the scheme-discovery gaps vs xcodebuild in the Rust resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 New features, improvements and bug fixes for SweetPad are documented in this file.
 
+## [Unreleased]
+
+- List Xcode's autocreated per-target schemes for projects/workspaces that have no `.xcscheme` files on disk (fresh or never-shared projects previously showed an empty scheme list)
+- Discover and resolve per-user schemes stored under `xcuserdata/<user>.xcuserdatad/xcschemes`, matching `xcodebuild -list` and `-showBuildSettings -scheme`
+- Resolve build settings for schemes stored in the workspace bundle's own `xcshareddata`/`xcuserdata` (they were listed but failed to launch), dispatching each buildable to the member project named by its `ReferencedContainer`
+
 ## [0.2.0] - 2026-06-10
 
 - Add built-in Swift code intelligence powered by a bundled Build Server Protocol (BSP) server: SweetPad feeds sourcekit-lsp accurate per-file compiler arguments, builds dependency modules on demand, and refreshes live when you switch scheme or configuration — with `SweetPad: Setup BSP` and `SweetPad: Diagnose BSP` commands, a status-bar control, and a first-run prompt

--- a/sweetpad-lib/src/build_context.rs
+++ b/sweetpad-lib/src/build_context.rs
@@ -143,10 +143,10 @@ pub struct BuildPlan {
     /// One [`ResolveQuery`] per scheme `BuildActionEntry` whose target
     /// lives in this project. Order matches the scheme's declared order.
     pub entries: Vec<ResolveQuery>,
-    /// Buildables the planner couldn't resolve to a target in this
-    /// context — typically cross-container references in a workspace
-    /// scheme. Multi-project workspaces aren't supported yet; callers
-    /// see what was left behind here.
+    /// Buildables that don't belong to this context's project — typically
+    /// cross-container references in a workspace scheme. They resolve when
+    /// the caller plans the same scheme against their own project (see
+    /// `build_settings::resolve_build_settings`'s workspace loop).
     pub skipped: Vec<BuildableRef>,
 }
 
@@ -263,7 +263,9 @@ impl BuildContext {
         let mut skipped = Vec::new();
         for entry in &scheme.build_entries {
             let name = &entry.buildable.blueprint_name;
-            if self.project.targets.iter().any(|t| t.name == *name) {
+            let owned = self.project.targets.iter().any(|t| t.name == *name)
+                && container_matches(&entry.buildable.container, &self.project.path);
+            if owned {
                 let mut q = ResolveQuery::new(name, configuration, sdk, arch);
                 if let Some(d) = destination {
                     q = q.with_destination(d.clone());
@@ -502,6 +504,23 @@ impl BuildContext {
             ""
         };
         Some(format!("/{wrapper}.app{contents}/PlugIns"))
+    }
+}
+
+/// Whether a scheme entry's `ReferencedContainer` (e.g.
+/// `container:Sub/Foo.xcodeproj`) plausibly refers to this context's project.
+/// The container path is relative to the scheme's own anchor directory, which
+/// the planner doesn't know, so compare by `.xcodeproj` basename — enough to
+/// keep a workspace scheme's buildable out of a *different* project that
+/// happens to own a same-named target. An entry with no parseable container
+/// matches permissively.
+fn container_matches(container: &str, project_path: &Path) -> bool {
+    let Some(rest) = container.strip_prefix("container:") else {
+        return true;
+    };
+    match Path::new(rest).file_name() {
+        Some(basename) => project_path.file_name() == Some(basename),
+        None => true,
     }
 }
 

--- a/sweetpad-lib/src/build_settings.rs
+++ b/sweetpad-lib/src/build_settings.rs
@@ -62,6 +62,78 @@ pub struct TargetSettings {
     pub settings: BTreeMap<String, String>,
 }
 
+/// What the `scheme` / `target` selector resolved to, decided once up front
+/// (see [`resolve_selection`]) and then planned against each project.
+enum Selection {
+    /// A parsed `.xcscheme` found in the workspace bundle or a member project
+    /// (shared or per-user). Plans one query per BuildAction buildable, each
+    /// resolved in the member project that owns it.
+    Scheme {
+        name: String,
+        // Boxed: a parsed Scheme dwarfs the other variants' Strings.
+        parsed: Box<scheme::Scheme>,
+    },
+    /// An explicit `target` query.
+    Target(String),
+    /// `scheme` was requested but no `.xcscheme` file exists anywhere —
+    /// Xcode's autocreated per-target scheme, which builds the same-named
+    /// target.
+    AutoScheme(String),
+}
+
+impl Selection {
+    /// What the final "nothing matched" error should call the selector.
+    fn describe(&self) -> String {
+        match self {
+            Selection::Scheme { name, .. } | Selection::AutoScheme(name) => {
+                format!("scheme {name}")
+            }
+            Selection::Target(t) => format!("target {t}"),
+        }
+    }
+
+    /// Target-style queries stop at the first project that resolves them;
+    /// scheme queries visit every member project (a workspace scheme can
+    /// build targets across several).
+    fn stops_at_first_match(&self) -> bool {
+        !matches!(self, Selection::Scheme { .. })
+    }
+}
+
+/// Resolve the `scheme` / `target` choice once, before the per-project loop.
+/// A scheme file is looked up across every container that can hold one — the
+/// workspace bundle itself, then each member project, shared then per-user
+/// directories (mirroring where xcodebuild finds schemes). A scheme with no
+/// file anywhere falls back to [`Selection::AutoScheme`].
+fn resolve_selection(
+    opts: &BuildSettingsOptions,
+    projects: &[PathBuf],
+) -> Result<Selection, String> {
+    if let Some(name) = opts.scheme.as_deref() {
+        let containers = opts
+            .workspace
+            .as_deref()
+            .into_iter()
+            .chain(projects.iter().map(PathBuf::as_path));
+        for container in containers {
+            let Some(path) = scheme::find_scheme_file(container, name) else {
+                continue;
+            };
+            let parsed = scheme::parse_file(&path)
+                .map_err(|e| format!("failed to parse scheme {name} at {}: {e}", path.display()))?;
+            return Ok(Selection::Scheme {
+                name: name.to_string(),
+                parsed: Box::new(parsed),
+            });
+        }
+        return Ok(Selection::AutoScheme(name.to_string()));
+    }
+    if let Some(target) = opts.target.as_deref() {
+        return Ok(Selection::Target(target.to_string()));
+    }
+    Err("either scheme or target is required".into())
+}
+
 /// Resolve build settings for the selected scheme/target across the supplied
 /// project/workspace. Mirrors `xcodebuild -showBuildSettings`.
 pub fn resolve_build_settings(opts: &BuildSettingsOptions) -> Result<Vec<TargetSettings>, String> {
@@ -72,15 +144,13 @@ pub fn resolve_build_settings(opts: &BuildSettingsOptions) -> Result<Vec<TargetS
         opts.catalog_cache.as_deref(),
     )?;
     let projects = resolve_project_paths(opts.project.as_deref(), opts.workspace.as_deref())?;
-
-    let want_scheme = opts.scheme.as_deref();
-    let want_target = opts.target.as_deref();
+    let selection = resolve_selection(opts, &projects)?;
 
     if projects.len() == 1 {
         // Single project: bubble up the underlying error directly so callers
         // get xcodebuild-equivalent messages ("no target named …").
         let ctx = build_one_context(&projects[0], catalog.as_ref(), opts.xcconfig.as_deref())?;
-        let queries = build_queries(&ctx, opts, want_scheme, want_target);
+        let queries = build_queries(&ctx, opts, &selection);
         let mut out = Vec::new();
         for query in queries {
             let resolved = ctx.resolve(&query).map_err(|e| e.to_string())?;
@@ -98,7 +168,7 @@ pub fn resolve_build_settings(opts: &BuildSettingsOptions) -> Result<Vec<TargetS
         let mut out = Vec::new();
         for project_path in &projects {
             let ctx = build_one_context(project_path, catalog.as_ref(), opts.xcconfig.as_deref())?;
-            let queries = build_queries(&ctx, opts, want_scheme, want_target);
+            let queries = build_queries(&ctx, opts, &selection);
             for query in queries {
                 if let Ok(r) = ctx.resolve(&query) {
                     out.push(TargetSettings {
@@ -107,17 +177,14 @@ pub fn resolve_build_settings(opts: &BuildSettingsOptions) -> Result<Vec<TargetS
                     });
                 }
             }
-            if !out.is_empty() && want_scheme.is_none() {
+            if !out.is_empty() && selection.stops_at_first_match() {
                 break;
             }
         }
         if out.is_empty() {
-            let needle = want_target
-                .map(|t| format!("target {t}"))
-                .or_else(|| want_scheme.map(|s| format!("scheme {s}")))
-                .unwrap_or_default();
             return Err(format!(
-                "no target matched {needle} across the supplied workspace"
+                "no target matched {} across the supplied workspace",
+                selection.describe()
             ));
         }
         project_keys(&mut out, opts.keys.as_deref());
@@ -139,8 +206,7 @@ pub fn resolve_compiler_arguments(
         opts.catalog_cache.as_deref(),
     )?;
     let projects = resolve_project_paths(opts.project.as_deref(), opts.workspace.as_deref())?;
-    let want_scheme = opts.scheme.as_deref();
-    let want_target = opts.target.as_deref();
+    let selection = resolve_selection(opts, &projects)?;
 
     let swift_opts = catalog
         .as_ref()
@@ -162,7 +228,7 @@ pub fn resolve_compiler_arguments(
     let mut out = Vec::new();
     for project_path in &projects {
         let ctx = build_one_context(project_path, catalog.as_ref(), opts.xcconfig.as_deref())?;
-        for query in build_queries(&ctx, opts, want_scheme, want_target) {
+        for query in build_queries(&ctx, opts, &selection) {
             match ctx.resolve(&query) {
                 Ok(resolved) => {
                     let sources = project::target_source_files(&ctx.project.path, &query.target)
@@ -198,16 +264,12 @@ pub fn resolve_compiler_arguments(
                 Err(_) => {}
             }
         }
-        if !out.is_empty() && want_scheme.is_none() {
+        if !out.is_empty() && selection.stops_at_first_match() {
             break;
         }
     }
     if out.is_empty() {
-        let needle = want_target
-            .map(|t| format!("target {t}"))
-            .or_else(|| want_scheme.map(|s| format!("scheme {s}")))
-            .unwrap_or_default();
-        return Err(format!("no target matched {needle}"));
+        return Err(format!("no target matched {}", selection.describe()));
     }
     Ok(out)
 }
@@ -248,12 +310,10 @@ pub fn resolve_file_arguments(
         .unwrap_or("");
     let projects = resolve_project_paths(opts.project.as_deref(), opts.workspace.as_deref())?;
 
+    let selection = Selection::Target(target.to_string());
     for project_path in &projects {
         let ctx = build_one_context(project_path, catalog.as_ref(), opts.xcconfig.as_deref())?;
-        let Some(query) = build_queries(&ctx, opts, None, Some(target))
-            .into_iter()
-            .next()
-        else {
+        let Some(query) = build_queries(&ctx, opts, &selection).into_iter().next() else {
             continue;
         };
         let Ok(resolved) = ctx.resolve(&query) else {
@@ -476,14 +536,15 @@ fn build_one_context(
     Ok(ctx)
 }
 
-/// Decide which target(s) to resolve, given the `scheme` or `target` choice.
-/// For `scheme`, look up the scheme XML on disk under the project's
-/// `xcshareddata/xcschemes/`.
+/// Turn the resolved [`Selection`] into the [`ResolveQuery`]s for one project
+/// context. A scheme plans one query per BuildAction buildable owned by this
+/// project (cross-container buildables resolve when the caller visits their
+/// own project); a target — explicit or an autocreated scheme's — is a single
+/// direct query.
 fn build_queries(
     ctx: &BuildContext,
     opts: &BuildSettingsOptions,
-    want_scheme: Option<&str>,
-    want_target: Option<&str>,
+    selection: &Selection,
 ) -> Vec<ResolveQuery> {
     let destination = opts.destination.as_ref();
     // A bound destination supplies the SDK + active arch (mirroring xcodebuild,
@@ -493,31 +554,26 @@ fn build_queries(
         None => (opts.sdk.as_str(), opts.arch.as_str()),
     };
     let mut queries = Vec::new();
-    if let Some(scheme_name) = want_scheme {
-        let scheme_path = ctx
-            .project
-            .path
-            .join("xcshareddata/xcschemes")
-            .join(format!("{scheme_name}.xcscheme"));
-        let Ok(parsed) = scheme::parse_file(&scheme_path) else {
-            return queries;
-        };
-        let plan = ctx.plan_build(&parsed, &opts.configuration, sdk, arch, destination);
-        for mut q in plan.entries {
+    match selection {
+        Selection::Scheme { parsed, .. } => {
+            let plan = ctx.plan_build(parsed, &opts.configuration, sdk, arch, destination);
+            for mut q in plan.entries {
+                if let Some(p) = &opts.derived_data_path {
+                    q = q.with_derived_data_path(p.clone());
+                }
+                queries.push(q);
+            }
+        }
+        Selection::Target(target_name) | Selection::AutoScheme(target_name) => {
+            let mut q = ResolveQuery::new(target_name, &opts.configuration, sdk, arch);
+            if let Some(d) = destination {
+                q = q.with_destination(d.clone());
+            }
             if let Some(p) = &opts.derived_data_path {
                 q = q.with_derived_data_path(p.clone());
             }
             queries.push(q);
         }
-    } else if let Some(target_name) = want_target {
-        let mut q = ResolveQuery::new(target_name, &opts.configuration, sdk, arch);
-        if let Some(d) = destination {
-            q = q.with_destination(d.clone());
-        }
-        if let Some(p) = &opts.derived_data_path {
-            q = q.with_derived_data_path(p.clone());
-        }
-        queries.push(q);
     }
     queries
 }

--- a/sweetpad-lib/src/node.rs
+++ b/sweetpad-lib/src/node.rs
@@ -42,7 +42,8 @@ pub fn xcode_version() -> XcodeVersion {
     }
 }
 
-/// A single `.xcodeproj`'s targets, configurations, and shared schemes.
+/// A single `.xcodeproj`'s targets, configurations, and schemes (shared +
+/// per-user, or autocreated per-target when no scheme file exists).
 /// Mirrors `xcodebuild -list -project`.
 #[napi(object)]
 pub struct ProjectInfo {
@@ -52,7 +53,7 @@ pub struct ProjectInfo {
     pub schemes: Vec<String>,
 }
 
-/// List a `.xcodeproj`'s targets, configurations, and shared schemes.
+/// List a `.xcodeproj`'s targets, configurations, and schemes.
 #[napi]
 pub fn list_project(path: String) -> napi::Result<ProjectInfo> {
     let project = project::open(Path::new(&path)).map_err(to_napi_err)?;
@@ -64,7 +65,9 @@ pub fn list_project(path: String) -> napi::Result<ProjectInfo> {
     })
 }
 
-/// A `.xcworkspace`'s declared `.xcodeproj` paths and merged shared schemes.
+/// A `.xcworkspace`'s declared `.xcodeproj` paths and merged schemes (the
+/// workspace bundle's own plus every member project's, shared + per-user,
+/// or autocreated per-target when no scheme file exists anywhere).
 /// Mirrors `xcodebuild -list -workspace`, plus the `projects` paths.
 #[napi(object)]
 pub struct WorkspaceInfo {
@@ -74,7 +77,7 @@ pub struct WorkspaceInfo {
     pub schemes: Vec<String>,
 }
 
-/// List a `.xcworkspace`'s member projects and merged shared schemes.
+/// List a `.xcworkspace`'s member projects and merged schemes.
 #[napi]
 pub fn list_workspace(path: String) -> napi::Result<WorkspaceInfo> {
     let ws = workspace::open(Path::new(&path)).map_err(to_napi_err)?;
@@ -95,9 +98,10 @@ fn is_workspace(path: &Path) -> bool {
     path.extension().and_then(|e| e.to_str()) == Some("xcworkspace")
 }
 
-/// Scheme names for a `.xcodeproj` or `.xcworkspace`. For a workspace, the
-/// merged shared schemes across member projects (sorted, like
-/// `xcodebuild -list -workspace`).
+/// Scheme names for a `.xcodeproj` or `.xcworkspace` — shared and per-user
+/// scheme files, falling back to autocreated per-target schemes when none
+/// exist. For a workspace, merged across the bundle and its member projects
+/// (sorted, like `xcodebuild -list -workspace`).
 #[napi]
 pub fn schemes(path: String) -> napi::Result<Vec<String>> {
     let p = Path::new(&path);

--- a/sweetpad-lib/src/project.rs
+++ b/sweetpad-lib/src/project.rs
@@ -22,8 +22,11 @@ pub struct Project {
     pub targets: Vec<Target>,
     /// Project-level configuration names in pbxproj order (e.g. `Debug`, `Release`).
     pub configurations: Vec<String>,
-    /// Names of shared schemes discovered in `xcshareddata/xcschemes/*.xcscheme`,
-    /// sorted alphabetically. Matches the order `xcodebuild -list` prints them.
+    /// Scheme names for this project, sorted alphabetically — the set
+    /// `xcodebuild -list` prints: shared (`xcshareddata/xcschemes`) plus
+    /// per-user (`xcuserdata/<user>.xcuserdatad/xcschemes`) scheme files,
+    /// or one autocreated scheme per target when no scheme file exists at
+    /// all (Xcode's scheme autocreation for fresh / never-shared projects).
     pub schemes: Vec<String>,
 }
 
@@ -87,7 +90,15 @@ pub fn open_from_value(value: &Value, xcodeproj_path: &Path) -> Result<Project, 
 
     let configurations = extract_project_configurations(objects, project_obj)?;
     let targets = extract_targets(objects, project_obj)?;
-    let schemes = scan_shared_schemes(xcodeproj_path);
+    let mut schemes = crate::scheme::container_schemes(xcodeproj_path);
+    if schemes.is_empty() {
+        // No scheme file on disk anywhere (shared or per-user): mirror Xcode's
+        // scheme autocreation — `xcodebuild -list` reports one scheme per
+        // target — so fresh / never-shared projects still list schemes.
+        schemes = targets.iter().map(|t| t.name.clone()).collect();
+        schemes.sort();
+        schemes.dedup();
+    }
 
     let name = xcodeproj_path
         .file_stem()
@@ -2702,26 +2713,6 @@ fn value_to_string(v: &Value) -> String {
     }
 }
 
-fn scan_shared_schemes(xcodeproj_path: &Path) -> Vec<String> {
-    let dir = xcodeproj_path.join("xcshareddata/xcschemes");
-    let Ok(entries) = fs::read_dir(&dir) else {
-        return Vec::new();
-    };
-    let mut out: Vec<String> = entries
-        .flatten()
-        .filter_map(|e| {
-            let p = e.path();
-            if p.extension() == Some(OsStr::new("xcscheme")) {
-                p.file_stem().and_then(OsStr::to_str).map(String::from)
-            } else {
-                None
-            }
-        })
-        .collect();
-    out.sort();
-    out
-}
-
 /// A shared scheme that builds `target`, for driving an `xcodebuild` build of it
 /// (BSP `prepare`). Prefers a scheme named exactly `target` (Xcode and Tuist
 /// create a per-target scheme); otherwise the first shared scheme whose build
@@ -3258,8 +3249,9 @@ mod tests {
             Some("com.apple.product-type.tool")
         );
         assert_eq!(scratch.configurations, vec!["Debug", "Release"]);
-        // Synthetic project has no xcshareddata directory.
-        assert!(project.schemes.is_empty());
+        // Synthetic project has no scheme files at all, so the autocreated
+        // per-target schemes surface (matching `xcodebuild -list`).
+        assert_eq!(project.schemes, vec!["Scratch"]);
     }
 
     #[test]

--- a/sweetpad-lib/src/scheme.rs
+++ b/sweetpad-lib/src/scheme.rs
@@ -15,8 +15,11 @@
 //! incrementally as concrete callers need them — see CLAUDE.md "minimum
 //! abstraction."
 
+use std::collections::BTreeSet;
+use std::ffi::OsStr;
 use std::fmt;
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use crate::xcscheme::{self, Element};
 
@@ -160,6 +163,59 @@ impl From<xcscheme::Error> for Error {
 pub fn parse_file(path: &Path) -> Result<Scheme, Error> {
     let root = xcscheme::parse_file(path)?;
     from_element(&root)
+}
+
+/// The directories a container (`.xcodeproj` or `.xcworkspace` — both share
+/// the same layout) stores scheme files in: `xcshareddata/xcschemes` first,
+/// then every per-user `xcuserdata/<user>.xcuserdatad/xcschemes`, sorted for
+/// a stable order.
+fn scheme_dirs(container: &Path) -> Vec<PathBuf> {
+    let mut dirs = vec![container.join("xcshareddata/xcschemes")];
+    if let Ok(entries) = fs::read_dir(container.join("xcuserdata")) {
+        let mut user_dirs: Vec<PathBuf> = entries
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension() == Some(OsStr::new("xcuserdatad")))
+            .map(|p| p.join("xcschemes"))
+            .collect();
+        user_dirs.sort();
+        dirs.extend(user_dirs);
+    }
+    dirs
+}
+
+/// Scheme names stored in a container: the shared schemes plus every user's
+/// personal schemes, deduplicated and sorted alphabetically — the set
+/// `xcodebuild -list` reports for the container.
+#[must_use]
+pub fn container_schemes(container: &Path) -> Vec<String> {
+    let mut set = BTreeSet::new();
+    for dir in scheme_dirs(container) {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.extension() == Some(OsStr::new("xcscheme"))
+                && let Some(name) = p.file_stem().and_then(OsStr::to_str)
+            {
+                set.insert(name.to_string());
+            }
+        }
+    }
+    set.into_iter().collect()
+}
+
+/// Locate `<name>.xcscheme` in a container: the shared directory first, then
+/// each per-user directory (a shared scheme shadows a same-named user one,
+/// matching Xcode). `None` when the scheme has no file — either it doesn't
+/// exist or it's an autocreated scheme Xcode never materialized.
+#[must_use]
+pub fn find_scheme_file(container: &Path, name: &str) -> Option<PathBuf> {
+    scheme_dirs(container)
+        .into_iter()
+        .map(|dir| dir.join(format!("{name}.xcscheme")))
+        .find(|p| p.is_file())
 }
 
 /// Build a [`Scheme`] from an already-parsed `<Scheme>` element.
@@ -419,5 +475,52 @@ mod tests {
         };
         let err = from_element(&element).unwrap_err();
         assert!(format!("{err}").contains("expected root element"));
+    }
+
+    /// A unique scratch container dir under the OS temp dir.
+    fn scratch_container(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static N: AtomicU32 = AtomicU32::new(0);
+        let n = N.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "sweetpad-scheme-{tag}-{}-{n}.xcodeproj",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn touch(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, b"").unwrap();
+    }
+
+    #[test]
+    fn container_schemes_merges_shared_and_user_schemes() {
+        let dir = scratch_container("merge");
+        touch(&dir.join("xcshareddata/xcschemes/Shared.xcscheme"));
+        touch(&dir.join("xcuserdata/alice.xcuserdatad/xcschemes/Personal.xcscheme"));
+        touch(&dir.join("xcuserdata/bob.xcuserdatad/xcschemes/Shared.xcscheme")); // dup of shared
+        assert_eq!(container_schemes(&dir), vec!["Personal", "Shared"]);
+    }
+
+    #[test]
+    fn container_schemes_empty_without_scheme_files() {
+        let dir = scratch_container("empty");
+        assert!(container_schemes(&dir).is_empty());
+    }
+
+    #[test]
+    fn find_scheme_file_prefers_shared_over_user() {
+        let dir = scratch_container("find");
+        let shared = dir.join("xcshareddata/xcschemes/App.xcscheme");
+        touch(&shared);
+        touch(&dir.join("xcuserdata/alice.xcuserdatad/xcschemes/App.xcscheme"));
+        let user_only = dir.join("xcuserdata/alice.xcuserdatad/xcschemes/Mine.xcscheme");
+        touch(&user_only);
+
+        assert_eq!(find_scheme_file(&dir, "App"), Some(shared));
+        assert_eq!(find_scheme_file(&dir, "Mine"), Some(user_only));
+        assert_eq!(find_scheme_file(&dir, "Nope"), None);
     }
 }

--- a/sweetpad-lib/src/workspace.rs
+++ b/sweetpad-lib/src/workspace.rs
@@ -1,7 +1,8 @@
 //! Typed model of an `.xcworkspace`.
 //!
 //! Reads `contents.xcworkspacedata` (XML, same parser as `.xcscheme`) and
-//! the workspace-level shared schemes under `xcshareddata/xcschemes/`.
+//! the workspace-level schemes (shared `xcshareddata/xcschemes/` plus
+//! per-user `xcuserdata/<user>.xcuserdatad/xcschemes/`).
 //! Returns absolute paths to every referenced `.xcodeproj`.
 //!
 //! What `contents.xcworkspacedata` looks like:
@@ -22,7 +23,6 @@
 
 use std::ffi::OsStr;
 use std::fmt;
-use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -39,9 +39,9 @@ pub struct Workspace {
     /// Absolute paths to every `.xcodeproj` referenced by the workspace,
     /// in declaration order.
     pub project_refs: Vec<PathBuf>,
-    /// Shared scheme names from `<ws>/xcshareddata/xcschemes/`, sorted
-    /// alphabetically. Matches the order `xcodebuild -list -workspace`
-    /// reports.
+    /// The workspace bundle's own scheme names (shared plus per-user files),
+    /// sorted alphabetically. Member-project schemes are merged in by
+    /// [`Workspace::merged_schemes`].
     pub schemes: Vec<String>,
 }
 
@@ -101,7 +101,7 @@ pub fn open(workspace_path: &Path) -> Result<Workspace, Error> {
     let mut seen = std::collections::HashSet::new();
     project_refs.retain(|p| seen.insert(p.clone()));
 
-    let schemes = scan_shared_schemes(workspace_path);
+    let schemes = crate::scheme::container_schemes(workspace_path);
 
     let name = workspace_path
         .file_stem()
@@ -119,26 +119,21 @@ pub fn open(workspace_path: &Path) -> Result<Workspace, Error> {
 
 impl Workspace {
     /// Schemes that `xcodebuild -list -workspace` would surface: the
-    /// workspace's own shared schemes UNION every member project's shared
-    /// schemes, deduplicated and sorted. Opens each project to scan its
-    /// `xcshareddata/xcschemes/`; failures (missing project, unreadable
-    /// directory) are skipped silently.
+    /// workspace's own schemes UNION every member project's schemes (shared
+    /// plus per-user files), deduplicated and sorted. When no scheme file
+    /// exists anywhere, falls back to Xcode's scheme autocreation — one
+    /// scheme per target across the member projects. Failures (missing
+    /// project, unreadable directory) are skipped silently.
     #[must_use]
     pub fn merged_schemes(&self) -> Vec<String> {
         let mut set: std::collections::BTreeSet<String> = self.schemes.iter().cloned().collect();
         for project_path in &self.project_refs {
-            let dir = project_path.join("xcshareddata/xcschemes");
-            let Ok(entries) = fs::read_dir(&dir) else {
-                continue;
-            };
-            for entry in entries.flatten() {
-                let p = entry.path();
-                if p.extension() == Some(OsStr::new("xcscheme"))
-                    && let Some(name) = p.file_stem().and_then(OsStr::to_str)
-                {
-                    set.insert(name.to_string());
-                }
-            }
+            set.extend(crate::scheme::container_schemes(project_path));
+        }
+        if set.is_empty() {
+            let mut autocreated = self.merged_targets();
+            autocreated.sort();
+            return autocreated;
         }
         set.into_iter().collect()
     }
@@ -181,19 +176,15 @@ impl Workspace {
     }
 
     /// Locate the `.xcodeproj` member that owns a scheme by name. Returns
-    /// the project path whose `xcshareddata/xcschemes/<name>.xcscheme`
-    /// exists. Used by callers (the CLI) that need to dispatch a
-    /// scheme-driven build to the right project.
+    /// the first project with a `<name>.xcscheme` file (shared or per-user).
+    /// Used by callers (the CLI) that need to dispatch a scheme-driven build
+    /// to the right project.
     #[must_use]
     pub fn project_for_scheme(&self, scheme_name: &str) -> Option<&Path> {
-        for project_path in &self.project_refs {
-            let candidate =
-                project_path.join(format!("xcshareddata/xcschemes/{scheme_name}.xcscheme"));
-            if candidate.exists() {
-                return Some(project_path);
-            }
-        }
-        None
+        self.project_refs
+            .iter()
+            .find(|p| crate::scheme::find_scheme_file(p, scheme_name).is_some())
+            .map(PathBuf::as_path)
     }
 }
 
@@ -244,29 +235,10 @@ fn resolve_location(location: &str, base: &Path) -> Option<PathBuf> {
     }
 }
 
-fn scan_shared_schemes(workspace_path: &Path) -> Vec<String> {
-    let dir = workspace_path.join("xcshareddata/xcschemes");
-    let Ok(entries) = fs::read_dir(&dir) else {
-        return Vec::new();
-    };
-    let mut out: Vec<String> = entries
-        .flatten()
-        .filter_map(|e| {
-            let p = e.path();
-            if p.extension() == Some(OsStr::new("xcscheme")) {
-                p.file_stem().and_then(OsStr::to_str).map(String::from)
-            } else {
-                None
-            }
-        })
-        .collect();
-    out.sort();
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     fn fixtures_root() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures")
@@ -359,6 +331,61 @@ mod tests {
                 base.join("Sub/Nested.xcodeproj")
             ],
         );
+    }
+
+    /// A scratch workspace under the OS temp dir containing one copy of the
+    /// synthetic `Scratch.xcodeproj` (a single `Scratch` target, no scheme
+    /// files), referenced via `group:`.
+    fn scratch_workspace(tag: &str) -> (PathBuf, PathBuf) {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static N: AtomicU32 = AtomicU32::new(0);
+        let n = N.fetch_add(1, Ordering::Relaxed);
+        let root =
+            std::env::temp_dir().join(format!("sweetpad-ws-{tag}-{}-{n}", std::process::id()));
+        let proj = root.join("Scratch.xcodeproj");
+        fs::create_dir_all(&proj).unwrap();
+        fs::copy(
+            fixtures_root().join(
+                "_synthetic-xcconfigs/xcode-26.5.0/project/Scratch.xcodeproj/project.pbxproj",
+            ),
+            proj.join("project.pbxproj"),
+        )
+        .unwrap();
+        let ws = root.join("Test.xcworkspace");
+        fs::create_dir_all(&ws).unwrap();
+        fs::write(
+            ws.join("contents.xcworkspacedata"),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Workspace version=\"1.0\">\n  <FileRef location=\"group:Scratch.xcodeproj\"/>\n</Workspace>\n",
+        )
+        .unwrap();
+        (ws, proj)
+    }
+
+    #[test]
+    fn merged_schemes_autocreates_per_target_when_no_scheme_files() {
+        let (ws_path, _proj) = scratch_workspace("autocreate");
+        let ws = open(&ws_path).unwrap();
+        // Neither the workspace nor the project has any scheme file, so the
+        // autocreated per-target schemes surface (matching xcodebuild -list).
+        assert_eq!(ws.merged_schemes(), vec!["Scratch"]);
+    }
+
+    #[test]
+    fn merged_schemes_includes_workspace_and_project_user_schemes() {
+        let (ws_path, proj) = scratch_workspace("user-schemes");
+        let ws_user = ws_path.join("xcuserdata/alice.xcuserdatad/xcschemes");
+        fs::create_dir_all(&ws_user).unwrap();
+        fs::write(ws_user.join("WsPersonal.xcscheme"), b"").unwrap();
+        let proj_user = proj.join("xcuserdata/alice.xcuserdatad/xcschemes");
+        fs::create_dir_all(&proj_user).unwrap();
+        fs::write(proj_user.join("ProjPersonal.xcscheme"), b"").unwrap();
+
+        let ws = open(&ws_path).unwrap();
+        // Scheme files exist, so no autocreation — just the user schemes from
+        // both the workspace bundle and the member project.
+        assert_eq!(ws.merged_schemes(), vec!["ProjPersonal", "WsPersonal"]);
+        // And the user scheme makes the project dispatchable by name.
+        assert_eq!(ws.project_for_scheme("ProjPersonal"), Some(proj.as_path()));
     }
 
     #[test]

--- a/sweetpad-lib/tests/build_settings.rs
+++ b/sweetpad-lib/tests/build_settings.rs
@@ -187,3 +187,126 @@ fn invalid_destination_is_rejected_at_parse() {
     // `None` (the CLI surfaced this as "invalid --destination").
     assert!(parse_destination_arg("platform=Android").is_none());
 }
+
+// ----- scheme discovery parity (autocreated / user / workspace-level) -------
+
+/// A unique scratch dir under the OS temp dir containing a copy of the
+/// synthetic `Scratch.xcodeproj` (one `Scratch` tool target, no scheme files).
+fn scratch_copy(tag: &str) -> (PathBuf, PathBuf) {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static N: AtomicU32 = AtomicU32::new(0);
+    let n = N.fetch_add(1, Ordering::Relaxed);
+    let root = std::env::temp_dir().join(format!("sweetpad-bs-{tag}-{}-{n}", std::process::id()));
+    let proj = root.join("Scratch.xcodeproj");
+    std::fs::create_dir_all(&proj).unwrap();
+    std::fs::copy(
+        scratch_proj().join("project.pbxproj"),
+        proj.join("project.pbxproj"),
+    )
+    .unwrap();
+    (root, proj)
+}
+
+/// A minimal `.xcscheme` whose BuildAction builds the `Scratch` target.
+const SCRATCH_SCHEME_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Scheme LastUpgradeVersion="1640" version="1.7">
+   <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
+      <BuildActionEntries>
+         <BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">
+            <BuildableReference
+               BuildableIdentifier="primary"
+               BlueprintIdentifier="14A71A1C6762522AADB33EF1"
+               BuildableName="Scratch"
+               BlueprintName="Scratch"
+               ReferencedContainer="container:Scratch.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+</Scheme>
+"#;
+
+fn write_scheme(dir: &PathBuf, name: &str) {
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(dir.join(format!("{name}.xcscheme")), SCRATCH_SCHEME_XML).unwrap();
+}
+
+#[test]
+fn scheme_without_file_resolves_the_same_named_target() {
+    // No `.xcscheme` exists anywhere — Xcode's autocreated per-target scheme.
+    // xcodebuild resolves it as the same-named target; so do we.
+    let (_root, proj) = scratch_copy("autocreated");
+    let opts = BuildSettingsOptions {
+        project: Some(proj),
+        scheme: Some("Scratch".to_string()),
+        configuration: "Debug".to_string(),
+        sdk: "macosx".to_string(),
+        arch: "arm64".to_string(),
+        ..Default::default()
+    };
+    let s = resolve_one(opts);
+    assert_eq!(s.get("PRODUCT_NAME").map(String::as_str), Some("Scratch"));
+}
+
+#[test]
+fn unknown_scheme_with_no_matching_target_errors() {
+    let (_root, proj) = scratch_copy("unknown-scheme");
+    let opts = BuildSettingsOptions {
+        project: Some(proj),
+        scheme: Some("Nonexistent".to_string()),
+        configuration: "Debug".to_string(),
+        sdk: "macosx".to_string(),
+        arch: "arm64".to_string(),
+        ..Default::default()
+    };
+    let err = resolve_build_settings(&opts).unwrap_err();
+    assert!(err.contains("no target named"), "err: {err}");
+}
+
+#[test]
+fn user_scheme_in_xcuserdata_resolves() {
+    // A per-user (non-shared) scheme under `xcuserdata/<user>.xcuserdatad/`
+    // resolves exactly like a shared one (xcodebuild accepts both).
+    let (_root, proj) = scratch_copy("user-scheme");
+    write_scheme(
+        &proj.join("xcuserdata/tester.xcuserdatad/xcschemes"),
+        "Custom",
+    );
+    let opts = BuildSettingsOptions {
+        project: Some(proj),
+        scheme: Some("Custom".to_string()),
+        configuration: "Debug".to_string(),
+        sdk: "macosx".to_string(),
+        arch: "arm64".to_string(),
+        ..Default::default()
+    };
+    let s = resolve_one(opts);
+    assert_eq!(s.get("TARGET_NAME").map(String::as_str), Some("Scratch"));
+}
+
+#[test]
+fn workspace_level_scheme_resolves() {
+    // A scheme stored in the workspace bundle's own `xcshareddata/xcschemes/`
+    // (not in any member project) — its buildables dispatch to the member
+    // project named by `ReferencedContainer`.
+    let (root, _proj) = scratch_copy("ws-scheme");
+    let ws = root.join("Test.xcworkspace");
+    std::fs::create_dir_all(&ws).unwrap();
+    std::fs::write(
+        ws.join("contents.xcworkspacedata"),
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Workspace version=\"1.0\">\n  <FileRef location=\"group:Scratch.xcodeproj\"/>\n</Workspace>\n",
+    )
+    .unwrap();
+    write_scheme(&ws.join("xcshareddata/xcschemes"), "WsScheme");
+
+    let opts = BuildSettingsOptions {
+        workspace: Some(ws),
+        scheme: Some("WsScheme".to_string()),
+        configuration: "Debug".to_string(),
+        sdk: "macosx".to_string(),
+        arch: "arm64".to_string(),
+        ..Default::default()
+    };
+    let s = resolve_one(opts);
+    assert_eq!(s.get("TARGET_NAME").map(String::as_str), Some("Scratch"));
+}


### PR DESCRIPTION
Three classes of schemes that xcodebuild -list / -showBuildSettings handle
were invisible or unlaunchable after the migration to in-process parsing:

- Autocreated schemes: a project/workspace with no .xcscheme file on disk
  now lists one scheme per target (Xcode's scheme autocreation), and
  resolving such a scheme falls back to the same-named target instead of
  returning empty settings.
- User schemes: xcuserdata/<user>.xcuserdatad/xcschemes is now scanned for
  listing, scheme-file lookup, and workspace scheme dispatch, with shared
  schemes shadowing same-named user ones.
- Workspace-level schemes: the scheme file is located once across every
  container (workspace bundle first, then member projects) and planned
  against each member project, so schemes stored in the workspace's own
  xcshareddata/xcuserdata resolve; plan_build now also checks the entry's
  ReferencedContainer basename so a buildable lands in its own project and
  not a same-named target elsewhere.

Discovery is centralized in scheme::container_schemes / find_scheme_file,
and the scheme/target selector is resolved once up front
(build_settings::Selection) instead of per-project.

https://claude.ai/code/session_01PwKhUMt2x7mW81Fser8aqE