### PR TITLE
Fix devicectl launch dropping `--` before dash-prefixed app args (#296)

### DIFF
--- a/sweetpad-vscode/src/build/manager.ts
+++ b/sweetpad-vscode/src/build/manager.ts
@@ -829,7 +829,11 @@ export class BuildManager {
         "--device",
         deviceId,
         bundlerId,
-        ...option.launchArgs,
+        // A `--` separator tells devicectl that everything after it belongs to
+        // the launched app, not to devicectl itself. Without it, launch args
+        // that start with `-` (common NSUserDefaults-style flags) are parsed as
+        // devicectl options and the launch fails. See issue #296.
+        ...(option.launchArgs.length ? ["--", ...option.launchArgs] : []),
       ].filter((arg) => arg !== null); // Filter out null arguments
 
       this.progress.updateText(`Running "${option.scheme}" on "${option.destination.name}"`);

--- a/sweetpad-vscode/src/cli-server/handlers/device.spec.ts
+++ b/sweetpad-vscode/src/cli-server/handlers/device.spec.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RpcContext } from "./context";
+import { deviceLaunch } from "./device";
+
+// Capture every argv handed to `execa("xcrun", [...])` so we can inspect the
+// exact command line SweetPad builds for `devicectl`. `vi.mock` is hoisted
+// above the imports, so `deviceLaunch` picks up this fake execa.
+const execaCalls: string[][] = [];
+
+vi.mock("execa", () => ({
+  execa: (_file: string, args: string[]) => {
+    execaCalls.push(args);
+    // devicectl prints the launched process identifier on success; give the
+    // handler something parseable so it doesn't blow up before we assert.
+    return Promise.resolve({ stdout: "processIdentifier: 4242" });
+  },
+}));
+
+function makeCtx(): RpcContext {
+  return {
+    workspacePath: "/tmp/ws",
+    extensionVersion: "test",
+    workspaceState: {} as RpcContext["workspaceState"],
+    buildManager: {} as RpcContext["buildManager"],
+    destinationsManager: {} as RpcContext["destinationsManager"],
+    buildRegistry: {} as RpcContext["buildRegistry"],
+    vscodeContext: {} as RpcContext["vscodeContext"],
+    configKeys: [],
+  };
+}
+
+describe("device.launch", () => {
+  beforeEach(() => {
+    execaCalls.length = 0;
+  });
+
+  // Regression test for issue #296: launching on a physical device via
+  // devicectl failed when the scheme had "Arguments Passed On Launch" values
+  // that start with `-`, because SweetPad forwarded them without a `--`
+  // separator and devicectl parsed them as its own options.
+  it("inserts a `--` separator before dash-prefixed app arguments (issue #296)", async () => {
+    await deviceLaunch(
+      {
+        deviceId: "00008120-000000000000000E",
+        bundleId: "com.example.app",
+        args: ["-com.example.someFlag", "-com.example.displayLog"],
+      },
+      makeCtx(),
+    );
+
+    const argv = execaCalls[0];
+    const bundleIdx = argv.indexOf("com.example.app");
+    const sepIdx = argv.indexOf("--");
+
+    // A `--` terminator must sit right after the bundle id...
+    expect(sepIdx).toBe(bundleIdx + 1);
+    // ...and every forwarded app argument must come after it, so devicectl
+    // treats them as app arguments rather than its own options.
+    expect(argv.slice(sepIdx + 1)).toEqual(["-com.example.someFlag", "-com.example.displayLog"]);
+  });
+
+  it("does not add a `--` separator when there are no launch arguments", async () => {
+    await deviceLaunch({ deviceId: "device-id", bundleId: "com.example.app" }, makeCtx());
+
+    expect(execaCalls[0]).not.toContain("--");
+    expect(execaCalls[0].at(-1)).toBe("com.example.app");
+  });
+});

--- a/sweetpad-vscode/src/cli-server/handlers/device.ts
+++ b/sweetpad-vscode/src/cli-server/handlers/device.ts
@@ -40,7 +40,9 @@ export const deviceLaunch: HandlerFn<
   const argv = ["device", "process", "launch"];
   if (params?.terminateExisting !== false) argv.push("--terminate-existing");
   argv.push("--device", deviceId, bundleId);
-  if (params?.args) argv.push(...params.args);
+  // A `--` separator keeps devicectl from parsing app arguments that start with
+  // `-` as its own options (see issue #296).
+  if (params?.args?.length) argv.push("--", ...params.args);
   // devicectl forwards env entries prefixed with DEVICECTL_CHILD_ to the
   // launched process.
   const env: Record<string, string> = {};


### PR DESCRIPTION
## Summary

Fixes #296. When launching on a **physical device** (iOS 17+, `devicectl` path), the app installed correctly but **failed to launch** if the selected scheme had *"Arguments Passed On Launch"* values starting with a dash (`-`) — common `NSUserDefaults`-style flags.

SweetPad appended the scheme's launch arguments right after the bundle identifier with **no `--` separator**, so `devicectl` parsed the leading-dash tokens as its own options and aborted with `Error: Missing value for '-t '` followed by a top-level usage dump.

## Reproduction

By mocking `execa` and driving the real `deviceLaunch` handler with dash-prefixed args, the command line SweetPad built was:

```
devicectl device process launch --terminate-existing --device <id> com.example.app -com.example.someFlag -com.example.displayLog
```

No `--` between the bundle id and the app arguments — exactly the reported failure.

## Fix

Insert a `--` terminator between the bundle identifier and the forwarded launch arguments (only when non-empty) so `devicectl` treats everything after it as app arguments. Applied in **both** launch paths:

- `src/build/manager.ts` — the production `runOnDevice` flow.
- `src/cli-server/handlers/device.ts` — the cli-server `device.launch` handler.

## Testing

- New regression test `src/cli-server/handlers/device.spec.ts` captures the argv handed to `devicectl` and asserts the `--` separator is present before dash-prefixed args (and absent when there are no launch args).
- Full suite: **333 tests pass** (28 files); `tsc --noEmit` and `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016tEoo6pbYhFKnzwupf2DMg)_