### PR TITLE
Fix native macOS targets that explicitly disable Catalyst

### DIFF
--- a/sweetpad-lib/src/project.rs
+++ b/sweetpad-lib/src/project.rs
@@ -1174,13 +1174,16 @@ pub fn detect_catalyst(
     if canonicalize_sdk_base(sdk_canonical) != "macosx" {
         return false;
     }
-    if matches!(
-        natural_sdk,
-        Some("iphoneos" | "appletvos" | "watchos" | "xros")
-    ) {
+    if matches!(supports_maccatalyst, Some(v) if v.eq_ignore_ascii_case("NO")) {
+        return false;
+    }
+    if matches!(supports_maccatalyst, Some(v) if v.eq_ignore_ascii_case("YES")) {
         return true;
     }
-    matches!(supports_maccatalyst, Some(v) if v.eq_ignore_ascii_case("YES"))
+    matches!(
+        natural_sdk,
+        Some("iphoneos" | "appletvos" | "watchos" | "xros")
+    )
 }
 
 /// Apple's Mac Catalyst minimum iOS deployment is 13.1. Any user-set
@@ -3957,6 +3960,8 @@ mod tests {
         assert!(!detect_catalyst("macosx", Some("macosx"), None));
         assert!(!detect_catalyst("macosx", None, None));
         assert!(!detect_catalyst("macosx", None, Some("NO")));
+        assert!(!detect_catalyst("macosx", Some("iphoneos"), Some("NO")));
+        assert!(!detect_catalyst("macosx", Some("iphoneos"), Some("no")));
         assert!(!detect_catalyst("iphonesimulator", Some("iphoneos"), None));
         // Simulators on the iOS family aren't Catalyst — they're native.
         assert!(!detect_catalyst("macosx", Some("iphonesimulator"), None));


### PR DESCRIPTION
Fixes a build settings resolver issue where native macOS targets could be incorrectly detected as Mac Catalyst.

Some projects inherit an iOS-family `SDKROOT` such as `iphoneos`, while the actual target supports native macOS and explicitly sets `SUPPORTS_MACCATALYST = NO`. SweetPad previously treated the iOS-family SDKROOT as enough to resolve the target as Catalyst, producing paths like `Debug-maccatalyst/...` even though Xcode builds the app under `Debug/...`.

<img width="1048" height="430" alt="Base SDK" src="https://github.com/user-attachments/assets/5f7954d4-d948-4c31-b16c-3aab4a9e6618" />
<img width="1466" height="502" alt="Supported Destinations" src="https://github.com/user-attachments/assets/ca7f2148-ada9-4a84-bc2b-e113ac253a14" />
<img width="2998" height="450" alt="SweetPad Outputs" src="https://github.com/user-attachments/assets/68e780c6-7297-458c-bb42-dea5110fffb4" />


## Testing

- [x] `cargo test detect_catalyst`
- [x] `cargo test --lib`