### PR TITLE
Fix hang, panic, and data-corruption bugs from the round-3 CLI audit (part 1)

### DIFF
--- a/sweetpad-cli/CLI_AUDIT.md
+++ b/sweetpad-cli/CLI_AUDIT.md
@@ -1,3 +1,78 @@
+# CLI audit — round 3 (July 2026)
+
+A fresh adversarial pass over the whole workspace (CLI, core, lib), run
+against `main` at c155570 (0.2.7). Method: thirteen independent review passes
+partitioned by module group, each finding verified against the source (and
+where possible reproduced with a compiled repro) before fixing. **Every
+verified finding is fixed** (commits `addcb1e`, `a12631c`) except the "known
+open" list below.
+
+## Worst findings (all fixed)
+
+- **`stream_lines` hung every streamed build/test at completion.** The
+  `Command` kept the merged pipe's two write ends after spawn (spawn only
+  borrows fds > 2), so the reader never saw EOF once xcodebuild exited.
+  Reproduced with a compiled repro; regression introduced by round 2's 4.7
+  fix. Also: the hand-rolled pipe lacked `FD_CLOEXEC`, so a child spawned
+  concurrently on another thread (BgBoot, watcher compiles) could hold the
+  pipe open with the same hang. (process.rs)
+- **The BSP server died on a percent-encoded URI panic.** `path_from_uri`
+  sliced the `&str` by byte index; a client URI with unencoded non-ASCII
+  after `%` (several BSP clients don't percent-encode) panicked the request
+  loop — in the extension, inside the extension host. Reproduced.
+  (bsp/mod.rs)
+- **xcconfig `#include` flattening was exponential.** The chain-only cycle
+  guard admitted 2^n re-inlining of diamond graphs — ~22 two-include files
+  took 14.6 s and 2M assignments; ~30 is an OOM. Reproduced. Now
+  include-once per flatten (matching Xcode's "already included" skip) plus a
+  depth cap. (resolver.rs)
+- **pbxproj merge silently corrupted duplicate-bearing token lists**
+  (`OTHER_LDFLAGS = ("-framework", A, "-framework", B)` lost the second
+  `-framework`) while reporting a clean merge; such arrays now conflict
+  instead. (pbxproj_merge.rs)
+- **A stale `--testing` pick failed every `sweetpad test` forever** —
+  `recover_stale` never looked at (or cleared) the testing-state layer.
+  (resolve.rs)
+- **`dep update` destroyed `Package.resolved` on a failed resolve** (deleted
+  before resolving, no restore), and the interactive `Package.swift` add
+  wrote a `--package` value (manifest name) that broke the next resolve for
+  packages whose identity differs (firebase-ios-sdk). (dependency.rs)
+
+The remaining ~35 fixes span: signal-registry pid-recycle windows
+(`check_exit`, `simctl record`), inject-server robustness (bounded protocol
+strings, stop-aware waits, straggling-payload desync, transient accept
+failures, shell-aware transcript tokenizing, path-boundary file matching),
+picker twins acting on the wrong simulator, `boot --wait` reporting failed
+boots as success, `core.quotePath` hiding conflicted non-ASCII paths, ndjson
+result events on pre-dispatch errors, empty `SWEETPAD_*` vars poisoning
+resolution, OpenStep octal/surrogate escapes, writer comments containing
+`*/`, cleared-setting flags (`-swift-version ""`, bare `-O`), quote-aware
+preprocessor-define splitting, JSON-RPC header caps, and scratch/clone dir
+leaks. See the two commit messages for the per-fix rationale.
+
+## Verified but deliberately not fixed (known open)
+
+- **xcconfig `serialize` corrupts files where a multi-line `/* … */` comment
+  ends on an entry line** (the raw-capture replay leaves an unterminated
+  comment that swallows the rest of the file on the next parse). `serialize`
+  has no callers outside the lib's own tests — no CLI write path reaches it —
+  so the fix (capturing raw spans from comment-stripped source) is deferred
+  until a write path exists.
+- **`<hex>` data literals round-trip as bare strings** in the pbxproj writer
+  (no `Value::Data` representation). Real Xcode projects don't carry them;
+  parse-only paths are unaffected.
+- **`spm unlink` with a target filter removes a product dependency shared by
+  several targets from all of them** (shared product-dependency objects are
+  a Tuist/hand-edit shape; single-target in practice).
+- **Inject-server verdicts are attributed by global counters**, so a verdict
+  arriving after its 15 s timeout is credited to the next load. Fixing this
+  needs a sequence tag the InjectionNext wire protocol doesn't carry.
+- **`file_cache` stamps are `(len, mtime)`**, so a same-length rewrite within
+  the filesystem's mtime granularity can serve a stale parse to the
+  long-lived addon. Needs a content hash or a don't-cache-recent rule.
+
+---
+
 # CLI audit — round 2 (July 2026)
 
 A fresh bugs/correctness/stability audit of the whole `sweetpad` CLI, run

--- a/sweetpad-cli/src/cli/buildlog.rs
+++ b/sweetpad-cli/src/cli/buildlog.rs
@@ -367,15 +367,30 @@ pub fn gh_annotation(event: &Event) -> Option<String> {
 /// the annotation to the wrong file.
 fn location_props(loc: &str) -> String {
     use std::fmt::Write as _;
-    let mut parts = loc.rsplitn(3, ':');
-    let col = parts.next().and_then(|p| p.parse::<u32>().ok());
-    let (line, file) = match (col, parts.next(), parts.next()) {
-        (Some(_), Some(line), Some(file)) if line.parse::<u32>().is_ok() => {
-            (Some(line.to_string()), file.to_string())
+    // Peel up to two trailing `:<number>` segments off the right; whatever
+    // remains — colons and all — is the file. A column-less `file:line`
+    // (SwiftLint's file-level violations) must still anchor to its line
+    // rather than degrade to a bare `file=path%3Aline` GitHub can't map.
+    let mut file = loc;
+    let mut nums: Vec<u32> = Vec::new();
+    for _ in 0..2 {
+        if let Some((rest, tail)) = file.rsplit_once(':')
+            && let Ok(n) = tail.parse::<u32>()
+            && !rest.is_empty()
+        {
+            nums.push(n);
+            file = rest;
+        } else {
+            break;
         }
-        _ => (None, loc.to_string()),
+    }
+    // Peeled right-to-left: one number is the line; two are col then line.
+    let (line, col) = match nums.as_slice() {
+        [line] => (Some(*line), None),
+        [col, line] => (Some(*line), Some(*col)),
+        _ => (None, None),
     };
-    let mut props = format!(" file={}", escape_property(&file));
+    let mut props = format!(" file={}", escape_property(file));
     if let Some(line) = line {
         let _ = write!(props, ",line={line}");
         if let Some(col) = col {
@@ -643,6 +658,21 @@ mod tests {
         assert!(gh_annotation(&warn).unwrap().starts_with("::warning file="));
         // Tasks and notes carry no annotation.
         assert!(gh_annotation(&parse_line("CompileSwift x.swift")).is_none());
+    }
+
+    #[test]
+    fn column_less_locations_still_anchor_line() {
+        // SwiftLint-style file-level diagnostics have no column; `file:line`
+        // used to degrade to a bogus `file=path%3Aline` GitHub can't map.
+        assert_eq!(
+            location_props("/x/File.swift:10"),
+            " file=/x/File.swift,line=10"
+        );
+        assert_eq!(
+            location_props("/x/File.swift:10:3"),
+            " file=/x/File.swift,line=10,col=3"
+        );
+        assert_eq!(location_props("/x/File.swift"), " file=/x/File.swift");
     }
 
     #[test]

--- a/sweetpad-cli/src/cli/commands/app.rs
+++ b/sweetpad-cli/src/cli/commands/app.rs
@@ -600,10 +600,23 @@ fn plan(ctx: &mut Context, opts: &RunOpts) -> Result<RunPlan, CliError> {
             Some(d) => d,
             None => resolve::pick_destination(ctx, &resolved.container.key(), &simctl::list()?)?,
         };
-        if destination == "platform=macOS" {
+        let platform = destination_platform(&destination).unwrap_or_default();
+        if platform.eq_ignore_ascii_case("macOS") {
             // The picker's "My Mac" row (or a config/remembered macOS
-            // destination) runs the native-app flow, not a simulator.
+            // destination, with or without extra keys like arch=) runs the
+            // native-app flow, not a simulator.
             (destination, Target::Mac)
+        } else if !platform.is_empty() && !platform.to_ascii_lowercase().contains("simulator") {
+            // A physical-device destination (platform=iOS,id=…) routes to
+            // devicectl — handing its udid to simctl would fail with an
+            // unrelated "Invalid device" much later.
+            let udid = udid(&destination).map_err(|_| {
+                CliError::new(format!(
+                    "physical-device destinations need an id= (got {destination:?})"
+                ))
+                .kind(ErrorKind::TargetResolution)
+            })?;
+            (destination, Target::Device(udid))
         } else {
             let udid = destination_udid(&destination)?;
             (destination, Target::Simulator(udid))
@@ -741,6 +754,13 @@ fn record_last_launched(ctx: &mut Context, plan: &RunPlan) {
     let key = plan.resolved.container.key();
     ctx.state.project_mut(&key).last_launched_app = Some(last);
     let _ = ctx.state.save();
+}
+
+/// Escape a value for embedding inside a double-quoted NSPredicate string
+/// literal: a raw `"` or `\` would otherwise terminate the literal and make
+/// `log stream` reject the whole predicate.
+fn predicate_escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 /// The `platform=` value from a `-destination` specifier, e.g. `iOS`.
@@ -1024,8 +1044,12 @@ fn run_hot_session(
         .map_or_else(|| std::path::PathBuf::from("."), Path::to_path_buf);
 
     // Per-session scratch dir for the recompiler's objects/dylibs + build log.
+    // The guard removes it on every exit path — the early error returns below
+    // would otherwise leak a multi-MB transcript per failed run (the pid-keyed
+    // name means no later run cleans it up either).
     let work = std::env::temp_dir().join(format!("sweetpad-hot-{}", std::process::id()));
     let _ = std::fs::create_dir_all(&work);
+    let _work_guard = RemoveDirOnDrop(work.clone());
     let build_log = work.join("build.log");
 
     // Boot the simulator on a background thread so it comes up while the project
@@ -1080,7 +1104,7 @@ fn run_hot_session(
         sdk.to_string(),
         inject::host_arch(),
         developer_dir,
-        Some(build_log),
+        Some(build_log.clone()),
         work,
     ));
     let log = hot_logger(&ctx.out);
@@ -1114,7 +1138,7 @@ fn run_hot_session(
     let outcome = if let Some(file) = selfcheck {
         hot_selfcheck(ctx, &server, file, udid)
     } else if ctx.out.is_interactive() {
-        terminate_on_exit = hot_key_loop(ctx, plan, udid, &launch_env, &mut logs);
+        terminate_on_exit = hot_key_loop(ctx, plan, udid, &launch_env, &mut logs, &build_log);
         Ok(())
     } else {
         ctx.out
@@ -1133,10 +1157,17 @@ fn run_hot_session(
         let _ = simctl::terminate(udid, &app.bundle_id);
     }
     drop(logs);
-    let _ = std::fs::remove_dir_all(
-        std::env::temp_dir().join(format!("sweetpad-hot-{}", std::process::id())),
-    );
     outcome
+}
+
+/// Removes a scratch directory on drop, so every exit path — including the
+/// hot session's early error returns — cleans up after itself.
+struct RemoveDirOnDrop(std::path::PathBuf);
+
+impl Drop for RemoveDirOnDrop {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
 }
 
 /// Marker token in the hot-reload fixture's `ContentView.swift` that the
@@ -1196,10 +1227,19 @@ fn hot_selfcheck(ctx: &Context, server: &Arc<InjectServer>, file: &Path, udid: &
     // Be generous so a slow/contended CI runner doesn't flake (the real watcher
     // loop has no such deadline — this bound only guards the self-check).
     let result = server.wait_for_result(baseline, Duration::from_secs(180));
-    // Restore the fixture regardless of outcome, and drop the backup once the
-    // pristine content is back in place.
-    let _ = std::fs::write(file, &original);
-    let _ = std::fs::remove_file(&backup);
+    // Restore the fixture regardless of outcome, and drop the backup only
+    // once the pristine content is verifiably back in place — a failed
+    // restore must keep the backup so the next run can self-heal.
+    match std::fs::write(file, &original) {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&backup);
+        }
+        Err(e) => ctx.out.alert(&format!(
+            "self-check: failed to restore {}: {e} (backup kept at {})",
+            file.display(),
+            backup.display()
+        )),
+    }
 
     match result {
         Some(true) => ctx.out.note("hot reload self-check: ✅ .injected"),
@@ -1307,6 +1347,7 @@ fn hot_key_loop(
     udid: &str,
     env: &[(String, String)],
     logs: &mut Option<LogStream>,
+    build_log: &Path,
 ) -> bool {
     let Ok(_raw) = rawmode::RawMode::enable() else {
         // No TTY for raw mode — just follow the log stream until Ctrl-C.
@@ -1331,8 +1372,10 @@ fn hot_key_loop(
                     };
                     // The session log stream follows the app by name, so it's
                     // left running — just terminate, rebuild, and relaunch.
+                    // Re-tee the transcript so the build-log recompiler keeps
+                    // seeing current frontend commands after the rebuild.
                     let _ = simctl::terminate(udid, &app.bundle_id);
-                    match build(plan, &ctx.out, None) {
+                    match build(plan, &ctx.out, Some(build_log)) {
                         BuildOutcome::Ok => {
                             if let Err(e) = launch_hot(ctx, udid, &app, env, &plan.launch.args) {
                                 ctx.out.error(&e);
@@ -2059,6 +2102,10 @@ fn check_exit(ctx: &Context, running: &mut Running) {
         .and_then(|c| c.try_wait().ok().flatten())
         .is_some();
     if exited {
+        // try_wait() reaped the child, so its pid can now be recycled —
+        // drop it from the signal handler's registry immediately rather than
+        // at session end, or a later SIGTERM could signal a stranger.
+        crate::cli::signals::unregister_child(running.reap_slot.take());
         ctx.out.alert(&format!("✗ {} exited", running.name));
         running.reported_exit = true;
     }
@@ -2114,7 +2161,7 @@ fn log_command(
     filters: &LogFilterArgs,
 ) -> (&'static str, Vec<String>) {
     use std::fmt::Write as _;
-    let exe = process_name(app);
+    let exe = predicate_escape(process_name(app));
     // A raw --predicate replaces the default process match wholesale;
     // --subsystem/--category narrow it.
     let mut predicate = filters.predicate.clone().unwrap_or_else(|| {
@@ -2123,10 +2170,10 @@ fn log_command(
         )
     });
     if let Some(subsystem) = &filters.subsystem {
-        let _ = write!(predicate, " AND subsystem == \"{subsystem}\"");
+        let _ = write!(predicate, " AND subsystem == \"{}\"", predicate_escape(subsystem));
     }
     if let Some(category) = &filters.category {
-        let _ = write!(predicate, " AND category == \"{category}\"");
+        let _ = write!(predicate, " AND category == \"{}\"", predicate_escape(category));
     }
     if let Some(marker) = marker {
         let _ = write!(

--- a/sweetpad-cli/src/cli/commands/context.rs
+++ b/sweetpad-cli/src/cli/commands/context.rs
@@ -567,10 +567,31 @@ fn effective<'a>(
     if let Some(value) = defaults_value(project, scope, v) {
         return (Some(value), "sweetpad.toml");
     }
-    match get(st, scope, v) {
-        Some(value) => (Some(value), "remembered"),
-        None => (None, ""),
+    if let Some(value) = get(st, scope, v) {
+        return (Some(value), "remembered");
     }
+    // `sweetpad test` falls back to the *build* context for scheme /
+    // configuration / destination (`resolve_testing`'s documented order), so
+    // the effective view must show that value — reporting "(not set)" here
+    // would tell a script the opposite of what `test` will actually use.
+    if matches!(scope, Scope::Testing)
+        && matches!(
+            v,
+            Variable::Scheme | Variable::Configuration | Variable::Destination
+        )
+    {
+        let (value, source) = effective(st, cfg, project, Scope::Build, v);
+        if value.is_some() {
+            let source = match source {
+                "config" => "build config",
+                "sweetpad.toml" => "build sweetpad.toml",
+                "remembered" => "build remembered",
+                other => other,
+            };
+            return (value, source);
+        }
+    }
+    (None, "")
 }
 
 fn print_scope(

--- a/sweetpad-cli/src/cli/commands/dependency.rs
+++ b/sweetpad-cli/src/cli/commands/dependency.rs
@@ -393,6 +393,10 @@ fn add_to_xcode(ctx: &mut Context, container: &Container, args: &AddArgs) -> Cli
     let pristine = std::fs::read_to_string(&pbxproj_path).map_err(|e| {
         CliError::new(format!("failed to read {}: {e}", pbxproj_path.display()))
     })?;
+    // The discovery resolve rewrites Package.resolved with the new package's
+    // pins — snapshot it too, so a cancel doesn't leave ghost pins that make
+    // `dep list`/`dep remove` misreport the abandoned package.
+    let pristine_lockfile = read_lockfile(container);
 
     // 1. Add the package reference (only) and write it, so resolution can fetch.
     let mut root = parse_owned(&xcodeproj)?;
@@ -435,9 +439,22 @@ fn add_to_xcode(ctx: &mut Context, container: &Container, args: &AddArgs) -> Cli
             Ok(())
         }
         Err(e) => {
-            let _ = std::fs::write(&pbxproj_path, &pristine);
-            ctx.out
-                .note("rolled the package reference back out of the project (nothing linked)");
+            if let Some(text) = pristine_lockfile {
+                let _ = std::fs::write(resolved_path(container), text);
+            }
+            // Report the rollback honestly — claiming success while the
+            // dangling reference remains would hide exactly the state this
+            // rollback exists to prevent.
+            if std::fs::write(&pbxproj_path, &pristine).is_ok() {
+                ctx.out
+                    .note("rolled the package reference back out of the project (nothing linked)");
+            } else {
+                ctx.out.warn(&format!(
+                    "could not roll the package reference back out of {} — the project may \
+                     reference the package without linking it",
+                    pbxproj_path.display()
+                ));
+            }
             Err(e)
         }
     }
@@ -490,12 +507,17 @@ fn add_to_package(ctx: &mut Context, container: &Container, args: &AddArgs) -> C
             })?;
         }
 
-        // 3. Settle products + targets and link each pair.
-        let (package_name, products) = if need_discovery {
-            let (name, available) = package_products(container, &args.url)?;
-            (name, choose("product", &available, &args.products, ctx)?)
+        // 3. Settle products + targets and link each pair. The `--package`
+        // value must be the dependency's *identity* (the URL basename), not
+        // the checkout manifest's declared name — for firebase-ios-sdk the
+        // manifest says "Firebase", and `.product(package: "Firebase")`
+        // fails the next resolve with "unknown package".
+        let package_name = package_display_name(&args.url);
+        let products = if need_discovery {
+            let available = package_products(container, &args.url)?;
+            choose("product", &available, &args.products, ctx)?
         } else {
-            (package_display_name(&args.url), args.products.clone())
+            args.products.clone()
         };
         let target_names = swiftpm::manifest(container)?
             .targets
@@ -587,21 +609,28 @@ fn discover_products(
     ctx.out.step("Resolving package dependencies", || {
         resolve_packages(container, Some(&clone), &ctx.out, true)
     })?;
-    let checkout = resolve_checkout(&clone, url).ok_or_else(|| {
-        CliError::new("could not locate the resolved package checkout to read its products")
-    })?;
-    Ok(product_names(&swiftpm::manifest_at(&checkout)?))
+    let products = (|| {
+        let checkout = resolve_checkout(&clone, url).ok_or_else(|| {
+            CliError::new("could not locate the resolved package checkout to read its products")
+        })?;
+        Ok(product_names(&swiftpm::manifest_at(&checkout)?))
+    })();
+    // The discovery checkouts (a full source clone of the package graph) are
+    // only needed to read the manifest — the pid-keyed dir would otherwise
+    // accumulate hundreds of MB per `dep add` with no later cleanup.
+    let _ = std::fs::remove_dir_all(&clone);
+    products
 }
 
-/// For a `Package.swift` add: resolve, then read the just-added package's name
-/// and products from its `.build` checkout.
-fn package_products(container: &Container, url: &str) -> Result<(String, Vec<String>), CliError> {
+/// For a `Package.swift` add: resolve, then read the just-added package's
+/// products from its `.build` checkout.
+fn package_products(container: &Container, url: &str) -> Result<Vec<String>, CliError> {
     let pkg_dir = swiftpm::package_dir(container).unwrap_or_else(|| PathBuf::from("."));
     let checkout = resolve_checkout(&pkg_dir.join(".build"), url).ok_or_else(|| {
         CliError::new("could not locate the resolved package checkout to read its products")
     })?;
     let manifest = swiftpm::manifest_at(&checkout)?;
-    Ok((manifest.name.clone(), product_names(&manifest)))
+    Ok(product_names(&manifest))
 }
 
 // ---------------------------------------------------------------------------
@@ -762,12 +791,35 @@ fn update(ctx: &mut Context, args: &UpdateArgs) -> CliResult {
 
     if !args.no_resolve {
         // Drop the stale pin so resolution re-pins to the new requirement
-        // (needed when downgrading), then resolve.
+        // (needed when downgrading), then resolve — restoring the lockfile
+        // if the resolve fails (e.g. offline) so the pin isn't lost.
+        let snapshot = read_lockfile(&container);
         remove_pin(&container, package);
-        resolve_packages(&container, None, &ctx.out, false)?;
+        if let Err(e) = resolve_packages(&container, None, &ctx.out, false) {
+            restore_lockfile(ctx, &container, snapshot);
+            return Err(e);
+        }
     }
     report_updated(ctx, package);
     Ok(())
+}
+
+/// Snapshot the lockfile's text (if it exists) before a destructive prune, so
+/// a failed resolve can put it back instead of losing every pinned version.
+fn read_lockfile(container: &Container) -> Option<String> {
+    std::fs::read_to_string(resolved_path(container)).ok()
+}
+
+/// Best-effort restore of a [`read_lockfile`] snapshot after a failed resolve.
+fn restore_lockfile(ctx: &Context, container: &Container, snapshot: Option<String>) {
+    let Some(text) = snapshot else { return };
+    if std::fs::write(resolved_path(container), text).is_ok() {
+        ctx.out
+            .note("restored Package.resolved after the failed resolve");
+    } else {
+        ctx.out
+            .warn("the resolve failed and Package.resolved could not be restored");
+    }
 }
 
 /// Plain update (no requirement change): bump pins to the latest the current
@@ -776,13 +828,26 @@ fn update_resolve(ctx: &mut Context, container: &Container, package: Option<&str
     if let Container::SwiftPackage(_) = container {
         swiftpm::update(container, package, ctx.out.is_json() || ctx.out.is_ndjson())?;
     } else {
+        // Verify the named package is actually declared before pruning, so a
+        // typo errors (with the did-you-mean hint) instead of reporting
+        // "updated <typo>" after a no-op resolve.
+        if let Some(p) = package {
+            let xcodeproj = pick_xcodeproj(ctx, container, Some(p))?;
+            let root = parse_owned(&xcodeproj)?;
+            find_package_or_hint(&root, container, p, &xcodeproj)?;
+        }
         // xcodebuild has no "update"; drop the pin(s) so the resolve re-pins to
-        // the latest allowed — one package, or the whole lockfile.
+        // the latest allowed — one package, or the whole lockfile. Snapshot
+        // first: a failed resolve (offline) must not destroy the lockfile.
+        let snapshot = read_lockfile(container);
         match package {
             Some(p) => remove_pin(container, p),
             None => delete_lockfile(container),
         }
-        resolve_packages(container, None, &ctx.out, false)?;
+        if let Err(e) = resolve_packages(container, None, &ctx.out, false) {
+            restore_lockfile(ctx, container, snapshot);
+            return Err(e);
+        }
     }
     report_updated(ctx, package.unwrap_or("all packages"));
     Ok(())
@@ -1110,7 +1175,13 @@ fn local_relative_path(xcodeproj: &Path, url: &str) -> Result<String, CliError> 
             "local package path `{url}` does not exist"
         )));
     }
-    let proj_dir = xcodeproj.parent().unwrap_or_else(|| Path::new("."));
+    // A bare `--project App.xcodeproj` has parent `Some("")`, not `None` —
+    // and canonicalizing "" fails, which would write an absolute (machine-
+    // specific) relativePath into the project.
+    let proj_dir = match xcodeproj.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p,
+        _ => Path::new("."),
+    };
     Ok(relative_path(proj_dir, &target))
 }
 
@@ -1335,7 +1406,21 @@ fn read_resolved(path: &Path) -> HashMap<String, Pin> {
         return map;
     };
     for pin in pins {
-        let Some(identity) = pin.get("identity").and_then(serde_json::Value::as_str) else {
+        // v2/v3 pins carry `identity`; v1 pins have no such key — derive it
+        // from `repositoryURL` (or the `package` display name) instead of
+        // silently skipping every v1 pin the branch above went to the
+        // trouble of finding.
+        let identity = pin
+            .get("identity")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .or_else(|| {
+                pin.get("repositoryURL")
+                    .or_else(|| pin.get("package"))
+                    .and_then(serde_json::Value::as_str)
+                    .map(spm_pbxproj::identity_from_url)
+            });
+        let Some(identity) = identity else {
             continue;
         };
         let state = pin.get("state");
@@ -1353,6 +1438,7 @@ fn read_resolved(path: &Path) -> HashMap<String, Pin> {
                 revision: field("revision"),
                 location: pin
                     .get("location")
+                    .or_else(|| pin.get("repositoryURL"))
                     .and_then(serde_json::Value::as_str)
                     .map(str::to_string),
             },

--- a/sweetpad-cli/src/cli/commands/settings.rs
+++ b/sweetpad-cli/src/cli/commands/settings.rs
@@ -116,6 +116,14 @@ fn show(ctx: &mut Context, target: Option<&str>, key: Option<&str>) -> CommandRe
     // an explicit --destination (the resolved layer) otherwise applies.
     let on_specifier = match ctx.targeting.on.clone() {
         Some(reference) => {
+            // Same rule as the build path: silently letting `--on` win would
+            // show settings for a destination a build with identical flags
+            // refuses to accept.
+            if ctx.targeting.destination.is_some() {
+                return Err(CliError::new(
+                    "--on and --destination are mutually exclusive; pass one",
+                ));
+            }
             let sims = crate::cli::simctl::list()?;
             let key = resolved.container.key();
             Some(resolve::resolve_on(ctx, &key, &reference, &sims)?.specifier())

--- a/sweetpad-cli/src/cli/commands/simulator.rs
+++ b/sweetpad-cli/src/cli/commands/simulator.rs
@@ -371,10 +371,16 @@ fn boot(ctx: &mut Context, target: Option<&str>, wait: bool) -> CommandResult {
             CliError::new(format!("no simulator matching {t:?}")).kind(ErrorKind::TargetResolution)
         })?
     } else {
-        let labels: Vec<String> = sims.iter().map(simctl::Simulator::label).collect();
+        // Disambiguate identical labels (name + OS clones) and map back by
+        // position, so the picker can never boot the wrong twin.
+        let refs: Vec<&simctl::Simulator> = sims.iter().collect();
+        let mut labels: Vec<String> = refs.iter().map(|s| s.label()).collect();
+        resolve::disambiguate_labels(&mut labels, &refs);
         let chosen = resolve::choose(ctx, "simulator", None, &labels)?;
-        sims.iter()
-            .find(|s| s.label() == chosen)
+        labels
+            .iter()
+            .position(|l| *l == chosen)
+            .map(|i| refs[i])
             .ok_or_else(|| CliError::new("simulator not found").kind(ErrorKind::TargetResolution))?
     };
 
@@ -459,11 +465,14 @@ fn screenshot(
 /// Put a PNG file on the macOS clipboard via osascript (`«class PNGf»`) — the
 /// only pasteboard route that needs no extra dependency.
 fn copy_png_to_clipboard(path: &std::path::Path) -> Result<(), CliError> {
-    let script = format!(
-        "set the clipboard to (read (POSIX file \"{}\") as «class PNGf»)",
-        path.display()
-    );
-    crate::cli::process::capture("osascript", &["-e", &script], None)
+    // The path rides in as an argv item (`on run argv`) instead of being
+    // spliced into the script source, where a `"` or `\` in the path would
+    // break compilation — or execute the path's content as AppleScript.
+    let script = "on run argv\n\
+                  set the clipboard to (read (POSIX file (item 1 of argv)) as «class PNGf»)\n\
+                  end run";
+    let path = path.to_string_lossy();
+    crate::cli::process::capture("osascript", &["-e", script, path.as_ref()], None)
         .map(|_| ())
         .map_err(|e| e.context("copying the screenshot to the clipboard"))
 }

--- a/sweetpad-cli/src/cli/config.rs
+++ b/sweetpad-cli/src/cli/config.rs
@@ -293,8 +293,21 @@ impl ProjectFile {
     #[must_use]
     pub fn load_for(container_dir: &std::path::Path) -> (Self, Vec<String>) {
         let path = container_dir.join("sweetpad.toml");
-        let Ok(text) = std::fs::read_to_string(&path) else {
-            return (Self::default(), Vec::new());
+        let text = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            // Only a *missing* file is silently defaults. A present-but-
+            // unreadable committed file (permissions, I/O error on a network
+            // mount) must warn like a malformed one — silently dropping the
+            // team's pinned defaults would build with the wrong Xcode.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return (Self::default(), Vec::new());
+            }
+            Err(e) => {
+                return (
+                    Self::default(),
+                    vec![format!("{}: {e} (file ignored)", path.display())],
+                );
+            }
         };
         match toml::from_str::<ProjectFile>(&text) {
             Ok(pf) => {

--- a/sweetpad-cli/src/cli/inject/client.rs
+++ b/sweetpad-cli/src/cli/inject/client.rs
@@ -172,8 +172,13 @@ fn materialize_client(bytes: &[u8], cache_root: &Path) -> Result<PathBuf, String
     }
     std::fs::create_dir_all(&dir).map_err(|e| format!("create client cache dir: {e}"))?;
     // Write to a temp path then rename, so a concurrent session never observes a
-    // half-written dylib at the final path.
-    let tmp = dir.join(".SweetpadInjectionClient.dylib.tmp");
+    // half-written dylib at the final path. The temp name carries our pid: with
+    // a fixed name, two concurrent processes would write through the same file
+    // and one could rename the other's half-written inode into place.
+    let tmp = dir.join(format!(
+        ".SweetpadInjectionClient.dylib.tmp.{}",
+        std::process::id()
+    ));
     std::fs::write(&tmp, bytes).map_err(|e| format!("write injection client: {e}"))?;
     std::fs::rename(&tmp, &dylib).map_err(|e| format!("install injection client: {e}"))?;
     Ok(dylib)

--- a/sweetpad-cli/src/cli/inject/protocol.rs
+++ b/sweetpad-cli/src/cli/inject/protocol.rs
@@ -91,19 +91,47 @@ pub fn read_int(s: &mut TcpStream) -> std::io::Result<Option<i32>> {
     Ok(read_exact_timed(s, &mut b)?.then(|| i32::from_le_bytes(b)))
 }
 
-/// Read a length-prefixed string. Blocks (ignoring intermediate timeouts) until
-/// the length and body arrive, since a partial string would desync the stream.
+/// Longest accepted length-prefixed string. Protocol strings are short paths
+/// and messages; without a cap, any local process connecting to the port
+/// could declare a ~2 GiB length and wedge the accept/serve thread on the
+/// allocation plus a read that never completes.
+const MAX_STRING_LEN: i32 = 1 << 20;
+
+/// Overall deadline for one string read. Retrying socket timeouts forever
+/// would let a peer that stops mid-string (or a desynced stream) hang the
+/// reading thread for the life of the connection.
+const STRING_READ_DEADLINE: Duration = Duration::from_secs(30);
+
+/// Read a length-prefixed string. Tolerates intermediate socket-timeout ticks
+/// (a partial string would desync the stream) but gives up after
+/// [`STRING_READ_DEADLINE`], and rejects lengths beyond [`MAX_STRING_LEN`].
 #[allow(clippy::cast_sign_loss)] // length is checked non-negative above
 pub fn read_string(s: &mut TcpStream) -> std::io::Result<String> {
+    let timed_out = || {
+        std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "timed out reading protocol string",
+        )
+    };
+    let deadline = std::time::Instant::now() + STRING_READ_DEADLINE;
     let len = loop {
         if let Some(v) = read_int(s)? {
             break v;
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(timed_out());
         }
     };
     if len < 0 {
         return Err(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
             "EOF reading string length",
+        ));
+    }
+    if len > MAX_STRING_LEN {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("protocol string length {len} exceeds the {MAX_STRING_LEN}-byte maximum"),
         ));
     }
     let mut buf = vec![0u8; len as usize];
@@ -119,7 +147,12 @@ pub fn read_string(s: &mut TcpStream) -> std::io::Result<String> {
             Ok(n) => filled += n,
             Err(e)
                 if e.kind() == std::io::ErrorKind::WouldBlock
-                    || e.kind() == std::io::ErrorKind::TimedOut => {}
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                if std::time::Instant::now() >= deadline {
+                    return Err(timed_out());
+                }
+            }
             Err(e) => return Err(e),
         }
     }

--- a/sweetpad-cli/src/cli/inject/recompiler.rs
+++ b/sweetpad-cli/src/cli/inject/recompiler.rs
@@ -270,7 +270,7 @@ impl Recompiler {
                             std::fs::canonicalize(f)
                                 .map(|c| c == canon)
                                 .unwrap_or(false)
-                                || f.ends_with(name)
+                                || path_suffix_matches(f, name)
                         })
                     {
                         return Ok(swift.clone());
@@ -316,10 +316,9 @@ impl Recompiler {
         let text = std::fs::read_to_string(log).map_err(|e| format!("read build log: {e}"))?;
 
         let is_primary_line = |l: &str| {
-            l.split_whitespace()
-                .collect::<Vec<_>>()
+            shell_tokens(l)
                 .windows(2)
-                .any(|w| w[0] == "-primary-file" && (w[1].ends_with(name) || w[1] == source_str))
+                .any(|w| w[0] == "-primary-file" && (path_suffix_matches(&w[1], name) || w[1] == source_str))
         };
         let line = text
             .lines()
@@ -332,8 +331,9 @@ impl Recompiler {
                 format!("no swift-frontend -primary-file command for {name} in build log")
             })?;
 
-        // Transcript args are shell-escaped; we exec argv directly, so unescape.
-        Ok(line.split_whitespace().map(unescape).collect())
+        // Transcript args are shell-escaped; we exec argv directly, so
+        // tokenize with escapes and quotes honored.
+        Ok(shell_tokens(line))
     }
 
     /// The `Xcode.app` path the client wants for `.xcodePath` (drops the
@@ -502,20 +502,61 @@ fn compile_and_link(
     Ok(())
 }
 
-/// Strip shell-escaping backslashes from a transcript token (`a\=b` -> `a=b`).
-fn unescape(t: &str) -> String {
-    let mut out = String::with_capacity(t.len());
-    let mut chars = t.chars();
+/// Tokenize a shell-escaped transcript line: an unquoted backslash escapes
+/// the next character (so `My\ Project` stays one token), quotes group, and
+/// only unescaped whitespace splits. A plain `split_whitespace` + unescape
+/// would tear every path containing a space into garbage tokens — routine on
+/// macOS ("My Project", "Application Support", iCloud Drive).
+fn shell_tokens(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut started = false;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut chars = line.chars();
     while let Some(c) = chars.next() {
-        if c == '\\' {
-            if let Some(n) = chars.next() {
-                out.push(n);
+        match c {
+            '\\' if !in_single => {
+                if let Some(n) = chars.next() {
+                    cur.push(n);
+                    started = true;
+                }
             }
-        } else {
-            out.push(c);
+            '\'' if !in_double => {
+                in_single = !in_single;
+                started = true;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+                started = true;
+            }
+            c if c.is_whitespace() && !in_single && !in_double => {
+                if started {
+                    out.push(std::mem::take(&mut cur));
+                    started = false;
+                }
+            }
+            c => {
+                cur.push(c);
+                started = true;
+            }
         }
     }
+    if started {
+        out.push(cur);
+    }
     out
+}
+
+/// Path-suffix match at a component boundary: `/a/b/View.swift` matches
+/// `b/View.swift` and `View.swift`, but a save of `View.swift` must not
+/// match `GridView.swift` (a bare `ends_with` would, selecting the wrong
+/// module or frontend command).
+fn path_suffix_matches(path: &str, suffix: &str) -> bool {
+    path == suffix
+        || (path.len() > suffix.len()
+            && path.ends_with(suffix)
+            && path.as_bytes()[path.len() - suffix.len() - 1] == b'/')
 }
 
 const DROP_WITH_NEXT: &[&str] = &[
@@ -561,7 +602,7 @@ fn single_file_command(
         }
         if t == "-primary-file" {
             let file = tokens.get(i + 1).ok_or("dangling -primary-file")?;
-            if file.ends_with(source) || source.ends_with(file.as_str()) {
+            if path_suffix_matches(file, source) || path_suffix_matches(source, file) {
                 out.push("-primary-file".into());
                 out.push(file.clone());
                 kept_primary = true;
@@ -647,19 +688,31 @@ mod tests {
     }
 
     #[test]
-    fn unescape_strips_backslashes() {
+    fn shell_tokens_unescapes_and_splits() {
         assert_eq!(
-            unescape(r"-enforce-exclusivity\=checked"),
-            "-enforce-exclusivity=checked"
+            shell_tokens(r"swiftc -primary-file /Users/me/My\ Project/Foo.swift x\=y"),
+            vec!["swiftc", "-primary-file", "/Users/me/My Project/Foo.swift", "x=y"]
         );
-        assert_eq!(unescape("plain"), "plain");
+        assert_eq!(shell_tokens("plain  two"), vec!["plain", "two"]);
+        assert_eq!(
+            shell_tokens(r#"a "quoted arg" 'single arg'"#),
+            vec!["a", "quoted arg", "single arg"]
+        );
+    }
+
+    #[test]
+    fn path_suffix_needs_component_boundary() {
+        assert!(path_suffix_matches("/a/b/View.swift", "View.swift"));
+        assert!(path_suffix_matches("/a/b/View.swift", "b/View.swift"));
+        assert!(!path_suffix_matches("/a/b/GridView.swift", "View.swift"));
+        assert!(path_suffix_matches("View.swift", "View.swift"));
     }
 
     #[test]
     fn single_file_keeps_our_primary_and_demotes_others() {
         let line = "/x/swift-frontend -frontend -c -primary-file /p/ContentView.swift \
                     -primary-file /p/App.swift -o /d/x.o -target arm64-apple-ios16.0-simulator";
-        let toks: Vec<String> = line.split_whitespace().map(unescape).collect();
+        let toks: Vec<String> = shell_tokens(line);
         let cmd =
             single_file_command(&toks, "/p/ContentView.swift", Path::new("/t/eval.o")).unwrap();
         // ContentView stays primary; App.swift demoted to a bare input; one -o added.
@@ -679,10 +732,8 @@ mod tests {
 
     #[test]
     fn single_file_errors_when_source_not_primary() {
-        let toks: Vec<String> = "swift-frontend -c -primary-file /p/Other.swift /p/X.swift"
-            .split_whitespace()
-            .map(unescape)
-            .collect();
+        let toks: Vec<String> =
+            shell_tokens("swift-frontend -c -primary-file /p/Other.swift /p/X.swift");
         assert!(single_file_command(&toks, "/p/X.swift", Path::new("/t/e.o")).is_err());
     }
 
@@ -770,10 +821,7 @@ mod tests {
     #[test]
     fn link_command_uses_build_target_and_sdk() {
         let toks: Vec<String> =
-            "swift-frontend -target arm64-apple-ios16.0-simulator -sdk /SDKs/Sim.sdk"
-                .split_whitespace()
-                .map(unescape)
-                .collect();
+            shell_tokens("swift-frontend -target arm64-apple-ios16.0-simulator -sdk /SDKs/Sim.sdk");
         let cmd = link_command(&toks, Path::new("/t/e.o"), Path::new("/t/e.dylib")).unwrap();
         assert!(cmd.contains(&"arm64-apple-ios16.0-simulator".to_string()));
         assert!(cmd.contains(&"/SDKs/Sim.sdk".to_string()));

--- a/sweetpad-cli/src/cli/inject/server.rs
+++ b/sweetpad-cli/src/cli/inject/server.rs
@@ -112,8 +112,12 @@ impl InjectServer {
                         std::thread::sleep(Duration::from_millis(100));
                     }
                     Err(e) => {
-                        log(&format!("[hot] Accept failed: {e}"));
-                        return;
+                        // accept(2) fails transiently (ECONNABORTED when a
+                        // peer resets between SYN and accept, EINTR); exiting
+                        // here would kill hot reload for the rest of the
+                        // session with no way to reconnect.
+                        log(&format!("[hot] Accept failed: {e} (still listening)"));
+                        std::thread::sleep(Duration::from_millis(500));
                     }
                 }
             }
@@ -192,6 +196,9 @@ impl InjectServer {
             if self.is_connected() {
                 return true;
             }
+            if self.stop.load(Ordering::Relaxed) {
+                return false;
+            }
             std::thread::sleep(Duration::from_millis(100));
         }
         self.is_connected()
@@ -210,6 +217,12 @@ impl InjectServer {
             }
             if fail > baseline.1 {
                 return Some(false);
+            }
+            // Shutdown closes the connection, so the verdict can never
+            // arrive — returning early keeps teardown from hanging the
+            // watcher join for the full timeout.
+            if self.stop.load(Ordering::Relaxed) {
+                return None;
             }
             std::thread::sleep(Duration::from_millis(100));
         }
@@ -335,6 +348,21 @@ fn response_loop(
                 if let Ok(msg) = protocol::read_string(&mut reader) {
                     log(&format!("[hot] {msg}"));
                 }
+            }
+            // Payload-bearing responses that straggle in after the handshake
+            // drain: consume their string(s), or the leftover bytes desync
+            // the stream and every later verdict is garbage.
+            Ok(Some(response::PLATFORM)) => {
+                let _ = protocol::read_string(&mut reader);
+                let _ = protocol::read_string(&mut reader);
+            }
+            Ok(Some(
+                response::TMP_PATH
+                | response::PROJECT_ROOT
+                | response::EXECUTABLE
+                | response::BAZEL_TARGET,
+            )) => {
+                let _ = protocol::read_string(&mut reader);
             }
             // .unhide (precedes .failed), other responses, and read timeouts:
             // nothing to report — keep polling.

--- a/sweetpad-cli/src/cli/merge.rs
+++ b/sweetpad-cli/src/cli/merge.rs
@@ -159,7 +159,13 @@ pub fn resolve(kind: Kind, paths: &[PathBuf], force: bool) -> CommandResult {
     let repo = PathBuf::from(git(None, &["rev-parse", "--show-toplevel"])?.trim());
 
     let targets: Vec<String> = if paths.is_empty() {
-        git(Some(&repo), &["diff", "--name-only", "--diff-filter=U"])?
+        git(
+            Some(&repo),
+            // quotePath off: with the default on, any non-ASCII path comes
+            // back C-quoted ("Caf\\303\\251…"), fails the extension match,
+            // and the conflict is silently skipped.
+            &["-c", "core.quotePath=off", "diff", "--name-only", "--diff-filter=U"],
+        )?
             .lines()
             .map(str::trim)
             .filter(|l| !l.is_empty() && kind.matches(l))
@@ -199,7 +205,13 @@ pub fn resolve_auto(paths: &[PathBuf], force: bool) -> CommandResult {
     let repo = PathBuf::from(git(None, &["rev-parse", "--show-toplevel"])?.trim());
 
     let targets: Vec<String> = if paths.is_empty() {
-        git(Some(&repo), &["diff", "--name-only", "--diff-filter=U"])?
+        git(
+            Some(&repo),
+            // quotePath off: with the default on, any non-ASCII path comes
+            // back C-quoted ("Caf\\303\\251…"), fails the extension match,
+            // and the conflict is silently skipped.
+            &["-c", "core.quotePath=off", "diff", "--name-only", "--diff-filter=U"],
+        )?
             .lines()
             .map(str::trim)
             .filter(|l| !l.is_empty() && (Kind::Pbxproj.matches(l) || Kind::Spm.matches(l)))

--- a/sweetpad-cli/src/cli/mod.rs
+++ b/sweetpad-cli/src/cli/mod.rs
@@ -220,6 +220,19 @@ pub struct Targeting {
     pub sdk: Option<String>,
 }
 
+/// Normalize clap's `env = …` fallback: an exported-but-empty `SWEETPAD_*`
+/// var arrives as `Some("")`, which would skip the resolution layers below it
+/// and hand xcodebuild an empty `-scheme`/`-destination`. Empty means unset —
+/// matching `Targeting::from_env`, which the bare status view uses.
+fn non_empty(v: Option<String>) -> Option<String> {
+    v.filter(|s| !s.is_empty())
+}
+
+/// [`non_empty`] for path-valued flags.
+fn non_empty_path(v: Option<std::path::PathBuf>) -> Option<std::path::PathBuf> {
+    v.filter(|p| !p.as_os_str().is_empty())
+}
+
 impl From<ContainerArgs> for Targeting {
     fn from(a: ContainerArgs) -> Self {
         // clap's `env = …` folds `SWEETPAD_WORKSPACE`/`SWEETPAD_PROJECT` into
@@ -227,8 +240,8 @@ impl From<ContainerArgs> for Targeting {
         // an explicit `--project` (the container check prefers workspace).
         // Consult the real argv to restore the documented flag > env order.
         let (workspace, project) = disambiguate_container(
-            a.workspace,
-            a.project,
+            non_empty_path(a.workspace),
+            non_empty_path(a.project),
             flag_typed("--workspace"),
             flag_typed("--project"),
         );
@@ -337,7 +350,7 @@ impl Targeting {
 impl From<SchemeArgs> for Targeting {
     fn from(a: SchemeArgs) -> Self {
         Self {
-            scheme: a.scheme,
+            scheme: non_empty(a.scheme),
             ..a.container.into()
         }
     }
@@ -351,16 +364,16 @@ impl From<BuildTargetArgs> for Targeting {
         // pair resolves post-parse like the container flags: the typed one
         // wins; both-typed is rejected where the destination settles.
         let (on, destination) = disambiguate_on_destination(
-            a.on,
-            a.destination,
+            non_empty(a.on),
+            non_empty(a.destination),
             flag_typed("--on"),
             flag_typed("--destination"),
         );
         Self {
-            configuration: a.configuration,
+            configuration: non_empty(a.configuration),
             destination,
             on,
-            sdk: a.sdk,
+            sdk: non_empty(a.sdk),
             ..a.scheme.into()
         }
     }
@@ -634,11 +647,9 @@ pub fn run(argv: &[String]) -> ExitCode {
     if let Some(dir) = &cli.global.chdir
         && let Err(e) = std::env::set_current_dir(dir)
     {
-        out.error(&CliError::new(format!(
-            "cannot change directory to {}: {e}",
-            dir.display()
-        )));
-        return ExitCode::FAILURE;
+        let err = CliError::new(format!("cannot change directory to {}: {e}", dir.display()));
+        render_early_error(&out, &err);
+        return ExitCode::from(err.error_kind().exit_code());
     }
     // `--developer-dir` pins the Xcode every spawned tool uses (xcrun,
     // xcodebuild, simctl all honor DEVELOPER_DIR).
@@ -647,11 +658,12 @@ pub fn run(argv: &[String]) -> ExitCode {
         unsafe { std::env::set_var("DEVELOPER_DIR", dir) };
     }
     if cli.global.gh_annotations && (out.is_json() || out.is_ndjson()) {
-        out.error(&CliError::new(
+        let err = CliError::new(
             "--gh-annotations writes ::error workflow commands to stdout, which -o json/ndjson \
              reserve for the envelope/event stream; use --gh-annotations with human output",
-        ));
-        return ExitCode::FAILURE;
+        );
+        render_early_error(&out, &err);
+        return ExitCode::from(err.error_kind().exit_code());
     }
     let config = match config::Config::load() {
         Ok(c) => c,
@@ -795,6 +807,22 @@ pub fn run(argv: &[String]) -> ExitCode {
 /// (`json_value` wraps the payload's data in `{schema, ok, data}`), or — under
 /// `-o ndjson` — the terminal `{"event":"result","ok":true,"data":…}` line
 /// closing the event stream. Also maps errors to exit codes.
+/// Mirror [`render_result`]'s error path for failures raised before a
+/// `Context` exists (`-C` chdir, flag conflicts): the ndjson stream's
+/// documented contract — it ends with a `{"event":"result",…}` line — must
+/// hold for these errors too.
+fn render_early_error(out: &output::Output, err: &CliError) {
+    out.ndjson_event(&serde_json::json!({
+        "event": "result",
+        "ok": false,
+        "error": {
+            "code": err.error_kind().code_str(),
+            "message": err.to_string(),
+        },
+    }));
+    out.error(err);
+}
+
 fn render_result(ctx: &Context, result: CommandResult) -> ExitCode {
     match result {
         Ok(Rendered::Data { payload, exit }) => {

--- a/sweetpad-cli/src/cli/process.rs
+++ b/sweetpad-cli/src/cli/process.rs
@@ -133,6 +133,10 @@ pub fn stream_lines(
     let (reader, out, err) = merged_output_pipe(program)?;
     cmd.stdout(out).stderr(err);
     let mut child = cmd.spawn().map_err(|e| spawn_error(program, &e))?;
+    // `spawn` only borrows fds > 2, so `cmd` still owns the pipe's two write
+    // ends — drop it now or the read below never sees EOF after the child
+    // exits, hanging the whole command.
+    drop(cmd);
     read_lines_lossy(reader, &mut on_line);
     let status = child.wait().map_err(|e| spawn_error(program, &e))?;
     Ok(status.success())
@@ -159,6 +163,14 @@ fn merged_output_pipe(program: &str) -> Result<(std::fs::File, Stdio, Stdio), Cl
             libc::close(fds[0]);
             libc::close(fds[1]);
             return Err(CliError::new(format!("failed to run `{program}`: {e}")));
+        }
+        // CLOEXEC on all three (macOS has no pipe2): a child spawned
+        // concurrently on another thread (BgBoot, the hot-reload watcher)
+        // must not inherit the write ends, or EOF waits for *that* child
+        // too. posix_spawn's dup2 file actions clear the flag on the
+        // intended child's stdio copies, so it still gets them.
+        for fd in [fds[0], fds[1], dup] {
+            libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC);
         }
         Ok((
             std::fs::File::from_raw_fd(fds[0]),

--- a/sweetpad-cli/src/cli/resolve.rs
+++ b/sweetpad-cli/src/cli/resolve.rs
@@ -468,10 +468,16 @@ pub fn select_simulator<'a>(
     } else {
         sims.iter().collect()
     };
-    let labels: Vec<String> = pool.iter().map(|s| s.label()).collect();
+    // Disambiguate identical labels (same name + OS clones) and map the choice
+    // back by position — matching on the label string alone would silently act
+    // on the *first* twin no matter which row the user picked.
+    let mut labels: Vec<String> = pool.iter().map(|s| s.label()).collect();
+    disambiguate_labels(&mut labels, &pool);
     let chosen = choose(ctx, "simulator", None, &labels)?;
-    pool.into_iter()
-        .find(|s| s.label() == chosen)
+    labels
+        .iter()
+        .position(|l| *l == chosen)
+        .map(|i| pool[i])
         .ok_or_else(|| CliError::new("simulator not found").kind(ErrorKind::TargetResolution))
 }
 
@@ -832,12 +838,24 @@ fn recover_stale(
     err: CliError,
 ) -> Result<Option<String>, CliError> {
     let key = container.key();
-    let field = |p: &crate::cli::state::ProjectState| match what {
-        "scheme" => p.scheme.clone(),
-        _ => p.configuration.clone(),
-    };
-    let remembered = ctx.state.projects.get(&key).and_then(field);
-    if remembered.as_deref() != Some(value) {
+    // The stale value may live in the build state, the testing state
+    // (`context select … --testing`), or both — `resolve_testing` reads both
+    // layers, so recovery must clear whichever one(s) hold it, or a stale
+    // testing pick fails every `sweetpad test` forever.
+    let st = ctx.state.projects.get(&key);
+    let build_match = st
+        .and_then(|p| match what {
+            "scheme" => p.scheme.as_deref(),
+            _ => p.configuration.as_deref(),
+        })
+        == Some(value);
+    let testing_match = st
+        .and_then(|p| match what {
+            "scheme" => p.testing.scheme.as_deref(),
+            _ => p.testing.configuration.as_deref(),
+        })
+        == Some(value);
+    if !build_match && !testing_match {
         return Err(err);
     }
     let flag = match what {
@@ -849,20 +867,49 @@ fn recover_stale(
         return Err(err);
     }
     let entry = ctx.state.project_mut(&key);
-    match what {
-        "scheme" => entry.scheme = None,
-        _ => entry.configuration = None,
+    if what == "scheme" {
+        if build_match {
+            entry.scheme = None;
+        }
+        if testing_match {
+            entry.testing.scheme = None;
+        }
+    } else {
+        if build_match {
+            entry.configuration = None;
+        }
+        if testing_match {
+            entry.testing.configuration = None;
+        }
     }
     let _ = ctx.state.save();
+    let hint = if testing_match {
+        format!("`sweetpad context remove {what} --testing` does this by hand")
+    } else {
+        format!("`sweetpad context remove {what}` does this by hand")
+    };
     ctx.out.warn(&format!(
-        "the remembered {what} {value:?} no longer exists in the project — cleared it \
-         (`sweetpad context remove {what}` does this by hand)"
+        "the remembered {what} {value:?} no longer exists in the project — cleared it ({hint})"
     ));
     let cfg = ctx.config.for_project(&key);
     let pf = ctx.project_file(container);
     let higher = match what {
-        "scheme" => flag.or_else(|| cfg.scheme.clone()).or_else(|| pf.scheme.clone()),
+        "scheme" => flag
+            .or_else(|| testing_match.then(|| cfg.testing.scheme.clone()).flatten())
+            .or_else(|| testing_match.then(|| pf.testing.scheme.clone()).flatten())
+            .or_else(|| cfg.scheme.clone())
+            .or_else(|| pf.scheme.clone()),
         _ => flag
+            .or_else(|| {
+                testing_match
+                    .then(|| cfg.testing.configuration.clone())
+                    .flatten()
+            })
+            .or_else(|| {
+                testing_match
+                    .then(|| pf.testing.configuration.clone())
+                    .flatten()
+            })
             .or_else(|| cfg.configuration.clone())
             .or_else(|| pf.configuration.clone()),
     };
@@ -1053,7 +1100,7 @@ fn destination_choices<'a>(
 /// Append a short udid suffix to any labels that would otherwise be identical
 /// (same name, OS version, and boot marker), so the picker shows distinct rows
 /// and the chosen label maps back to exactly one simulator in [`pick_destination`].
-fn disambiguate_labels(labels: &mut [String], ordered: &[&crate::cli::simctl::Simulator]) {
+pub(crate) fn disambiguate_labels(labels: &mut [String], ordered: &[&crate::cli::simctl::Simulator]) {
     use std::fmt::Write as _;
     let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
     for label in labels.iter() {

--- a/sweetpad-cli/src/cli/scaffold.rs
+++ b/sweetpad-cli/src/cli/scaffold.rs
@@ -171,10 +171,16 @@ pub fn bundle_id_segment(name: &str) -> String {
     }
 }
 
-/// A version-shaped string like `17.0` or `16`.
+/// A version-shaped string like `17.0` or `16`: one to three dot-separated
+/// digit runs. A digits-and-dots test alone admits `17.`, `1..2`, and
+/// `1.2.3.4` — shapes Xcode rejects or misreads once scaffolded into
+/// `IPHONEOS_DEPLOYMENT_TARGET`.
 pub fn validate_deployment_target(target: &str) -> Result<(), String> {
-    let shaped = target.chars().next().is_some_and(|c| c.is_ascii_digit())
-        && target.chars().all(|c| c.is_ascii_digit() || c == '.');
+    let segments: Vec<&str> = target.split('.').collect();
+    let shaped = (1..=3).contains(&segments.len())
+        && segments
+            .iter()
+            .all(|s| !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()));
     if shaped {
         Ok(())
     } else {
@@ -820,7 +826,12 @@ mod tests {
         assert!(validate_bundle_id("com.example app").is_err());
         assert!(validate_deployment_target("17.0").is_ok());
         assert!(validate_deployment_target("16").is_ok());
+        assert!(validate_deployment_target("17.0.1").is_ok());
         assert!(validate_deployment_target("latest").is_err());
+        // Digits-and-dots isn't enough: these scaffold settings Xcode rejects.
+        assert!(validate_deployment_target("17.").is_err());
+        assert!(validate_deployment_target("1..2").is_err());
+        assert!(validate_deployment_target("1.2.3.4").is_err());
     }
 
     #[test]

--- a/sweetpad-cli/src/cli/simctl.rs
+++ b/sweetpad-cli/src/cli/simctl.rs
@@ -434,7 +434,17 @@ pub fn open_app() -> Result<(), CliError> {
 /// Block until a booting simulator is fully up (`simctl bootstatus -b`).
 pub fn boot_wait(udid: &str) -> Result<(), CliError> {
     process::run("xcrun", &["simctl", "bootstatus", udid, "-b"], None, true)
-        .map(|_| ())
+        .and_then(|ok| {
+            // `run` returns Ok(false) on a non-zero exit — a bootstatus that
+            // errored mid-boot must not report the boot as finished.
+            if ok {
+                Ok(())
+            } else {
+                Err(CliError::new(
+                    "simctl bootstatus exited with a non-zero status",
+                ))
+            }
+        })
         .context("waiting for the simulator to finish booting")
 }
 
@@ -554,8 +564,24 @@ pub fn record(udid: &str, path: &str) -> Result<bool, CliError> {
     .context("recording the simulator screen")?;
     let mut child = child;
     crate::cli::signals::set_forward_child(child.id());
-    let status = child.wait();
-    crate::cli::signals::clear_forward_child();
+    // Poll-reap instead of a blocking wait: recordVideo takes seconds to
+    // finalize after the forwarded SIGINT, and users double-tap Ctrl-C. With
+    // a blocking wait the forward pid stayed armed for that whole window
+    // after the reap, so a second Ctrl-C could signal a freed (recyclable)
+    // pid. Polling shrinks the armed-after-reap window to one loop tick.
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                crate::cli::signals::clear_forward_child();
+                break child.wait();
+            }
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(50)),
+            Err(e) => {
+                crate::cli::signals::clear_forward_child();
+                break Err(e);
+            }
+        }
+    };
     let stopped = crate::cli::signals::take_forwarded();
     match status {
         Ok(s) if s.success() || stopped => Ok(stopped),

--- a/sweetpad-cli/src/cli/state.rs
+++ b/sweetpad-cli/src/cli/state.rs
@@ -286,7 +286,10 @@ fn quarantine_path(path: &std::path::Path) -> PathBuf {
             return candidate;
         }
     }
-    base
+    // 100 backups already exist (a recurring corruption source). Returning
+    // `base` here would rename over the oldest — possibly only intact —
+    // snapshot; a pid-suffixed name stays collision-free instead.
+    path.with_extension(format!("toml.corrupt.pid{}", std::process::id()))
 }
 
 /// Whether a state key points at a deleted container: the path is gone but its

--- a/sweetpad-cli/src/cli/swiftpm.rs
+++ b/sweetpad-cli/src/cli/swiftpm.rs
@@ -90,13 +90,19 @@ impl Manifest {
 fn parse_dependency(dep: &serde_json::Value) -> Option<DeclaredDep> {
     if let Some(sc) = first_of(dep, "sourceControl") {
         let identity = str_at(sc, "identity").unwrap_or_default().to_string();
-        let location = sc
-            .get("location")
-            .and_then(|loc| {
-                first_of(loc, "remote")
-                    .and_then(|m| str_at(m, "urlString").or_else(|| str_at(m, "url")))
-                    .or_else(|| loc.as_str())
-            })
+        // The location union has a `local` case too (a local *git* URL like
+        // `.package(url: "../Sibling", …)`) — without it the location column
+        // rendered blank for such dependencies.
+        let loc = sc.get("location");
+        let remote_url = loc
+            .and_then(|l| first_of(l, "remote"))
+            .and_then(|m| str_at(m, "urlString").or_else(|| str_at(m, "url")));
+        let local_path = loc
+            .and_then(|l| first_of(l, "local"))
+            .and_then(|m| m.as_str().or_else(|| str_at(m, "path")));
+        let location = remote_url
+            .or(local_path)
+            .or_else(|| loc.and_then(serde_json::Value::as_str))
             .unwrap_or_default()
             .to_string();
         let requirement = sc
@@ -106,7 +112,7 @@ fn parse_dependency(dep: &serde_json::Value) -> Option<DeclaredDep> {
             identity,
             location,
             requirement,
-            remote: true,
+            remote: remote_url.is_some() || local_path.is_none(),
         });
     }
     if let Some(fs) = first_of(dep, "fileSystem") {
@@ -366,8 +372,17 @@ pub fn build(
 ) -> Result<(), CliError> {
     let cwd = package_dir(container);
     if clean {
-        process::run("swift", &["package", "clean"], cwd.as_deref(), quiet)
+        // The user explicitly asked for a clean build — a failed clean
+        // followed by an incremental build would silently hand back stale
+        // artifacts, so a non-zero `swift package clean` is an error here.
+        let cleaned = process::run("swift", &["package", "clean"], cwd.as_deref(), quiet)
             .context("cleaning the package build")?;
+        if !cleaned {
+            return Err(
+                CliError::new("swift package clean exited with a non-zero status")
+                    .context("cleaning the package build"),
+            );
+        }
     }
     let args = build_args(configuration, passthrough);
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();

--- a/sweetpad-core/src/bsp/mod.rs
+++ b/sweetpad-core/src/bsp/mod.rs
@@ -1272,11 +1272,16 @@ fn path_from_uri(uri: &str) -> PathBuf {
     let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
+        // Decode on bytes only: slicing `raw` here would panic on a non-char
+        // boundary when a client sends `%` followed by unencoded non-ASCII
+        // (several BSP clients don't percent-encode), and hex is validated
+        // per digit so a stray `%+5` stays literal.
         if bytes[i] == b'%'
             && i + 2 < bytes.len()
-            && let Ok(b) = u8::from_str_radix(&raw[i + 1..i + 3], 16)
+            && let Some(hi) = (bytes[i + 1] as char).to_digit(16)
+            && let Some(lo) = (bytes[i + 2] as char).to_digit(16)
         {
-            out.push(b);
+            out.push((hi * 16 + lo) as u8);
             i += 3;
             continue;
         }

--- a/sweetpad-core/src/bsp/mod.rs
+++ b/sweetpad-core/src/bsp/mod.rs
@@ -1281,7 +1281,8 @@ fn path_from_uri(uri: &str) -> PathBuf {
             && let Some(hi) = (bytes[i + 1] as char).to_digit(16)
             && let Some(lo) = (bytes[i + 2] as char).to_digit(16)
         {
-            out.push((hi * 16 + lo) as u8);
+            // Two hex digits are ≤ 0xFF by construction.
+            out.push(u8::try_from(hi * 16 + lo).unwrap_or(u8::MAX));
             i += 3;
             continue;
         }
@@ -1387,7 +1388,27 @@ fn editor_sdk_for(sdkroot: &str, supported_platforms: &str) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::editor_sdk_for;
+    use super::{editor_sdk_for, path_from_uri};
+
+    #[test]
+    fn path_from_uri_survives_unencoded_non_ascii_after_percent() {
+        // A `%` followed within two bytes by a multi-byte char used to panic
+        // (str slice off a char boundary) and kill the whole BSP server.
+        assert_eq!(
+            path_from_uri("file:///tmp/100%€/x.swift"),
+            std::path::PathBuf::from("/tmp/100%€/x.swift")
+        );
+        // Normal decoding still works, and per-digit hex validation keeps a
+        // stray `%+5` literal instead of decoding it.
+        assert_eq!(
+            path_from_uri("file:///a%20b/c.swift"),
+            std::path::PathBuf::from("/a b/c.swift")
+        );
+        assert_eq!(
+            path_from_uri("file:///x%+5y"),
+            std::path::PathBuf::from("/x%+5y")
+        );
+    }
 
     #[test]
     fn editor_sdk_from_concrete_sdkroot() {

--- a/sweetpad-core/src/build_settings.rs
+++ b/sweetpad-core/src/build_settings.rs
@@ -180,6 +180,13 @@ pub fn resolve_build_settings(opts: &BuildSettingsOptions) -> Result<Vec<TargetS
                 settings: resolved.settings,
             });
         }
+        // Zero queries (a scheme whose entries are all testing-only, or whose
+        // container references another project) must error like the workspace
+        // branch does — an empty Ok would surface downstream as a misleading
+        // "no app bundle"-style failure instead of naming the real cause.
+        if out.is_empty() {
+            return Err(format!("no target matched {}", selection.describe()));
+        }
         project_keys(&mut out, opts.keys.as_deref());
         Ok(out)
     } else {

--- a/sweetpad-core/src/framing.rs
+++ b/sweetpad-core/src/framing.rs
@@ -11,15 +11,32 @@ use std::io::{BufRead, Write};
 /// single body byte is read.
 const MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
 
+/// Largest accepted header line. Real headers are tens of bytes; without a
+/// bound, a peer that streams bytes with no newline grows the header buffer
+/// without limit — the exact allocation blowup [`MAX_FRAME_BYTES`] exists to
+/// stop, just before the body instead of inside it.
+const MAX_HEADER_BYTES: u64 = 64 * 1024;
+
 /// Read one `Content-Length`-framed JSON-RPC message. `Ok(None)` on clean EOF.
 pub fn read_message(reader: &mut impl BufRead) -> Result<Option<String>, String> {
     let mut content_length: Option<usize> = None;
     loop {
-        let mut line = String::new();
-        let n = reader.read_line(&mut line).map_err(|e| e.to_string())?;
+        let mut raw = Vec::new();
+        // UFCS so `take` binds to `impl Read for &mut R` (a plain method call
+        // auto-derefs and tries to move the reader itself).
+        let mut limited = std::io::Read::take(&mut *reader, MAX_HEADER_BYTES);
+        let n = limited
+            .read_until(b'\n', &mut raw)
+            .map_err(|e| e.to_string())?;
         if n == 0 {
             return Ok(None);
         }
+        if raw.last() != Some(&b'\n') && n as u64 == MAX_HEADER_BYTES {
+            return Err(format!(
+                "header line exceeds the {MAX_HEADER_BYTES}-byte cap"
+            ));
+        }
+        let line = String::from_utf8_lossy(&raw);
         let line = line.trim_end_matches(['\r', '\n']);
         if line.is_empty() {
             break;

--- a/sweetpad-lib/src/compiler_args.rs
+++ b/sweetpad-lib/src/compiler_args.rs
@@ -220,14 +220,19 @@ pub fn swift_arguments(
     }
     // SWIFT_OPTIMIZATION_LEVEL: the spec enum maps `-Owholemodule` specially and
     // passes everything else (`-Onone`/`-O`/`-Osize`) through as the flag itself.
+    // The hand-coded fallbacks apply the same empty/unexpanded guard as
+    // `spec`: a cleared `SWIFT_OPTIMIZATION_LEVEL =` xcconfig idiom would
+    // otherwise emit a bare empty flag, and an empty `SWIFT_VERSION` an
+    // invalid `-swift-version ""` swiftc rejects.
+    let present = |v: &str| !v.is_empty() && !v.contains("$(");
     if let Some(args) = spec("SWIFT_OPTIMIZATION_LEVEL") {
         a.extend(args);
-    } else if let Some(opt) = get("SWIFT_OPTIMIZATION_LEVEL") {
+    } else if let Some(opt) = get("SWIFT_OPTIMIZATION_LEVEL").filter(|v| present(v)) {
         a.flag(opt);
     }
     // SWIFT_VERSION has no swift-spec encoding — the build system passes it,
     // collapsing `5.0` → `5`.
-    if let Some(v) = get("SWIFT_VERSION") {
+    if let Some(v) = get("SWIFT_VERSION").filter(|v| present(v)) {
         a.pair("-swift-version", swift_version(v));
     }
 
@@ -306,7 +311,9 @@ pub fn swift_arguments(
 
     // --- Clang importer flags ----------------------------------------------
     // GCC_PREPROCESSOR_DEFINITIONS reach the embedded clang importer as -Xcc -D.
-    for def in ws(get("GCC_PREPROCESSOR_DEFINITIONS")) {
+    // Quote-aware: `APP_NAME='My App'` is one define — a plain whitespace
+    // split would tear it into two garbage macros with unbalanced quotes.
+    for def in ws_quoted(get("GCC_PREPROCESSOR_DEFINITIONS")) {
         a.pair("-Xcc", &format!("-D{def}"));
     }
     // The products `include` dir, where Xcode drops generated module maps.
@@ -610,7 +617,10 @@ pub fn link_arguments(
     if mach_o == Some("mh_bundle") {
         a.flag("-bundle");
     }
-    if let Some(level) = get("GCC_OPTIMIZATION_LEVEL") {
+    // A cleared `GCC_OPTIMIZATION_LEVEL =` must emit nothing — a bare `-O`
+    // would silently link at clang's -O1 instead of the project's level.
+    if let Some(level) = get("GCC_OPTIMIZATION_LEVEL").filter(|v| !v.is_empty() && !v.contains("$("))
+    {
         a.flag(&format!("-O{level}"));
     }
     let library_paths = emit_library_paths(&mut a, settings);
@@ -1273,6 +1283,47 @@ fn ws(v: Option<&str>) -> Vec<&str> {
 /// string as a literal (relative) path and never find the framework / header /
 /// module map. (Distinct from [`ws`], which leaves quotes intact for value
 /// lists like preprocessor defines.)
+/// Like [`ws_unquoted`], but the quote characters are *kept* in each token —
+/// for value lists (preprocessor defines) where the quoting is part of the
+/// value, yet a quoted segment's spaces still must not split the token:
+/// `APP_NAME='My App'` is one define, not two.
+fn ws_quoted(v: Option<&str>) -> Vec<String> {
+    let Some(s) = v else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut quote: Option<char> = None;
+    let mut started = false;
+    for ch in s.chars() {
+        match (ch, quote) {
+            (c @ ('"' | '\''), None) => {
+                quote = Some(c);
+                cur.push(c);
+                started = true;
+            }
+            (c, Some(q)) if c == q => {
+                quote = None;
+                cur.push(c);
+            }
+            (c, None) if c.is_whitespace() => {
+                if started {
+                    out.push(std::mem::take(&mut cur));
+                    started = false;
+                }
+            }
+            (c, _) => {
+                cur.push(c);
+                started = true;
+            }
+        }
+    }
+    if started {
+        out.push(cur);
+    }
+    out
+}
+
 fn ws_unquoted(v: Option<&str>) -> Vec<String> {
     let Some(s) = v else {
         return Vec::new();

--- a/sweetpad-lib/src/pbxproj.rs
+++ b/sweetpad-lib/src/pbxproj.rs
@@ -663,6 +663,26 @@ mod tests {
     }
 
     #[test]
+    fn quoted_string_decodes_octal_escapes() {
+        // CF's old-style parser reads `\ddd` as up to three octal digits;
+        // consuming only `\0` used to leak the remaining digits as literals.
+        let v = parse(r#"{ a = "\101\012x"; nul = "\0z"; }"#).unwrap();
+        assert_eq!(v.get("a").and_then(Value::as_str), Some("A\nx"));
+        assert_eq!(v.get("nul").and_then(Value::as_str), Some("\0z"));
+    }
+
+    #[test]
+    fn quoted_string_recombines_surrogate_pairs() {
+        // Apple's serializer escapes per UTF-16 code unit, so an emoji is a
+        // `\Ud83d\Ude00` pair — previously a hard "bad unicode codepoint".
+        let v = parse(r#"{ e = "\Ud83d\Ude00"; bmp = "\U00e9"; }"#).unwrap();
+        assert_eq!(v.get("e").and_then(Value::as_str), Some("😀"));
+        assert_eq!(v.get("bmp").and_then(Value::as_str), Some("é"));
+        // A lone high surrogate is still rejected.
+        assert!(parse(r#"{ bad = "\Ud83d"; }"#).is_err());
+    }
+
+    #[test]
     fn preserves_key_insertion_order() {
         let v = parse("{ z = 1; a = 2; m = 3; }").unwrap();
         let keys: Vec<&str> = v.as_dict().unwrap().keys().map(String::as_str).collect();

--- a/sweetpad-lib/src/pbxproj.rs
+++ b/sweetpad-lib/src/pbxproj.rs
@@ -501,28 +501,53 @@ impl<'a> Parser<'a> {
                         Some(b'n') => out.push('\n'),
                         Some(b'r') => out.push('\r'),
                         Some(b't') => out.push('\t'),
-                        Some(b'0') => out.push('\0'),
                         Some(b'a') => out.push('\x07'),
                         Some(b'b') => out.push('\x08'),
                         Some(b'f') => out.push('\x0c'),
                         Some(b'v') => out.push('\x0b'),
                         Some(b'U') => {
-                            let mut code: u32 = 0;
-                            for _ in 0..4 {
-                                let d = self
-                                    .advance()
-                                    .ok_or_else(|| self.error("incomplete unicode escape"))?;
-                                let v: u32 = match d {
-                                    b'0'..=b'9' => u32::from(d - b'0'),
-                                    b'a'..=b'f' => u32::from(d - b'a' + 10),
-                                    b'A'..=b'F' => u32::from(d - b'A' + 10),
-                                    _ => return Err(self.error("bad hex digit")),
-                                };
-                                code = code * 16 + v;
-                            }
+                            // Apple's old-style serializer escapes per UTF-16
+                            // code unit, so an astral char (emoji) arrives as
+                            // a surrogate pair of two \U escapes — recombine
+                            // it like CF does instead of rejecting the file.
+                            let hi = self.unicode_escape_unit()?;
+                            let code = if (0xD800..=0xDBFF).contains(&hi)
+                                && self.peek() == Some(b'\\')
+                                && self.peek_at(1) == Some(b'U')
+                            {
+                                self.pos += 2;
+                                let lo = self.unicode_escape_unit()?;
+                                if (0xDC00..=0xDFFF).contains(&lo) {
+                                    0x10000 + ((hi - 0xD800) << 10) + (lo - 0xDC00)
+                                } else {
+                                    return Err(self.error("bad unicode codepoint"));
+                                }
+                            } else {
+                                hi
+                            };
                             match char::from_u32(code) {
                                 Some(c) => out.push(c),
                                 None => return Err(self.error("bad unicode codepoint")),
+                            }
+                        }
+                        Some(d @ b'0'..=b'7') => {
+                            // OpenStep octal escape: up to three octal digits
+                            // (`\101` = 'A'); a bare `\0` is NUL. Consuming
+                            // only the first digit would leak the rest into
+                            // the value as literal characters.
+                            let mut code = u32::from(d - b'0');
+                            for _ in 0..2 {
+                                match self.peek() {
+                                    Some(d @ b'0'..=b'7') => {
+                                        self.pos += 1;
+                                        code = code * 8 + u32::from(d - b'0');
+                                    }
+                                    _ => break,
+                                }
+                            }
+                            match char::from_u32(code) {
+                                Some(c) => out.push(c),
+                                None => return Err(self.error("bad octal escape")),
                             }
                         }
                         Some(other) => out.push(other as char),
@@ -532,6 +557,24 @@ impl<'a> Parser<'a> {
                 _ => unreachable!(),
             }
         }
+    }
+
+    /// Four hex digits of a `\Uxxxx` escape — one UTF-16 code unit.
+    fn unicode_escape_unit(&mut self) -> Result<u32, ParseError> {
+        let mut code: u32 = 0;
+        for _ in 0..4 {
+            let d = self
+                .advance()
+                .ok_or_else(|| self.error("incomplete unicode escape"))?;
+            let v: u32 = match d {
+                b'0'..=b'9' => u32::from(d - b'0'),
+                b'a'..=b'f' => u32::from(d - b'a' + 10),
+                b'A'..=b'F' => u32::from(d - b'A' + 10),
+                _ => return Err(self.error("bad hex digit")),
+            };
+            code = code * 16 + v;
+        }
+        Ok(code)
     }
 
     fn parse_bare_string(&mut self) -> Result<String, ParseError> {

--- a/sweetpad-lib/src/pbxproj_merge.rs
+++ b/sweetpad-lib/src/pbxproj_merge.rs
@@ -121,7 +121,31 @@ impl Merger {
                 Value::Dict(self.merge_dict(path, base.and_then(Value::as_dict), o, t))
             }
             (Value::Array(o), Value::Array(t)) => {
-                Value::Array(merge_array(base.and_then(Value::as_array), o, t))
+                let b = base.and_then(Value::as_array);
+                // The ordered-set merge below is only sound when the arrays
+                // really are sets (pbxproj GUID ref-lists all are). A repeated
+                // element — routine in build-setting token lists like
+                // OTHER_LDFLAGS = ("-framework", A, "-framework", B) — would
+                // be silently dropped by the union walk, corrupting the list
+                // while reporting a clean merge; report a conflict instead.
+                if has_duplicates(o) || has_duplicates(t) || b.is_some_and(has_duplicates) {
+                    self.conflicts.push(Conflict {
+                        path: path.to_string(),
+                        kind: if base.is_none() {
+                            ConflictKind::AddAdd
+                        } else {
+                            ConflictKind::BothModified
+                        },
+                        detail: format!(
+                            "list with repeated elements changed on both sides: ours={}, theirs={}",
+                            summarize(ours),
+                            summarize(theirs)
+                        ),
+                    });
+                    ours.clone()
+                } else {
+                    Value::Array(merge_array(b, o, t))
+                }
             }
             _ => {
                 self.conflicts.push(Conflict {
@@ -202,6 +226,15 @@ impl Merger {
 /// every pbxproj reference list: `children`, `files`, `buildPhases`, …).
 /// Honors one-sided deletions and unions additions from both sides, biased
 /// to ours' ordering. Reorder-only differences resolve to ours.
+/// Whether an array repeats any element — the signal that it is a token list
+/// (build-setting flags), not a reference set, and must not be set-merged.
+fn has_duplicates(items: &[Value]) -> bool {
+    items
+        .iter()
+        .enumerate()
+        .any(|(i, v)| contains(&items[..i], v))
+}
+
 fn merge_array(base: Option<&[Value]>, ours: &[Value], theirs: &[Value]) -> Vec<Value> {
     let base = base.unwrap_or(&[]);
     let mut result: Vec<Value> = Vec::new();

--- a/sweetpad-lib/src/pbxproj_merge.rs
+++ b/sweetpad-lib/src/pbxproj_merge.rs
@@ -362,6 +362,31 @@ mod tests {
     }
 
     #[test]
+    fn arrays_with_repeated_tokens_conflict_instead_of_dropping_them() {
+        // OTHER_LDFLAGS-style token lists legitimately repeat elements
+        // ("-framework" A "-framework" B); the set-merge used to silently
+        // drop the second "-framework", leaving a bare library name on the
+        // link line while reporting a clean merge.
+        let base = dict(vec![("FLAGS", arr(vec![s("-framework"), s("A")]))]);
+        let ours = dict(vec![(
+            "FLAGS",
+            arr(vec![s("-framework"), s("A"), s("-framework"), s("B")]),
+        )]);
+        let theirs = dict(vec![("FLAGS", arr(vec![s("-framework"), s("A"), s("-ObjC")]))]);
+
+        let m = merge(Some(&base), &ours, &theirs);
+
+        assert!(!m.is_clean(), "duplicate-bearing lists must not set-merge");
+        // Ours is kept verbatim — nothing silently dropped.
+        assert_eq!(
+            m.value.get("FLAGS").unwrap().as_array().unwrap().len(),
+            4,
+            "{:?}",
+            m.value.get("FLAGS")
+        );
+    }
+
+    #[test]
     fn one_sided_deletion_is_honored() {
         // ours deletes B; theirs leaves it untouched → B is gone.
         let base = objects(vec![("A", file_ref("A.swift")), ("B", file_ref("B.swift"))]);

--- a/sweetpad-lib/src/pbxproj_writer.rs
+++ b/sweetpad-lib/src/pbxproj_writer.rs
@@ -233,7 +233,12 @@ fn build_comments(root: &Value, project_name: &str) -> HashMap<String, String> {
     };
     let mut comments = HashMap::new();
     for (guid, _) in objects {
-        if let Some(c) = ctx.comment_for(guid, 0) {
+        // A name containing `*/` would terminate the block comment early and
+        // make the written file unparseable (by Xcode too); the annotation is
+        // cosmetic, so drop it rather than corrupt the file.
+        if let Some(c) = ctx.comment_for(guid, 0)
+            && !c.contains("*/")
+        {
             comments.insert(guid.clone(), c);
         }
     }

--- a/sweetpad-lib/src/project.rs
+++ b/sweetpad-lib/src/project.rs
@@ -802,7 +802,10 @@ pub fn target_linked_libraries(
                 .and_then(|l| l.rsplit('/').next())
                 .and_then(|n| n.strip_suffix(".dylib"))
             {
-                out.push(name.trim_start_matches("lib").to_string());
+                // Strip the `lib` prefix exactly once: `trim_start_matches`
+                // repeats, so `liblibtls.dylib` would collapse to `tls` and
+                // the caller would emit the wrong `-l` flag.
+                out.push(name.strip_prefix("lib").unwrap_or(name).to_string());
             }
         }
     }

--- a/sweetpad-lib/src/resolver.rs
+++ b/sweetpad-lib/src/resolver.rs
@@ -104,36 +104,47 @@ impl std::error::Error for Error {}
 /// producing a flat list of assignments in source order.
 pub fn flatten_xcconfig(path: &Path) -> Result<Vec<Assignment>, Error> {
     let mut out = Vec::new();
-    flatten_into(path, &mut out, &mut Vec::new())?;
+    flatten_into(path, &mut out, &mut Vec::new(), 0)?;
     Ok(out)
 }
+
+/// Recursion depth cap for `#include` chains. Real chains are single digits;
+/// past this the file is skipped rather than overflowing the stack on a
+/// pathological thousands-deep chain of distinct files.
+const MAX_INCLUDE_DEPTH: usize = 64;
 
 fn flatten_into(
     path: &Path,
     out: &mut Vec<Assignment>,
-    chain: &mut Vec<PathBuf>,
+    included: &mut Vec<PathBuf>,
+    depth: usize,
 ) -> Result<(), Error> {
-    // Cycle guard: Xcode warns ("Skipping the inclusion of … because it is
-    // already included") and skips a file already on the include chain rather
-    // than failing the build — or, as naive recursion would here, overflowing
-    // the stack. Canonicalize so the same file reached through different
-    // lexical spellings is still caught; fall back to the lexical path when
-    // canonicalize fails (e.g. the file is missing — the read below reports
-    // that properly).
-    let id = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    if chain.contains(&id) {
+    // Include-once guard: Xcode warns ("Skipping the inclusion of … because it
+    // is already included") and skips a file that was already included
+    // *anywhere* in this flatten — not just on the current chain. Tracking the
+    // whole flatten matches that behavior and also bounds total work: a
+    // chain-only guard (popped on return) still admits 2^n re-inlining of a
+    // diamond include graph — ~20 two-include files was already a multi-second
+    //, multi-million-assignment blowup. Canonicalize so the same file reached
+    // through different lexical spellings is still caught; fall back to the
+    // lexical path when canonicalize fails (e.g. the file is missing — the
+    // read below reports that properly).
+    if depth > MAX_INCLUDE_DEPTH {
         return Ok(());
     }
-    chain.push(id);
-    let result = flatten_entries(path, out, chain);
-    chain.pop();
-    result
+    let id = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    if included.contains(&id) {
+        return Ok(());
+    }
+    included.push(id);
+    flatten_entries(path, out, included, depth)
 }
 
 fn flatten_entries(
     path: &Path,
     out: &mut Vec<Assignment>,
-    chain: &mut Vec<PathBuf>,
+    included: &mut Vec<PathBuf>,
+    depth: usize,
 ) -> Result<(), Error> {
     // Shared cache entry — iterate by reference and clone each assignment out
     // rather than consuming the (now `Arc`-owned) parse.
@@ -160,7 +171,7 @@ fn flatten_entries(
                 } else {
                     base_dir.join(&inc.path)
                 };
-                match flatten_into(&inc_path, out, chain) {
+                match flatten_into(&inc_path, out, included, depth + 1) {
                     Ok(()) => {}
                     // `#include?` forgives exactly one failure mode: the
                     // optional file *itself* being absent. A present-but-
@@ -318,7 +329,15 @@ fn substitute_inherited(key: &str, value: &str, inherited: &str) -> String {
     let mut out = String::new();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'$' && i + 1 < bytes.len() && (bytes[i + 1] == b'(' || bytes[i + 1] == b'{')
+        if bytes[i] == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'$' {
+            // `$$` escapes a literal `$` — it can never start an inherited/
+            // self reference. Copy both so `$$(inherited)` survives to the
+            // expansion pass, which collapses the escape.
+            out.push_str("$$");
+            i += 2;
+        } else if bytes[i] == b'$'
+            && i + 1 < bytes.len()
+            && (bytes[i + 1] == b'(' || bytes[i + 1] == b'{')
         {
             let open = bytes[i + 1];
             let close = if open == b'(' { b')' } else { b'}' };
@@ -367,18 +386,15 @@ fn substitute_inherited(key: &str, value: &str, inherited: &str) -> String {
 }
 
 fn expand_variables(map: &mut BTreeMap<String, String>) {
-    for _ in 0..16 {
-        let snapshot = map.clone();
-        let mut changed = false;
-        for value in map.values_mut() {
-            let expanded = expand_one(value, &snapshot);
-            if *value != expanded {
-                *value = expanded;
-                changed = true;
-            }
-        }
-        if !changed {
-            return;
+    // A single pass suffices: `expand_one` fully resolves referenced values
+    // recursively (see `resolve_var_with_depth`). Re-running it over its own
+    // output is not idempotent — a `$$(FOO)` escape collapses to the literal
+    // `$(FOO)` on the first pass, and a second pass would wrongly expand it.
+    let snapshot = map.clone();
+    for value in map.values_mut() {
+        let expanded = expand_one(value, &snapshot);
+        if *value != expanded {
+            *value = expanded;
         }
     }
 }

--- a/sweetpad-lib/tests/resolver.rs
+++ b/sweetpad-lib/tests/resolver.rs
@@ -114,6 +114,58 @@ fn inherited_without_lower_layer_starts_with_space() {
 }
 
 #[test]
+fn diamond_includes_are_flattened_once() {
+    // A doubling include graph must not re-inline subtrees 2^n times — the
+    // include-once rule (matching Xcode's "already included" skip) keeps the
+    // flatten linear. Before the fix, 24 two-include files meant 2^23
+    // assignments and a multi-second hang.
+    let dir = std::env::temp_dir().join(format!("sweetpad-include-once-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    for i in 0..24 {
+        let body = if i == 23 {
+            "LEAF = yes\n".to_string()
+        } else {
+            format!(
+                "#include \"f{next}.xcconfig\"\n#include \"f{next}.xcconfig\"\n",
+                next = i + 1
+            )
+        };
+        std::fs::write(dir.join(format!("f{i}.xcconfig")), body).unwrap();
+    }
+    let ass = flatten_xcconfig(&dir.join("f0.xcconfig")).unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+    assert_eq!(ass.len(), 1, "LEAF must be inlined exactly once");
+}
+
+#[test]
+fn double_dollar_escape_stays_literal() {
+    // `$$` means a literal `$` (swift-build semantics): `$$(inherited)` must
+    // not be folded at merge time nor expanded by a later pass.
+    let dir = std::env::temp_dir().join(format!("sweetpad-dollar-escape-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("lower.xcconfig"), "FOO = bar\n").unwrap();
+    std::fs::write(
+        dir.join("upper.xcconfig"),
+        "FOO = $$(inherited) extra\nBAZ = $$(FOO) end\n",
+    )
+    .unwrap();
+    let lower = flatten_xcconfig(&dir.join("lower.xcconfig")).unwrap();
+    let upper = flatten_xcconfig(&dir.join("upper.xcconfig")).unwrap();
+    let r = resolve(&[&lower, &upper], &ctx("macosx", "arm64", "Debug"));
+    let _ = std::fs::remove_dir_all(&dir);
+    assert_eq!(
+        r.get("FOO").map(String::as_str),
+        Some("$(inherited) extra"),
+        "$$(inherited) is a literal, not a fold"
+    );
+    assert_eq!(
+        r.get("BAZ").map(String::as_str),
+        Some("$(FOO) end"),
+        "$$(FOO) must not be re-expanded by a second pass"
+    );
+}
+
+#[test]
 fn include_directive_brings_in_referenced_xcconfig() {
     let ass = flatten_xcconfig(&xcconfig_path("include-directive")).unwrap();
     let r = resolve(&[&ass], &ctx("macosx", "arm64", "Debug"));


### PR DESCRIPTION
- process: drop the Command after spawn in stream_lines — the retained
  pipe write ends meant the reader never saw EOF, hanging every
  streamed build/test after xcodebuild exited (repro'd); set CLOEXEC on
  the merged-pipe fds so concurrently spawned children (BgBoot, watcher
  compiles) can't hold the pipe open either
- bsp: percent-decode URIs on bytes, not str slices — a client URI with
  unencoded non-ASCII after '%' panicked the whole BSP server
- resolver: include each xcconfig once per flatten (matching Xcode) —
  the chain-only cycle guard admitted 2^n re-inlining of diamond
  include graphs (~20 files = multi-second hang, OOM beyond); cap
  include depth; honor $$ escapes in inherited-substitution and stop
  re-expanding expansion output ($$(FOO) leaked through as expanded)
- pbxproj: decode OpenStep octal escapes and \U surrogate pairs instead
  of corrupting/rejecting them; merge: report a conflict instead of
  silently dropping repeated tokens (OTHER_LDFLAGS) in the set-merge;
  writer: drop cosmetic /* */ annotations containing '*/' which made
  the written project unparseable
- project: strip the 'lib' dylib prefix once, not repeatedly
  (liblibtls.dylib linked as -ltls)
- inject: tokenize build transcripts shell-aware (paths with spaces),
  match file names at path-component boundaries (View.swift no longer
  matches GridView.swift), cap protocol string reads and bound their
  retry loop, consume straggling handshake payloads in the response
  loop, survive transient accept() failures, stop-check the result/
  connect waits so teardown doesn't hang 15s, pid-unique client temp
  file
- app run: deregister the console child from the signal registry as
  soon as its exit is reaped (pid-recycle hazard), route device/mac
  destinations with extra keys correctly instead of into simctl,
  escape log-predicate values, refresh the hot-rebuild transcript,
  keep the selfcheck backup when the restore write fails, clean the
  hot session scratch dir on every exit path

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PTHQzKGkUcqE62cSxAchHa