### PR TITLE
Add Catalyst oracle + regression test for native-macOS detection (#264)

### DIFF
--- a/.github/workflows/catalyst-oracle.yaml
+++ b/.github/workflows/catalyst-oracle.yaml
@@ -1,0 +1,60 @@
+name: catalyst-oracle
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "sweetpad-lib/**"
+      - ".github/workflows/catalyst-oracle.yaml"
+  pull_request:
+    paths:
+      - "sweetpad-lib/**"
+      - ".github/workflows/catalyst-oracle.yaml"
+  workflow_dispatch:
+
+# Differential oracle / regression gate for native-macOS Catalyst detection
+# (the #264 class). Runs real `xcodebuild -sdk macosx -showBuildSettings` as the
+# ground truth and compares the in-process resolver's IS_MACCATALYST against it,
+# on a fixture matching the report: project-wide iOS-family Base SDK
+# (SDKROOT=iphoneos), target supports native macOS with SUPPORTS_MACCATALYST=NO.
+#
+# The resolver must agree with xcodebuild — IS_MACCATALYST=NO, products under
+# `Debug/` not `Debug-maccatalyst/`. This job is RED if that regresses (it was
+# the proof of the #264 bug and now guards the fix).
+jobs:
+  oracle:
+    name: native-macOS Catalyst differential
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: sweetpad-lib
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: sweetpad-lib
+
+      - name: Tooling versions
+        run: |
+          xcodebuild -version
+          rustc --version
+
+      - name: Build the sweetpad CLI
+        run: cargo build --bin sweetpad
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate the fixture project
+        working-directory: sweetpad-lib/ci/fixture-catalyst
+        run: xcodegen generate
+
+      - name: Catalyst misdetection oracle
+        env:
+          SWEETPAD_BIN: ${{ github.workspace }}/sweetpad-lib/target/debug/sweetpad
+        run: bash ci/catalyst-oracle.sh

--- a/sweetpad-lib/ci/catalyst-oracle.sh
+++ b/sweetpad-lib/ci/catalyst-oracle.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Differential oracle / regression gate for native-macOS Catalyst misdetection
+# (the #264 class — https://github.com/sweetpad-dev/sweetpad/pull/264).
+#
+# Captures the Catalyst-defining build settings two ways for the SAME target,
+# built for macOS:
+#
+#   ORACLE   — real `xcodebuild -project … -target … -sdk macosx
+#              -showBuildSettings -json` (ground truth)
+#   RESOLVER — the in-process resolver via
+#              `sweetpad settings show --project … --target … --destination platform=macOS`
+#
+# The fixture target has a project-wide iOS-family Base SDK (`SDKROOT=iphoneos`)
+# but supports native macOS with `SUPPORTS_MACCATALYST=NO`. Xcode builds it as a
+# native macOS app — IS_MACCATALYST=NO, EFFECTIVE_PLATFORM_NAME="", products
+# under `…/Debug/`. Before the fix the resolver keyed Catalyst off the iOS-family
+# SDKROOT alone, reporting IS_MACCATALYST=YES and `…/Debug-maccatalyst/`,
+# pointing at a build dir Xcode never writes (the symptom in #264).
+#
+# This script exits non-zero on that divergence. It was the proof of the #264
+# bug; with the detect_catalyst fix (explicit SUPPORTS_MACCATALYST=NO wins over
+# the iOS-family SDKROOT) it passes, and stays in CI as the regression gate.
+#
+# Requires: SWEETPAD_BIN pointing at the built binary; the fixture project
+# already generated with `xcodegen generate` under fixture-catalyst.
+set -euo pipefail
+
+BIN="${SWEETPAD_BIN:?set SWEETPAD_BIN to the sweetpad binary}"
+ROOT="$(cd "$(dirname "$0")/fixture-catalyst" && pwd -P)"
+PROJ="$ROOT/CatalystProbe.xcodeproj"
+TARGET="CatalystProbe"
+
+# Read one build-setting key. <expr> (argv[1]) selects the settings dict from
+# the parsed document `d`; argv[2] is the key. Program via `-c` so stdin stays
+# free for the piped JSON; tolerate any preamble by slicing from the first {/[.
+get_key() {
+  python3 -c '
+import json, sys
+raw = sys.stdin.read()
+starts = [i for i in (raw.find("{"), raw.find("[")) if i != -1]
+d = json.loads(raw[min(starts):]) if starts else json.loads(raw)
+print(eval(sys.argv[1], {"d": d}).get(sys.argv[2], ""))
+' "$1" "$2"
+}
+oracle_key()   { get_key 'd[0]["buildSettings"]' "$1" <<<"$oracle_json"; }
+resolver_key() { get_key 'd["targets"][0]["settings"]' "$1" <<<"$resolver_json"; }
+
+echo "==== PR #264 native-macOS Catalyst differential ===="
+echo "project: $PROJ"
+echo "target:  $TARGET   destination: macOS"
+echo
+
+oracle_json="$(
+  xcodebuild -project "$PROJ" -target "$TARGET" \
+    -configuration Debug -sdk macosx -showBuildSettings -json
+)"
+resolver_json="$(
+  "$BIN" settings show --project "$PROJ" --target "$TARGET" \
+    --destination "platform=macOS" --json
+)"
+
+printf '  %-24s %-14s %s\n' "setting" "ORACLE" "RESOLVER"
+for key in PLATFORM_NAME IS_MACCATALYST EFFECTIVE_PLATFORM_NAME TARGET_BUILD_DIR; do
+  o="$(oracle_key "$key")"
+  r="$(resolver_key "$key")"
+  printf '  %-24s %-14s %s\n' "$key" "${o:-<empty>}" "${r:-<empty>}"
+done
+echo
+
+# Sanity guard: both sides must actually have resolved for macOS, or the
+# IS_MACCATALYST comparison below is meaningless (a false green). If the
+# resolver didn't bind macosx, that's a setup fault, not a verdict.
+o_platform="$(oracle_key PLATFORM_NAME)"
+r_platform="$(resolver_key PLATFORM_NAME)"
+if [ "$o_platform" != "macosx" ] || [ "$r_platform" != "macosx" ]; then
+  echo "ERROR: expected both sides to resolve for macOS (PLATFORM_NAME=macosx);" >&2
+  echo "       got oracle='$o_platform' resolver='$r_platform' — setup fault." >&2
+  exit 2
+fi
+
+oracle_is="$(oracle_key IS_MACCATALYST)"
+resolver_is="$(resolver_key IS_MACCATALYST)"
+if [ -z "$oracle_is" ]; then
+  echo "ERROR: oracle did not report IS_MACCATALYST — setup fault." >&2
+  exit 2
+fi
+
+if [ "$oracle_is" != "$resolver_is" ]; then
+  echo "FAIL (PR #264 reproduced):" >&2
+  echo "  xcodebuild builds this native macOS target with IS_MACCATALYST=$oracle_is," >&2
+  echo "  but the resolver reports IS_MACCATALYST=$resolver_is. It is keying Catalyst" >&2
+  echo "  off the iOS-family SDKROOT and ignoring the explicit SUPPORTS_MACCATALYST=NO," >&2
+  echo "  so it points at a '-maccatalyst' build dir Xcode never writes." >&2
+  exit 1
+fi
+
+echo "PASS: resolver matches xcodebuild — IS_MACCATALYST=$oracle_is (native macOS, not Catalyst)."

--- a/sweetpad-lib/ci/fixture-catalyst/.gitignore
+++ b/sweetpad-lib/ci/fixture-catalyst/.gitignore
@@ -1,0 +1,2 @@
+# Generated on CI by `xcodegen generate`.
+*.xcodeproj/

--- a/sweetpad-lib/ci/fixture-catalyst/Sources/CatalystProbe.swift
+++ b/sweetpad-lib/ci/fixture-catalyst/Sources/CatalystProbe.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+@main
+struct CatalystProbeApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("Hello, SweetPad Catalyst oracle")
+                .padding()
+        }
+    }
+}

--- a/sweetpad-lib/ci/fixture-catalyst/project.yml
+++ b/sweetpad-lib/ci/fixture-catalyst/project.yml
@@ -1,0 +1,49 @@
+# Fixture for the issue/#264 Catalyst-misdetection oracle (ci/catalyst-oracle.sh).
+#
+# Reproduces the report's setup: a project-wide iOS-family Base SDK
+# (`SDKROOT = iphoneos`) on a target that ALSO supports native macOS ("My Mac")
+# and explicitly opts OUT of Mac Catalyst (`SUPPORTS_MACCATALYST = NO`). Built
+# for macOS, Xcode treats this as a native macOS build (IS_MACCATALYST = NO,
+# products under `Debug/`), but the resolver currently keys off the iOS-family
+# SDKROOT alone and misdetects Catalyst (`Debug-maccatalyst/`).
+#
+# Generated on CI with XcodeGen (`xcodegen generate`); the .xcodeproj is not
+# committed.
+name: CatalystProbe
+options:
+  bundleIdPrefix: dev.sweetpad.ci
+  deploymentTarget:
+    iOS: "16.0"
+    macOS: "13.0"
+  createIntermediateGroups: true
+
+settings:
+  base:
+    # The iOS-family "Base SDK" the whole project inherits — the trigger.
+    SDKROOT: iphoneos
+    CODE_SIGNING_ALLOWED: "NO"
+    SWIFT_VERSION: "5.0"
+
+targets:
+  CatalystProbe:
+    type: application
+    platform: iOS
+    sources:
+      - Sources
+    settings:
+      base:
+        # Native macOS ("My Mac") is a supported destination, but this is a
+        # native macOS target — NOT Mac Catalyst.
+        SUPPORTED_PLATFORMS: "macosx iphoneos iphonesimulator"
+        SUPPORTS_MACCATALYST: "NO"
+        GENERATE_INFOPLIST_FILE: "YES"
+        INFOPLIST_KEY_UILaunchScreen_Generation: "YES"
+        PRODUCT_BUNDLE_IDENTIFIER: dev.sweetpad.ci.catalystprobe
+
+schemes:
+  CatalystProbe:
+    build:
+      targets:
+        CatalystProbe: all
+    run:
+      config: Debug

--- a/sweetpad-lib/tests/build_settings.rs
+++ b/sweetpad-lib/tests/build_settings.rs
@@ -616,3 +616,38 @@ fn workspace_keys_derived_data_by_the_workspace_not_a_nested_member() {
         "BUILD_DIR must not be keyed under the nested member project (issue #265): {build_dir}"
     );
 }
+
+/// A native macOS target that inherits an iOS-family Base SDK but explicitly
+/// opts out of Mac Catalyst, resolved for a macOS destination. Regression for
+/// the misdetection fixed in #264: an explicit `SUPPORTS_MACCATALYST = NO` must
+/// win over the iOS-family `SDKROOT` heuristic, so the resolver agrees with
+/// xcodebuild — native macOS (IS_MACCATALYST=NO), not Catalyst (which would
+/// wrongly yield a `-maccatalyst` build dir Xcode never writes).
+#[test]
+fn native_macos_target_opting_out_of_catalyst_is_not_catalyst() {
+    let dir = std::env::temp_dir().join(format!("sweetpad-catalyst-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    // The report's shape: a project-wide iOS-family Base SDK, but the target is
+    // a native macOS app that does NOT support Mac Catalyst.
+    let xcconfig = dir.join("catalyst.xcconfig");
+    std::fs::write(&xcconfig, "SDKROOT = iphoneos\nSUPPORTS_MACCATALYST = NO\n").unwrap();
+    let opts = BuildSettingsOptions {
+        // A macOS run destination binds the macosx SDK — the trigger for
+        // Catalyst detection.
+        destination: parse_destination_arg("platform=macOS"),
+        xcconfig: Some(xcconfig),
+        ..scratch_opts()
+    };
+    let s = resolve_one(opts);
+    assert_eq!(
+        s.get("IS_MACCATALYST").map(String::as_str),
+        Some("NO"),
+        "explicit SUPPORTS_MACCATALYST=NO must beat the iOS-family SDKROOT (issue #264)"
+    );
+    assert_ne!(
+        s.get("EFFECTIVE_PLATFORM_NAME").map(String::as_str),
+        Some("-maccatalyst"),
+        "a native macOS target must not get the -maccatalyst build dir"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Follow-up coverage for the #264 fix (native macOS targets with `SUPPORTS_MACCATALYST = NO` no longer misdetected as Mac Catalyst), landing on top of it.

## What

- **Regression test** (`tests/build_settings.rs`): resolves a target with an iOS-family `SDKROOT` + explicit `SUPPORTS_MACCATALYST = NO` for a macOS destination, asserting `IS_MACCATALYST=NO` and no `-maccatalyst` build dir. Pure in-process — runs in the standard `cargo test` gate, no Xcode needed. Fails on the pre-#264 code, passes now.
- **Differential oracle** (`ci/fixture-catalyst` + `ci/catalyst-oracle.sh` + `catalyst-oracle.yaml`): a macOS job that captures real `xcodebuild -sdk macosx -showBuildSettings` as ground truth and compares the resolver's `IS_MACCATALYST` against it, on a fixture matching the report (project-wide `SDKROOT=iphoneos`, target supports My Mac with `SUPPORTS_MACCATALYST=NO`). This is the job that originally proved the bug; it now guards the fix.

## Expected CI

Both green: the `cargo test` job (incl. the new test) and the `catalyst-oracle` differential (resolver now agrees with xcodebuild — `IS_MACCATALYST=NO`).

https://claude.ai/code/session_01Mq1Q3JZCG1PpqEz2eY5Wm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mq1Q3JZCG1PpqEz2eY5Wm9)_