### PR TITLE
Fix 24 correctness bugs found in the round-4 CLI audit

### DIFF
--- a/sweetpad-cli/src/bin/sweetpad.rs
+++ b/sweetpad-cli/src/bin/sweetpad.rs
@@ -23,6 +23,8 @@ fn main() -> ExitCode {
     // (`sweetpad … | head`) surfaces as a "failed printing to stdout: Broken
     // pipe" panic (exit 101, backtrace on stderr). Restore the default
     // disposition so the process dies quietly like every other Unix tool.
+    // (The runtime already clobbered any disposition inherited from the
+    // parent, so a pre-exec `SIG_IGN` cannot be detected or preserved here.)
     // Safety: setting a signal disposition before any threads exist.
     unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);

--- a/sweetpad-cli/src/cli/buildlog.rs
+++ b/sweetpad-cli/src/cli/buildlog.rs
@@ -167,6 +167,14 @@ fn parse_diagnostic(line: &str, t: &str) -> Option<Event> {
 
 /// Task lines, keyed on the leading verb; unrecognized lines become `Other`.
 fn parse_task(line: &str, t: &str) -> Event {
+    // Task headers start at column 0. Indented occurrences of the same verbs
+    // are not fresh tasks — notably the tab-indented "The following build
+    // commands failed:" summary after a failure, which would otherwise render
+    // as spurious `Compiling …` lines *after* the failure banner.
+    if line.starts_with(char::is_whitespace) {
+        return Event::Other(line.to_string());
+    }
+    let stripped = strip_target_annotation(t);
     match t.split_whitespace().next().unwrap_or("") {
         "CompileSwift" | "SwiftCompile" | "CompileC" | "CompileXIB" | "CompileStoryboard" => {
             Event::Compile {
@@ -180,28 +188,52 @@ fn parse_task(line: &str, t: &str) -> Event {
             name: "asset catalog".to_string(),
         },
         "Ld" => Event::Link {
-            target: t
-                .split_whitespace()
-                .nth(1)
-                .map_or_else(|| "binary".to_string(), base),
+            target: ld_target(stripped).unwrap_or_else(|| "binary".to_string()),
         },
         "CodeSign" => Event::CodeSign {
-            name: t
-                .split_whitespace()
-                .nth(1)
-                .map_or_else(|| "bundle".to_string(), base),
+            name: verb_argument(stripped).map_or_else(|| "bundle".to_string(), base),
         },
         "CpResource" | "PBXCp" | "Copy" | "CpHeader" | "Ditto" | "CopySwiftLibs" => Event::Copy {
-            name: last_token(t).map_or_else(|| "files".to_string(), |s| base(&s)),
+            name: last_token(stripped).map_or_else(|| "files".to_string(), |s| base(&s)),
         },
         "ProcessInfoPlistFile" => Event::ProcessPlist {
-            name: t
+            name: stripped
                 .split_whitespace()
-                .nth(1)
+                .find(|tok| Path::new(tok).extension().is_some_and(|e| e == "plist"))
                 .map_or_else(|| "Info.plist".to_string(), base),
         },
         _ => Event::Other(line.to_string()),
     }
+}
+
+/// Strip xcodebuild's trailing `(in target 'X' from project 'Y')` (or the
+/// older `(in target 'X')`) annotation from a task line — its tokens would
+/// otherwise be mistaken for the task's file arguments.
+fn strip_target_annotation(t: &str) -> &str {
+    t.rfind(" (in target '").map_or(t, |i| t[..i].trim_end())
+}
+
+/// The linked binary's path from an annotation-stripped `Ld` line: everything
+/// between the verb and the trailing `normal [<arch>]` tokens, so a product
+/// path containing spaces survives intact.
+fn ld_target(stripped: &str) -> Option<String> {
+    const ARCHS: [&str; 6] = ["arm64", "arm64e", "armv7", "armv7s", "x86_64", "i386"];
+    let mut rest = verb_argument(stripped)?;
+    while let Some((head, tail)) = rest.rsplit_once(char::is_whitespace) {
+        if tail == "normal" || ARCHS.contains(&tail) {
+            rest = head.trim_end();
+        } else {
+            break;
+        }
+    }
+    (!rest.is_empty()).then(|| base(rest))
+}
+
+/// Everything after the leading verb of a task line — the argument as one
+/// string, not whitespace-split (paths may contain spaces).
+fn verb_argument(stripped: &str) -> Option<&str> {
+    let rest = stripped.split_once(char::is_whitespace)?.1.trim();
+    (!rest.is_empty()).then_some(rest)
 }
 
 /// Render an event for the terminal, or `None` to suppress it. `verbose` keeps
@@ -287,7 +319,7 @@ impl BuildProgress {
             spinner: Some(Spinner::start_timed(
                 label,
                 out.is_interactive() && !out.is_quiet(),
-                out.use_color(),
+                out.use_color_stderr(),
             )),
             start: Instant::now(),
             color: out.use_color(),
@@ -769,6 +801,59 @@ mod tests {
                 name: "App.app".to_string()
             }
         );
+    }
+
+    #[test]
+    fn task_names_exclude_the_target_annotation() {
+        // The `(in target 'X' from project 'Y')` suffix is metadata, not a
+        // file — `Copying 'App')` was the old rendering.
+        assert_eq!(
+            parse_line("CpResource /d/App.app/Foo.png /src/Foo.png (in target 'App' from project 'App')"),
+            Event::Copy {
+                name: "Foo.png".to_string()
+            }
+        );
+        assert_eq!(
+            parse_line("ProcessInfoPlistFile /d/App.app/Info.plist /src/Info.plist (in target 'App' from project 'App')"),
+            Event::ProcessPlist {
+                name: "Info.plist".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn task_paths_with_spaces_survive() {
+        assert_eq!(
+            parse_line("Ld /d/My App.app/My App normal arm64 (in target 'My App' from project 'My App')"),
+            Event::Link {
+                target: "My App".to_string()
+            }
+        );
+        assert_eq!(
+            parse_line("CodeSign /d/My App.app (in target 'My App' from project 'My App')"),
+            Event::CodeSign {
+                name: "My App.app".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn indented_failure_summary_lines_are_not_tasks() {
+        // xcodebuild's post-failure "The following build commands failed:"
+        // block repeats task lines tab-indented; they must not render as
+        // fresh `Compiling …` tasks after the failure banner.
+        assert_eq!(
+            parse_line("\tCompileSwift normal arm64 /a/File.swift (in target 'App' from project 'App')"),
+            Event::Other(
+                "\tCompileSwift normal arm64 /a/File.swift (in target 'App' from project 'App')"
+                    .to_string()
+            )
+        );
+        // Unindented task lines still parse.
+        assert!(matches!(
+            parse_line("CompileSwift normal arm64 /a/File.swift"),
+            Event::Compile { .. }
+        ));
     }
 
     #[test]

--- a/sweetpad-cli/src/cli/commands/app.rs
+++ b/sweetpad-cli/src/cli/commands/app.rs
@@ -294,6 +294,7 @@ pub fn run(ctx: &mut Context, action: &Action) -> CommandResult {
                     mac: args.mac,
                     no_logs: args.no_logs,
                     hot,
+                    hot_explicit: args.hot,
                     hot_mode,
                     hot_selfcheck: args.hot_selfcheck.as_deref(),
                     launch: &args.launch,
@@ -378,6 +379,10 @@ struct RunOpts<'a> {
     mac: bool,
     no_logs: bool,
     hot: bool,
+    /// Whether `--hot` was typed (vs. the `[run] hot` config default) — a
+    /// config default is silently ignored for non-simulator targets instead
+    /// of erroring on a committed file.
+    hot_explicit: bool,
     hot_mode: Mode,
     hot_selfcheck: Option<&'a Path>,
     /// Launch args/env/wait-for-debugger for the app process.
@@ -498,7 +503,35 @@ fn run_app(ctx: &mut Context, opts: &RunOpts) -> CliResult {
         ));
     }
 
-    let plan = plan(ctx, opts)?;
+    let mut plan = plan(ctx, opts)?;
+
+    // Hot reload is simulator-only. A typed `--hot` on another target errors
+    // inside `run_hot_session`; the `[run] hot = true` *config default* is
+    // simply ignored for `--on mac`/device/SPM runs — a committed file must
+    // not break them (the flag-gated variants are pre-filtered in
+    // `hot_settings`, but only the resolved plan knows about `--on` and
+    // remembered macOS destinations). Clearing `plan.hot` also drops the
+    // hot-only build flags and the summary's "hot reload on" tag.
+    let hot = opts.hot && (opts.hot_explicit || matches!(plan.target, Target::Simulator(_)));
+    plan.hot = hot;
+    let plan = plan;
+
+    // The hot session launches without debugger suspension and owns the log
+    // stream as part of its UI — reject the flags it can't honor instead of
+    // silently dropping them.
+    if hot && plan.launch.wait_for_debugger {
+        return Err(CliError::new(
+            "--wait-for-debugger isn't supported with --hot; run without --hot to \
+             attach a debugger at launch",
+        ));
+    }
+    if hot && opts.no_logs {
+        return Err(CliError::new(
+            "--no-logs isn't supported with --hot; the hot session streams logs \
+             as part of its UI",
+        ));
+    }
+
     print_summary(ctx, &plan);
 
     // Bring the Simulator window up so the running app is visible. Best-effort and
@@ -508,7 +541,7 @@ fn run_app(ctx: &mut Context, opts: &RunOpts) -> CliResult {
         let _ = simctl::open_app();
     }
 
-    let result = if opts.hot {
+    let result = if hot {
         // Hot reload owns its own build + launch + watch session (simulator only).
         run_hot_session(ctx, &plan, opts.hot_mode, opts.hot_selfcheck)
     } else if matches!(plan.target, Target::SpmRun(_)) {
@@ -534,6 +567,26 @@ fn run_app(ctx: &mut Context, opts: &RunOpts) -> CliResult {
         record_last_launched(ctx, &plan);
     }
     result
+}
+
+/// The in-process resolver that locates the built .app can't see passthrough
+/// flags that move xcodebuild's output — installing a stale bundle from
+/// default DerivedData would silently run old code. Warn instead.
+fn warn_if_passthrough_moves_output(ctx: &Context, passthrough: &[String]) {
+    let moves_output = |t: &String| {
+        t == "-derivedDataPath"
+            || t == "-xcconfig"
+            || t.starts_with("SYMROOT=")
+            || t.starts_with("OBJROOT=")
+            || t.starts_with("CONFIGURATION_BUILD_DIR=")
+            || t.starts_with("TARGET_BUILD_DIR=")
+    };
+    if let Some(flag) = passthrough.iter().find(|t| moves_output(t)) {
+        ctx.out.warn(&format!(
+            "{flag} can move the build output, but the app is installed from the \
+             default build location — the launched bundle may be stale or missing"
+        ));
+    }
 }
 
 /// Resolve a full run plan, choosing a simulator (default), a device, or macOS.
@@ -630,6 +683,8 @@ fn plan(ctx: &mut Context, opts: &RunOpts) -> Result<RunPlan, CliError> {
             "--arg/--env/--wait-for-debugger aren't supported for physical devices yet",
         ));
     }
+
+    warn_if_passthrough_moves_output(ctx, opts.passthrough);
 
     let plan = RunPlan {
         resolved,
@@ -771,8 +826,23 @@ fn destination_platform(spec: &str) -> Option<String> {
 }
 
 /// `swift run <product>` in the package directory: builds and runs the
-/// executable, streaming its output until it exits.
+/// executable, streaming its output until it exits. `--arg` rides after the
+/// product name (SwiftPM passes everything there to the program) and `--env`
+/// lands in the child's environment; `--wait-for-debugger` has no `swift run`
+/// equivalent, so it errors instead of being silently dropped.
 fn spm_run(ctx: &Context, plan: &RunPlan, product: &str) -> CliResult {
+    if plan.launch.wait_for_debugger {
+        return Err(CliError::new(
+            "--wait-for-debugger isn't supported for a Swift package executable; \
+             use `swift build` and attach lldb to the binary directly",
+        ));
+    }
+    if !plan.passthrough.is_empty() {
+        return Err(CliError::new(
+            "`--` passthrough args are xcodebuild flags; a Swift package runs via \
+             `swift run` (use --arg for program arguments)",
+        ));
+    }
     let cwd = plan
         .resolved
         .container
@@ -780,8 +850,11 @@ fn spm_run(ctx: &Context, plan: &RunPlan, product: &str) -> CliResult {
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
         .map(Path::to_path_buf);
+    let env = plan.launch.env_pairs("")?;
+    let mut args: Vec<&str> = vec!["run", product];
+    args.extend(plan.launch.args.iter().map(String::as_str));
     ctx.out.note(&format!("Running {product} (swift run)"));
-    crate::cli::process::stream("swift", &["run", product], cwd.as_deref())
+    crate::cli::process::stream_env("swift", &args, cwd.as_deref(), &env)
         .context("running the package executable")
 }
 
@@ -1435,8 +1508,10 @@ enum RunningKind {
     /// Terminate via `simctl`; the attached console child (`Running.stream`) is what
     /// liveness is probed on.
     Simulator { udid: String, bundle_id: String },
-    /// The console process launched the app; terminate via devicectl.
-    Device { id: String, bundle_id: String },
+    /// The console process launched the app; terminate via devicectl, which
+    /// addresses processes by the `.app` directory name in their executable
+    /// path (there is no terminate-by-bundle-id).
+    Device { id: String, app_dir: String },
     /// The streamed child *is* the macOS app; killing it stops the app.
     Mac,
 }
@@ -1529,7 +1604,7 @@ fn start_app(ctx: &Context, plan: &RunPlan, filter: &Arc<AtomicU8>) -> Result<Ru
                 stream: Some(child),
                 kind: RunningKind::Device {
                     id: id.clone(),
-                    bundle_id: app.bundle_id.clone(),
+                    app_dir: app_dir_name(&app.path),
                 },
                 name: app.bundle_id,
                 reported_exit: false,
@@ -1593,6 +1668,14 @@ fn detach_app(running: Running) {
 
 /// Terminate the running app and stop its output stream. The session-scoped
 /// simulator log stream is left running — it's torn down once, at session end.
+/// The `.app` directory name of a built bundle (`/…/My.app` → `My.app`) — the
+/// key [`devicectl::terminate`] matches running processes by.
+fn app_dir_name(path: &Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
 fn terminate_app(running: Running) {
     let Running {
         stream,
@@ -1607,8 +1690,8 @@ fn terminate_app(running: Running) {
         } => {
             let _ = simctl::terminate(&udid, &bundle_id);
         }
-        RunningKind::Device { id, bundle_id } => {
-            let _ = devicectl::terminate(&id, &bundle_id);
+        RunningKind::Device { id, app_dir } => {
+            let _ = devicectl::terminate(&id, &app_dir);
         }
         // The macOS app *is* the streamed child — killing it below stops it.
         RunningKind::Mac => {}
@@ -2309,12 +2392,21 @@ fn render_device_logs(child: &mut Child, color: bool, exe: String, filter: Arc<A
     };
     let debug_dylib = format!("{exe}.debug.dylib");
     std::thread::spawn(move || {
+        // Multi-line messages (JSON dumps, stack traces) span several physical
+        // lines; only the first matches the syslog shape. Print the rest
+        // verbatim while they continue an entry that was just shown, instead
+        // of silently dropping lines 2..n of the app's own message.
+        let mut continuing = false;
         for line in BufReader::new(stdout).lines() {
             let Ok(line) = line else { break };
             let Some(entry) = pymobiledevice3::parse_line(&line) else {
+                if continuing {
+                    println!("{line}");
+                }
                 continue;
             };
             if entry.image != exe && entry.image != debug_dylib {
+                continuing = false;
                 continue;
             }
             let rendered = oslog::render_fields(
@@ -2324,7 +2416,8 @@ fn render_device_logs(child: &mut Child, color: bool, exe: String, filter: Arc<A
                 entry.message,
                 color,
             );
-            if rendered.level.as_u8() >= filter.load(Ordering::Relaxed) {
+            continuing = rendered.level.as_u8() >= filter.load(Ordering::Relaxed);
+            if continuing {
                 println!("{}", rendered.text);
             }
         }
@@ -2439,6 +2532,7 @@ fn simple(
         mac: false,
         no_logs: true,
         hot: false,
+        hot_explicit: false,
         hot_mode: Mode::Resolver,
         hot_selfcheck: None,
         launch,
@@ -2469,6 +2563,7 @@ fn debug(ctx: &mut Context, launch: &LaunchArgs) -> CommandResult {
         mac: false,
         no_logs: true,
         hot: false,
+        hot_explicit: false,
         hot_mode: Mode::Resolver,
         hot_selfcheck: None,
         launch,
@@ -2626,7 +2721,7 @@ fn simple_on_device(
         }
         Stage::Stop => {
             ctx.out.step("Terminating app on device", || {
-                devicectl::terminate(id, &app.bundle_id)
+                devicectl::terminate(id, &app_dir_name(&app.path))
             })?;
             stage_report(
                 "terminated",
@@ -2697,6 +2792,7 @@ fn simple_logs(ctx: &mut Context, filters: &LogFilterArgs) -> CommandResult {
         mac: false,
         no_logs: true,
         hot: false,
+        hot_explicit: false,
         hot_mode: Mode::Resolver,
         hot_selfcheck: None,
         launch: &LaunchArgs::default(),

--- a/sweetpad-cli/src/cli/commands/archive.rs
+++ b/sweetpad-cli/src/cli/commands/archive.rs
@@ -114,10 +114,14 @@ pub fn run(ctx: &mut Context, args: &ArchiveArgs) -> CommandResult {
     let configuration = archive_configuration(ctx, &resolved)?;
     let destination = archive_destination(ctx)?;
 
+    // Both xcodebuild steps run with the *container's* parent as cwd, while
+    // sweetpad itself creates the output dir and writes the plist from the
+    // CLI's cwd — absolutize so the two sides agree on where `build/` is.
     let out_dir = args
         .output
         .clone()
         .unwrap_or_else(|| PathBuf::from("build"));
+    let out_dir = std::path::absolute(&out_dir).unwrap_or(out_dir);
     let archive_path = out_dir.join(format!("{scheme}.xcarchive"));
 
     let mut archive_args: Vec<String> = vec![
@@ -144,6 +148,7 @@ pub fn run(ctx: &mut Context, args: &ArchiveArgs) -> CommandResult {
         .export_options
         .clone()
         .unwrap_or_else(|| out_dir.join("ExportOptions.plist"));
+    let plist_path = std::path::absolute(&plist_path).unwrap_or(plist_path);
     let export_args: Vec<String> = vec![
         "-exportArchive".into(),
         "-archivePath".into(),

--- a/sweetpad-cli/src/cli/commands/clean.rs
+++ b/sweetpad-cli/src/cli/commands/clean.rs
@@ -57,8 +57,22 @@ pub fn run(ctx: &mut Context, purge: bool) -> CommandResult {
     let cleaned = match &resolved.container {
         Container::SwiftPackage(_) => {
             let cwd = xcodebuild::working_dir(&resolved.container);
-            process::stream("swift", &["package", "clean"], cwd.as_deref())
-                .context("cleaning the package")?;
+            // Under --json/-o ndjson, capture the toolchain's output so
+            // nothing interleaves with the envelope on stdout — the same
+            // discipline as the xcodebuild branch below.
+            if ctx.out.is_json() || ctx.out.is_ndjson() {
+                let run = process::run_captured("swift", &["package", "clean"], cwd.as_deref())?;
+                if !run.success {
+                    return Err(CliError::new(format!(
+                        "swift package clean exited with a non-zero status:\n{}",
+                        run.tail
+                    ))
+                    .context("cleaning the package"));
+                }
+            } else {
+                process::stream("swift", &["package", "clean"], cwd.as_deref())
+                    .context("cleaning the package")?;
+            }
             "swift package clean"
         }
         Container::Project(_) | Container::Workspace(_) => {

--- a/sweetpad-cli/src/cli/commands/context.rs
+++ b/sweetpad-cli/src/cli/commands/context.rs
@@ -443,7 +443,7 @@ fn prompt_value(
                 .projects
                 .get(key)
                 .and_then(|st| get(st, scope, v).map(String::from));
-            input(v.name(), current.as_deref(), ctx.out.use_color())
+            input(v.name(), current.as_deref(), ctx.out.use_color_stderr())
         }
     }
 }

--- a/sweetpad-cli/src/cli/commands/dependency.rs
+++ b/sweetpad-cli/src/cli/commands/dependency.rs
@@ -439,9 +439,7 @@ fn add_to_xcode(ctx: &mut Context, container: &Container, args: &AddArgs) -> Cli
             Ok(())
         }
         Err(e) => {
-            if let Some(text) = pristine_lockfile {
-                let _ = std::fs::write(resolved_path(container), text);
-            }
+            restore_or_remove_lockfile(container, pristine_lockfile);
             // Report the rollback honestly — claiming success while the
             // dangling reference remains would hide exactly the state this
             // rollback exists to prevent.
@@ -488,6 +486,10 @@ fn add_to_package(ctx: &mut Context, container: &Container, args: &AddArgs) -> C
     let pristine = std::fs::read_to_string(&manifest_path).map_err(|e| {
         CliError::new(format!("failed to read {}: {e}", manifest_path.display()))
     })?;
+    // The resolve in step 2 writes the new package's pins into
+    // Package.resolved — snapshot it too, so a cancel doesn't leave ghost
+    // pins that make `dep list`/`dep remove` misreport the abandoned package.
+    let pristine_lockfile = read_lockfile(container);
 
     // 1. Add the dependency to the manifest.
     let requirement = if remote {
@@ -541,9 +543,25 @@ fn add_to_package(ctx: &mut Context, container: &Container, args: &AddArgs) -> C
         }
         Err(e) => {
             let _ = std::fs::write(&manifest_path, &pristine);
+            restore_or_remove_lockfile(container, pristine_lockfile);
             ctx.out
                 .note("rolled the dependency back out of Package.swift (nothing linked)");
             Err(e)
+        }
+    }
+}
+
+/// Roll `Package.resolved` back to a [`read_lockfile`] snapshot after a
+/// cancelled add: restore the pristine text, or — when no lockfile existed
+/// before — remove the one the discovery resolve created, so no ghost pins
+/// for the abandoned package survive either way.
+fn restore_or_remove_lockfile(container: &Container, pristine: Option<String>) {
+    match pristine {
+        Some(text) => {
+            let _ = std::fs::write(resolved_path(container), text);
+        }
+        None => {
+            let _ = std::fs::remove_file(resolved_path(container));
         }
     }
 }
@@ -690,18 +708,34 @@ fn remove_pin(container: &Container, query: &str) {
         return;
     };
     let id = spm_pbxproj::identity_from_url(query);
-    if let Some(pins) = json
-        .get_mut("pins")
-        .and_then(serde_json::Value::as_array_mut)
-    {
-        pins.retain(|p| {
-            p.get("identity")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_ascii_lowercase)
-                != Some(id.clone())
-        });
+    // v2/v3 store `pins` at the top level; v1 nested them under `object` (and
+    // its pins carry no `identity` key — derive one, as `read_resolved` does).
+    let has_top = json.get("pins").is_some_and(serde_json::Value::is_array);
+    let pins = if has_top {
+        json.get_mut("pins").and_then(serde_json::Value::as_array_mut)
+    } else {
+        json.get_mut("object")
+            .and_then(|o| o.get_mut("pins"))
+            .and_then(serde_json::Value::as_array_mut)
+    };
+    if let Some(pins) = pins {
+        pins.retain(|p| pin_identity(p).map(|i| i.to_ascii_lowercase()) != Some(id.clone()));
     }
     let _ = std::fs::write(&path, sweetpad_lib::spm_resolved::serialize(&json));
+}
+
+/// A pin's identity: the `identity` key (v2/v3), or derived from
+/// `repositoryURL`/`package` for v1 pins that carry none.
+fn pin_identity(pin: &serde_json::Value) -> Option<String> {
+    pin.get("identity")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            pin.get("repositoryURL")
+                .or_else(|| pin.get("package"))
+                .and_then(serde_json::Value::as_str)
+                .map(spm_pbxproj::identity_from_url)
+        })
 }
 
 /// The product names a local package declares — passed to `remove_package` so
@@ -1025,22 +1059,22 @@ fn choose(
     if !flags.is_empty() {
         return Ok(flags.to_vec());
     }
-    multi_select(&format!("Select {kind}(s)"), available, ctx.out.use_color())
+    multi_select(kind, available, ctx.out.use_color_stderr())
 }
 
-fn multi_select(prompt: &str, items: &[String], color: bool) -> Result<Vec<String>, CliError> {
+fn multi_select(kind: &str, items: &[String], color: bool) -> Result<Vec<String>, CliError> {
     let theme: Box<dyn dialoguer::theme::Theme> = if color {
         Box::new(dialoguer::theme::ColorfulTheme::default())
     } else {
         Box::new(dialoguer::theme::SimpleTheme)
     };
     let chosen = dialoguer::MultiSelect::with_theme(theme.as_ref())
-        .with_prompt(prompt)
+        .with_prompt(format!("Select {kind}(s)"))
         .items(items)
         .interact()
         .map_err(|e| CliError::new(format!("prompt failed: {e}")).kind(ErrorKind::UserCancel))?;
     if chosen.is_empty() {
-        return Err(CliError::new(format!("no {prompt} chosen")).kind(ErrorKind::UserCancel));
+        return Err(CliError::new(format!("no {kind} chosen")).kind(ErrorKind::UserCancel));
     }
     Ok(chosen.into_iter().map(|i| items[i].clone()).collect())
 }

--- a/sweetpad-cli/src/cli/commands/derived_data.rs
+++ b/sweetpad-cli/src/cli/commands/derived_data.rs
@@ -171,7 +171,7 @@ fn purge(ctx: &mut Context, all: bool, yes: bool) -> CommandResult {
         // The same color-aware theme as every other prompt, so `--no-color` holds.
         let colorful = ColorfulTheme::default();
         let simple = SimpleTheme;
-        let theme: &dyn Theme = if ctx.out.use_color() {
+        let theme: &dyn Theme = if ctx.out.use_color_stderr() {
             &colorful
         } else {
             &simple
@@ -270,10 +270,17 @@ fn project_base_name(container: &Container) -> Option<String> {
     Some(name)
 }
 
-/// Xcode names DerivedData folders `<Name>-<hash>`. Match the exact name (older
-/// layouts) or the `<Name>-` prefix.
+/// Xcode names DerivedData folders `<Name>-<hash>`, sanitizing the name by
+/// replacing non-alphanumeric characters with `_` (`My App` → `My_App-<hash>`).
+/// Match the exact name (older layouts) or the raw/sanitized `<Name>-` prefix.
 fn matches_project(entry: &str, base: &str) -> bool {
-    entry == base || entry.starts_with(&format!("{base}-"))
+    let sanitized: String = base
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    entry == base
+        || entry.starts_with(&format!("{base}-"))
+        || entry.starts_with(&format!("{sanitized}-"))
 }
 
 /// Recursively sum the size of regular files under `path` (symlinks are not
@@ -349,6 +356,10 @@ mod tests {
         // A different project sharing a prefix must not match.
         assert!(!matches_project("MyAppHelper-abc", "MyApp"));
         assert!(!matches_project("Other-xyz", "MyApp"));
+        // Xcode replaces non-alphanumerics with `_` in the folder name.
+        assert!(matches_project("My_App-abcdef123", "My App"));
+        assert!(matches_project("My_App-abcdef123", "My-App"));
+        assert!(!matches_project("My_AppHelper-abc", "My App"));
     }
 
     #[test]

--- a/sweetpad-cli/src/cli/commands/self_update.rs
+++ b/sweetpad-cli/src/cli/commands/self_update.rs
@@ -27,7 +27,10 @@ pub fn run(ctx: &mut Context) -> CommandResult {
         .and_then(std::fs::canonicalize)
         .unwrap_or_default();
     let path = exe.to_string_lossy();
-    let brewed = path.contains("/Cellar/") || path.contains("/homebrew/");
+    // `/Cellar/` covers resolved keg paths everywhere (incl. Linuxbrew);
+    // `/opt/homebrew/` is the Apple-silicon prefix. A bare `/homebrew/` would
+    // also match unrelated checkouts like ~/dev/homebrew-tools/.
+    let brewed = path.contains("/Cellar/") || path.contains("/opt/homebrew/");
     if brewed {
         ctx.out.note("updating via Homebrew…");
         process::stream("brew", &["upgrade", "sweetpad"], None)

--- a/sweetpad-cli/src/cli/commands/simulator.rs
+++ b/sweetpad-cli/src/cli/commands/simulator.rs
@@ -598,13 +598,14 @@ impl Render for SimAppearance {
     }
 }
 
-/// `./sweetpad-shots/<device>-<epoch-secs>.png` — one predictable folder
+/// `./sweetpad-shots/<device>-<epoch-millis>.png` — one predictable folder
 /// instead of screenshots scattering through the working directory. Shared
-/// with the run session's `s` key.
+/// with the run session's `s` key. Millisecond resolution so two quick
+/// captures (double-tapping `s`) don't overwrite each other.
 pub(crate) fn default_screenshot_path(device_name: &str) -> PathBuf {
-    let secs = SystemTime::now()
+    let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
+        .map(|d| d.as_millis())
         .unwrap_or_default();
     let slug: String = device_name
         .chars()
@@ -616,7 +617,7 @@ pub(crate) fn default_screenshot_path(device_name: &str) -> PathBuf {
             }
         })
         .collect();
-    PathBuf::from("sweetpad-shots").join(format!("{slug}-{secs}.png"))
+    PathBuf::from("sweetpad-shots").join(format!("{slug}-{millis}.png"))
 }
 
 #[cfg(test)]

--- a/sweetpad-cli/src/cli/commands/test.rs
+++ b/sweetpad-cli/src/cli/commands/test.rs
@@ -209,8 +209,14 @@ fn test(ctx: &mut Context, args: &RunArgs) -> CommandResult {
 
     let target = resolve::build_target(ctx, &resolved, !args.show_command)?;
 
-    let final_bundle = args
-        .result_bundle.map_or_else(|| retained_bundle_path(&resolved.container), Path::to_path_buf);
+    // xcodebuild resolves `-resultBundlePath` against the *container's* parent
+    // (its cwd), while the CLI's own exists/summary/rename steps resolve
+    // against the CLI's cwd — absolutize so a relative `--result-bundle`
+    // means the same directory on both sides.
+    let final_bundle = args.result_bundle.map_or_else(
+        || retained_bundle_path(&resolved.container),
+        |p| std::path::absolute(p).unwrap_or_else(|_| p.to_path_buf()),
+    );
 
     // `--failed`: the selectors come from the *previous* run's retained
     // bundle, read before anything touches it.
@@ -287,9 +293,10 @@ fn test(ctx: &mut Context, args: &RunArgs) -> CommandResult {
     // still writes a bundle, so "bundle exists" proves nothing). Surface the
     // real cause instead of a vacuous `0 passed, 0 failed` summary — and keep
     // the previous retained bundle so `--failed` still works.
-    let ran_tests = summary
-        .as_ref()
-        .is_some_and(|s| s.total_test_count > 0 || outcome.passed);
+    // A green xcodebuild exit means the tests ran even if the summary can't be
+    // read back (xcresulttool hiccup / older syntax) — misclassifying that as
+    // "failed before any test ran" would delete a perfectly good bundle.
+    let ran_tests = outcome.passed || summary.as_ref().is_some_and(|s| s.total_test_count > 0);
     if !ran_tests {
         let _ = std::fs::remove_dir_all(&run_bundle);
         let detail = outcome
@@ -309,6 +316,10 @@ fn test(ctx: &mut Context, args: &RunArgs) -> CommandResult {
     } else {
         run_bundle
     };
+    if summary.is_none() {
+        ctx.out
+            .warn("could not read the result bundle's summary; counts show as 0");
+    }
     let summary = summary.unwrap_or_default();
     let passed = outcome.passed;
 

--- a/sweetpad-cli/src/cli/devicectl.rs
+++ b/sweetpad-cli/src/cli/devicectl.rs
@@ -247,7 +247,7 @@ pub fn spawn_console(device_id: &str, bundle_id: &str) -> Result<std::process::C
     )
 }
 
-/// Terminate a running app on a device.
+/// Uninstall an app from a device.
 pub fn uninstall(device_id: &str, bundle_id: &str) -> Result<(), CliError> {
     process::stream(
         "xcrun",
@@ -265,20 +265,115 @@ pub fn uninstall(device_id: &str, bundle_id: &str) -> Result<(), CliError> {
     .context("uninstalling the app from the device")
 }
 
-pub fn terminate(device_id: &str, bundle_id: &str) -> Result<(), CliError> {
-    process::stream(
+/// Terminate a running app on a device. `devicectl` has no
+/// terminate-by-bundle-id — processes are addressed by pid — so the app's
+/// pid(s) are looked up in the device's process list by the `.app` directory
+/// name in the executable path, then signalled. Nothing running is success,
+/// mirroring `simctl terminate`'s idempotence.
+pub fn terminate(device_id: &str, app_dir_name: &str) -> Result<(), CliError> {
+    if app_dir_name.is_empty() {
+        return Err(CliError::new(
+            "cannot terminate: the app bundle's name is unknown",
+        ));
+    }
+    for pid in app_pids(device_id, app_dir_name)? {
+        // Best-effort per pid: the process may have exited between the list
+        // and the signal, which devicectl reports as a failure.
+        let _ = process::run(
+            "xcrun",
+            &[
+                "devicectl",
+                "device",
+                "process",
+                "signal",
+                "--signal",
+                "15",
+                "--pid",
+                &pid.to_string(),
+                "--device",
+                device_id,
+            ],
+            None,
+            true,
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct ProcessesOutput {
+    result: ProcessesResult,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ProcessesResult {
+    #[serde(default)]
+    running_processes: Vec<RawProcess>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawProcess {
+    #[serde(default)]
+    process_identifier: i64,
+    #[serde(default)]
+    executable: String,
+}
+
+/// Pids of running processes whose executable lives inside the named `.app`
+/// directory. `devicectl device info processes` routes through a
+/// `--json-output` temp file like [`list`].
+fn app_pids(device_id: &str, app_dir_name: &str) -> Result<Vec<i64>, CliError> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp: PathBuf = std::env::temp_dir().join(format!(
+        "sweetpad-processes-{}-{nanos}.json",
+        std::process::id()
+    ));
+    let ok = process::run(
         "xcrun",
         &[
             "devicectl",
             "device",
-            "process",
-            "terminate",
+            "info",
+            "processes",
             "--device",
             device_id,
-            bundle_id,
+            "--json-output",
+            &tmp.to_string_lossy(),
         ],
         None,
-    )
+        true,
+    )?;
+    if !ok {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(CliError::new(
+            "`xcrun devicectl device info processes` failed",
+        ));
+    }
+    let raw = std::fs::read_to_string(&tmp)
+        .map_err(|e| CliError::new(format!("reading devicectl output: {e}")))?;
+    let _ = std::fs::remove_file(&tmp);
+    parse_app_pids(&raw, app_dir_name)
+}
+
+/// Parse the process list, keeping pids whose executable path contains the
+/// `.app` directory (executables are reported as `file://` URLs, e.g.
+/// `file:///private/var/.../My.app/My`).
+fn parse_app_pids(raw: &str, app_dir_name: &str) -> Result<Vec<i64>, CliError> {
+    let parsed: ProcessesOutput = serde_json::from_str(raw)
+        .map_err(|e| CliError::new(format!("parsing devicectl output: {e}")))?;
+    let needle = format!("/{app_dir_name}/");
+    Ok(parsed
+        .result
+        .running_processes
+        .into_iter()
+        .filter(|p| p.process_identifier > 0 && p.executable.contains(&needle))
+        .map(|p| p.process_identifier)
+        .collect())
 }
 
 #[cfg(test)]
@@ -325,6 +420,23 @@ mod tests {
     fn drops_devices_without_any_id() {
         let raw = r#"{"result":{"devices":[{"identifier":"","hardwareProperties":{}}]}}"#;
         assert!(parse_devices(raw).unwrap().is_empty());
+    }
+
+    #[test]
+    fn app_pids_match_the_bundle_directory() {
+        let raw = r#"{
+          "result": {
+            "runningProcesses": [
+              {"processIdentifier": 496, "executable": "file:///usr/libexec/backboardd"},
+              {"processIdentifier": 1201, "executable": "file:///private/var/containers/Bundle/Application/AAAA/My.app/My"},
+              {"processIdentifier": 1300, "executable": "file:///private/var/containers/Bundle/Application/BBBB/MyOther.app/MyOther"},
+              {"processIdentifier": 0, "executable": "file:///x/My.app/My"}
+            ]
+          }
+        }"#;
+        assert_eq!(parse_app_pids(raw, "My.app").unwrap(), vec![1201]);
+        assert_eq!(parse_app_pids(raw, "MyOther.app").unwrap(), vec![1300]);
+        assert!(parse_app_pids(raw, "Absent.app").unwrap().is_empty());
     }
 
     #[test]

--- a/sweetpad-cli/src/cli/inject/protocol.rs
+++ b/sweetpad-cli/src/cli/inject/protocol.rs
@@ -60,10 +60,19 @@ pub fn write_command(s: &mut TcpStream, cmd: i32, arg: Option<&str>) -> std::io:
     Ok(())
 }
 
+/// How long a frame that has *started* arriving may stall before the read
+/// errors. Bytes already consumed can't be pushed back, so giving up mid-frame
+/// silently would desync every later read on the connection.
+const PARTIAL_FRAME_DEADLINE: Duration = Duration::from_secs(30);
+
 /// Read exactly `buf.len()` bytes. `Ok(false)` distinguishes a clean read
-/// timeout (the socket's read timeout fired) from EOF/error (`Err`).
+/// timeout (the socket's read timeout fired with nothing consumed) from
+/// EOF/error (`Err`). Once any byte has arrived the frame is committed:
+/// timeout ticks keep waiting (up to [`PARTIAL_FRAME_DEADLINE`]) instead of
+/// discarding the prefix and desyncing the stream.
 fn read_exact_timed(s: &mut TcpStream, buf: &mut [u8]) -> std::io::Result<bool> {
     let mut filled = 0;
+    let mut deadline: Option<std::time::Instant> = None;
     while filled < buf.len() {
         match s.read(&mut buf[filled..]) {
             Ok(0) => {
@@ -77,7 +86,17 @@ fn read_exact_timed(s: &mut TcpStream, buf: &mut [u8]) -> std::io::Result<bool> 
                 if e.kind() == std::io::ErrorKind::WouldBlock
                     || e.kind() == std::io::ErrorKind::TimedOut =>
             {
-                return Ok(false);
+                if filled == 0 {
+                    return Ok(false);
+                }
+                let d = *deadline
+                    .get_or_insert_with(|| std::time::Instant::now() + PARTIAL_FRAME_DEADLINE);
+                if std::time::Instant::now() >= d {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "timed out mid-frame; stream would desync",
+                    ));
+                }
             }
             Err(e) => return Err(e),
         }

--- a/sweetpad-cli/src/cli/inject/recompiler.rs
+++ b/sweetpad-cli/src/cli/inject/recompiler.rs
@@ -123,6 +123,12 @@ impl Recompiler {
         // The `eval_injection_` prefix is what the client's image scan expects.
         let dylib = self.out_dir.join(format!("eval_injection_{n}.dylib"));
         let object = self.out_dir.join(format!("eval_injection_{n}.o"));
+        // The watcher hands over whatever shape the walk produced — a relative
+        // `./Sources/Foo.swift` (relative `--project`) or a symlink-prefixed
+        // path (`/var` vs `/private/var`) matches the build system's absolute
+        // `-primary-file` tokens in neither direction; canonicalize first.
+        let source = std::fs::canonicalize(source).unwrap_or_else(|_| source.to_path_buf());
+        let source = source.as_path();
         let source_str = source.to_string_lossy().into_owned();
 
         // Primary: the recovered single-file frontend command (resolver `-###`, or
@@ -315,6 +321,16 @@ impl Recompiler {
             .ok_or("bad source path")?;
         let text = std::fs::read_to_string(log).map_err(|e| format!("read build log: {e}"))?;
 
+        // Prefer a line whose `-primary-file` is the *exact* path: in a
+        // multi-target project two targets can both compile a `ContentView.swift`,
+        // and a basename first-hit would pick the other target's command (whose
+        // primaries don't include this file at all). The suffix match stays as
+        // the fallback for logs whose paths differ by a symlink prefix.
+        let exact_primary_line = |l: &str| {
+            shell_tokens(l)
+                .windows(2)
+                .any(|w| w[0] == "-primary-file" && w[1] == source_str)
+        };
         let is_primary_line = |l: &str| {
             shell_tokens(l)
                 .windows(2)
@@ -322,7 +338,11 @@ impl Recompiler {
         };
         let line = text
             .lines()
-            .find(|l| l.contains("-primary-file") && is_primary_line(l))
+            .find(|l| l.contains("-primary-file") && exact_primary_line(l))
+            .or_else(|| {
+                text.lines()
+                    .find(|l| l.contains("-primary-file") && is_primary_line(l))
+            })
             .or_else(|| {
                 text.lines()
                     .find(|l| l.contains("swift-frontend") && l.contains(name))

--- a/sweetpad-cli/src/cli/inject/watcher.rs
+++ b/sweetpad-cli/src/cli/inject/watcher.rs
@@ -85,20 +85,44 @@ impl Drop for Watcher {
 }
 
 /// Walk `dir` recursively, invoking `visit` for each `.swift` file with its
-/// modification time. Skips [`IGNORED_DIRS`] and hidden directories.
+/// modification time. Skips [`IGNORED_DIRS`] and hidden directories. Follows
+/// symlinked directories (monorepos commonly link `Sources` elsewhere), with
+/// a canonical-path guard so a symlink cycle can't loop the walk.
 fn scan(dir: &Path, visit: &mut impl FnMut(PathBuf, SystemTime)) {
+    let mut seen_links = std::collections::HashSet::new();
+    scan_inner(dir, visit, &mut seen_links);
+}
+
+fn scan_inner(
+    dir: &Path,
+    visit: &mut impl FnMut(PathBuf, SystemTime),
+    seen_links: &mut std::collections::HashSet<PathBuf>,
+) {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return;
     };
     for entry in entries.flatten() {
         let path = entry.path();
         let Ok(ft) = entry.file_type() else { continue };
-        if ft.is_dir() {
+        // `file_type()` doesn't follow symlinks — treat a symlink-to-directory
+        // as a directory so linked source trees are watched too.
+        let is_dir = ft.is_dir() || (ft.is_symlink() && path.is_dir());
+        if is_dir {
             let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
             if name.starts_with('.') || IGNORED_DIRS.contains(&name) {
                 continue;
             }
-            scan(&path, visit);
+            // Every cycle must pass through a symlink — guarding those alone
+            // breaks all loops.
+            if ft.is_symlink() {
+                let Ok(canon) = std::fs::canonicalize(&path) else {
+                    continue;
+                };
+                if !seen_links.insert(canon) {
+                    continue;
+                }
+            }
+            scan_inner(&path, visit, seen_links);
         } else if path.extension().is_some_and(|e| e == "swift")
             && let Ok(mtime) = entry.metadata().and_then(|m| m.modified())
         {

--- a/sweetpad-cli/src/cli/mod.rs
+++ b/sweetpad-cli/src/cli/mod.rs
@@ -761,7 +761,9 @@ pub fn run(argv: &[String]) -> ExitCode {
         Resource::Archive(archive_args) => commands::archive::run(&mut ctx, &archive_args),
         Resource::Clean(clean_args) => {
             let mut targeting: Targeting = clean_args.scheme.clone().into();
-            targeting.configuration.clone_from(&clean_args.configuration);
+            // Same `env = SWEETPAD_CONFIGURATION` normalization as
+            // `BuildTargetArgs`: exported-but-empty means unset.
+            targeting.configuration = non_empty(clean_args.configuration.clone());
             ctx.targeting = targeting;
             commands::clean::run(&mut ctx, clean_args.purge)
         }

--- a/sweetpad-cli/src/cli/output.rs
+++ b/sweetpad-cli/src/cli/output.rs
@@ -21,6 +21,7 @@ pub struct Output {
     ndjson: bool,
     non_interactive: bool,
     color: bool,
+    color_stderr: bool,
     verbose: bool,
     quiet: bool,
     gh_annotations: bool,
@@ -45,7 +46,11 @@ impl Output {
         let no_color =
             global.no_color || std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty());
         let force_color = env_truthy("CLICOLOR_FORCE") || env_truthy("FORCE_COLOR");
+        // Color is decided per stream: `sweetpad build 2> err.log` must not
+        // write ANSI escapes into the log, and `sweetpad build > out.txt`
+        // must not strip color from the interactive stderr chatter.
         let color = !no_color && (force_color || std::io::stdout().is_terminal());
+        let color_stderr = !no_color && (force_color || std::io::stderr().is_terminal());
         // CI is first-class non-interactive: prompts must strict-error there
         // even when the runner fakes a TTY.
         let non_interactive =
@@ -55,6 +60,7 @@ impl Output {
             ndjson,
             non_interactive,
             color,
+            color_stderr,
             // `--quiet` wins over `--verbose`, so a script that always passes
             // `-v` can still be quieted.
             verbose: global.verbose && !quiet,
@@ -93,6 +99,13 @@ impl Output {
     #[must_use]
     pub fn use_color(&self) -> bool {
         self.color
+    }
+
+    /// Color for *stderr* writes (status chatter, spinners, prompts) — decided
+    /// by stderr's own TTY-ness, independent of stdout's.
+    #[must_use]
+    pub fn use_color_stderr(&self) -> bool {
+        self.color_stderr
     }
 
     /// True when the terminal is interactive — gates the picker fallback in
@@ -188,7 +201,7 @@ impl Output {
     /// corrupt state file, a config typo) that should surface even in scripts;
     /// stderr keeps them out of any JSON payload on stdout.
     pub fn warn(&self, s: &str) {
-        let prefix = if self.color {
+        let prefix = if self.color_stderr {
             "\x1b[33mwarning:\x1b[0m"
         } else {
             "warning:"
@@ -200,7 +213,7 @@ impl Output {
     /// app exiting. Stands out from the dim session notes.
     pub fn alert(&self, s: &str) {
         if !self.json && !self.ndjson && !self.quiet {
-            let line = if self.color {
+            let line = if self.color_stderr {
                 format!("\x1b[33m{s}\x1b[0m")
             } else {
                 s.to_string()
@@ -214,7 +227,11 @@ impl Output {
     /// in place. Animates only when interactive (TTY, not `--json`); otherwise
     /// `f` just runs. Use for long, otherwise-silent steps (boot, install).
     pub fn step<T>(&self, message: &str, f: impl FnOnce() -> T) -> T {
-        let _spinner = Spinner::start(message, self.is_interactive() && !self.quiet, self.color);
+        let _spinner = Spinner::start(
+            message,
+            self.is_interactive() && !self.quiet,
+            self.color_stderr,
+        );
         f()
     }
 
@@ -243,7 +260,7 @@ impl Output {
             }
             return;
         }
-        let prefix = if self.color {
+        let prefix = if self.color_stderr {
             "\x1b[31merror:\x1b[0m"
         } else {
             "error:"
@@ -260,8 +277,10 @@ impl Output {
         }
     }
 
+    // `dim`/`bold` style stderr messages only (note/debug/error) — they follow
+    // the stderr color decision.
     fn dim(&self, s: &str) -> String {
-        if self.color {
+        if self.color_stderr {
             format!("\x1b[2m{s}\x1b[0m")
         } else {
             s.to_string()
@@ -279,7 +298,7 @@ impl Output {
     }
 
     fn bold(&self, s: &str) -> String {
-        if self.color {
+        if self.color_stderr {
             format!("\x1b[1m{s}\x1b[0m")
         } else {
             s.to_string()

--- a/sweetpad-cli/src/cli/process.rs
+++ b/sweetpad-cli/src/cli/process.rs
@@ -71,7 +71,14 @@ pub fn run_captured(
     }
     let output = cmd.output().map_err(|e| spawn_error(program, &e))?;
     let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
-    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    let stderr_text = String::from_utf8_lossy(&output.stderr);
+    // Keep the streams line-separated: without this, a stdout that doesn't
+    // end in a newline fuses its last line with stderr's first, and the
+    // diagnostics post-parse misreads the fused line.
+    if !text.is_empty() && !text.ends_with('\n') && !stderr_text.is_empty() {
+        text.push('\n');
+    }
+    text.push_str(&stderr_text);
     Ok(CapturedRun {
         success: output.status.success(),
         tail: tail_lines(&text, 25),
@@ -85,6 +92,31 @@ fn tail_lines(text: &str, n: usize) -> String {
     let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
     let start = lines.len().saturating_sub(n);
     lines[start..].join("\n")
+}
+
+/// [`stream`] with extra environment variables set on the child — used where
+/// the child *is* the user's program (`swift run`) and `--env` must reach it.
+pub fn stream_env(
+    program: &str,
+    args: &[&str],
+    cwd: Option<&Path>,
+    env: &[(String, String)],
+) -> Result<(), CliError> {
+    let mut cmd = Command::new(program);
+    cmd.args(args)
+        .envs(env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    let status = cmd.status().map_err(|e| spawn_error(program, &e))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(CliError::new(format!(
+            "{program} {} exited with a non-zero status",
+            args.join(" ")
+        )))
+    }
 }
 
 /// Run a command to completion, returning whether it succeeded rather than

--- a/sweetpad-cli/src/cli/resolve.rs
+++ b/sweetpad-cli/src/cli/resolve.rs
@@ -433,7 +433,7 @@ pub fn choose(
     match candidates.len() {
         0 => Err(CliError::new(format!("no {what} available")).kind(ErrorKind::TargetResolution)),
         1 => Ok(candidates[0].clone()),
-        _ if ctx.out.is_interactive() => prompt_choice(what, candidates, ctx.out.use_color()),
+        _ if ctx.out.is_interactive() => prompt_choice(what, candidates, ctx.out.use_color_stderr()),
         _ => Err(missing(what)),
     }
 }

--- a/sweetpad-cli/src/cli/signals.rs
+++ b/sweetpad-cli/src/cli/signals.rs
@@ -13,9 +13,12 @@
 //! terminal must stop the build group, not detach it), SIGPIPE (a session
 //! writing its log stream into a gone pipe must still restore the terminal),
 //! and SIGTSTP/SIGCONT (suspending mid-session hands the shell a cooked
-//! terminal and resuming re-asserts raw mode). Each of INT/TERM/HUP/PIPE/TSTP
+//! terminal and resuming re-asserts raw mode). Each of INT/TERM/HUP/TSTP
 //! honors an inherited `SIG_IGN` — a background job a shell protected from
-//! Ctrl-C stays protected.
+//! Ctrl-C stays protected. SIGPIPE is the exception: the Rust runtime sets it
+//! to `SIG_IGN` before `main` (and `main` resets it to default), so a
+//! parent's deliberate ignore-disposition is unobservable by the time this
+//! runs — PIPE always gets the handler.
 //!
 //! The interactive `app run` session disables `ISIG`, so Ctrl-C there arrives
 //! as a key byte and never reaches this handler; it exists for everything

--- a/sweetpad-cli/src/cli/simctl.rs
+++ b/sweetpad-cli/src/cli/simctl.rs
@@ -385,7 +385,11 @@ pub fn shutdown(udid: &str) -> Result<(), CliError> {
         return Ok(());
     }
     let stderr = String::from_utf8_lossy(&output.stderr);
-    if stderr.contains("current state: Shutdown") || stderr.contains("Unable to shutdown") {
+    // Only the already-shutdown no-op is success. A broader "Unable to
+    // shutdown" match would also swallow real failures — notably `current
+    // state: Shutting Down`, where reporting success lets a follow-up
+    // `erase` run against a device that isn't down yet.
+    if stderr.contains("current state: Shutdown") {
         return Ok(());
     }
     Err(CliError::new(format!(

--- a/sweetpad-cli/src/cli/xcodebuild.rs
+++ b/sweetpad-cli/src/cli/xcodebuild.rs
@@ -87,6 +87,9 @@ impl BuildPlan<'_> {
         let mut failure_detail = String::new();
         let mut stats = None;
         let mut diagnostics = Vec::new();
+        // Only the raw `-v` human passthrough leaves output unparsed; every
+        // parsing mode (including ndjson under `-v`) records the artifact.
+        let mut parsed = true;
         let ok = if out.is_ndjson() {
             let (ok, s) = buildlog::run_ndjson("xcodebuild", &args, cwd.as_deref(), out)?;
             diagnostics.clone_from(&s.diagnostics);
@@ -101,6 +104,7 @@ impl BuildPlan<'_> {
             run.success
         } else if out.is_verbose() {
             // Raw passthrough is unparsed — no artifact for this mode.
+            parsed = false;
             process::run("xcodebuild", &args, cwd.as_deref(), false)?
         } else {
             let (ok, d) =
@@ -108,7 +112,7 @@ impl BuildPlan<'_> {
             diagnostics = d;
             ok
         };
-        if !out.is_verbose() {
+        if parsed {
             record_build_diagnostics(self.container, ok, &diagnostics);
         }
         if ok {

--- a/sweetpad-cli/src/vscode_cli.rs
+++ b/sweetpad-cli/src/vscode_cli.rs
@@ -133,7 +133,10 @@ fn parse_argv(args: &[String]) -> Result<ParsedArgv, String> {
                     .flags
                     .insert(key.to_string(), FlagValue::Str(value.to_string()));
                 i += 1;
-            } else if let Some(next) = args.get(i + 1).filter(|n| !n.starts_with('-')) {
+            } else if let Some(next) = args
+                .get(i + 1)
+                .filter(|n| !n.starts_with('-') && (method_seen || !method_shaped(n)))
+            {
                 result
                     .flags
                     .insert(body.to_string(), FlagValue::Str(next.clone()));
@@ -158,6 +161,21 @@ fn parse_argv(args: &[String]) -> Result<ParsedArgv, String> {
         }
     }
     Ok(result)
+}
+
+/// Whether a token has the dotted-method shape (`resource.verb`, identifier
+/// segments only). Used so a boolean `--flag` typed *before* the method
+/// doesn't swallow the method token as its value — `sweetpad vscode --booted
+/// destination.list` must call `destination.list`, not send `{booted:
+/// "destination.list"}` to nothing (or, worse, to a later token's method).
+fn method_shaped(token: &str) -> bool {
+    token.contains('.')
+        && token.split('.').all(|s| {
+            !s.is_empty()
+                && s.starts_with(|c: char| c.is_ascii_alphabetic())
+                && s.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        })
 }
 
 /// Build the JSON-RPC `params` object from the parsed flags. Each flag name
@@ -395,6 +413,20 @@ mod tests {
 
         let r = argv(&["destination.list", "--booted"]);
         assert_eq!(r.flags["booted"], FlagValue::True);
+    }
+
+    #[test]
+    fn boolean_flag_before_the_method_does_not_swallow_it() {
+        // `--booted` is a toggle here — the dotted token is the method, not
+        // its value.
+        let r = argv(&["--booted", "destination.list"]);
+        assert_eq!(r.method.as_deref(), Some("destination.list"));
+        assert_eq!(r.flags["booted"], FlagValue::True);
+
+        // After the method, values that merely contain a dot still work.
+        let r = argv(&["scheme.set", "--name", "My.App"]);
+        assert_eq!(r.method.as_deref(), Some("scheme.set"));
+        assert_eq!(r.flags["name"], FlagValue::Str("My.App".into()));
     }
 
     #[test]


### PR DESCRIPTION
Path resolution (two-cwd mismatches):
- archive: the output dir and generated ExportOptions.plist were created
  relative to the CLI's cwd while xcodebuild resolved the same relative
  paths against the container's parent — export failed (or used a stale
  plist) whenever the CLI ran from a subdirectory. Absolutize both.
- test: a relative --result-bundle had the same split, so a green run was
  reported as "failed before any test ran" (exit 3) and the fresh bundle
  was deleted. Absolutize it.
- test: a run whose summary can't be read back (xcresulttool hiccup) is no
  longer misclassified as failed-before-any-test when xcodebuild passed,
  and the bundle is kept; a warning notes the missing counts.

Build-log parsing:
- Task names no longer swallow the "(in target 'X' from project 'Y')"
  annotation (Copying 'App') and survive paths with spaces (Ld/CodeSign/
  ProcessInfoPlistFile previously truncated at the first space).
- The tab-indented "The following build commands failed:" summary block is
  no longer re-parsed as fresh compile tasks after the failure banner.
- ndjson + -v now records the last-build diagnostics artifact (only the
  raw -v human passthrough is unparsed).
- run_captured separates stdout from stderr with a newline so the last
  stdout line can't fuse with stderr and mis-parse.

Dependency management:
- dep add (Package.swift path) now snapshots/restores Package.resolved on
  a cancelled add, matching the xcodeproj path's rollback; both paths now
  also *remove* a lockfile the discovery resolve created when none existed
  before, instead of leaving ghost pins.
- dep update now removes pins from v1 lockfiles (object.pins, identity
  derived from repositoryURL) instead of silently keeping the stale pin.
- The empty multi-select error reads "no product chosen", not
  "no Select product(s) chosen".

Devices and simulators:
- devicectl terminate used a nonexistent positional bundle-id form, so
  `app stop --device` always failed and session teardown silently leaked
  the running app. It now looks up the app's pid(s) in `device info
  processes` by .app directory and signals them.
- simctl shutdown no longer treats every "Unable to shutdown" as success —
  only the already-shutdown no-op — so a device still shutting down isn't
  reported as down (breaking a follow-up erase).
- Device log streaming keeps the continuation lines of multi-line messages
  (JSON dumps, stack traces) instead of dropping every line after the
  first.
- Screenshot filenames use millisecond timestamps so two quick captures
  don't overwrite each other.

app run:
- A committed `[run] hot = true` config default no longer errors
  `--on mac`/`--on device`/SPM runs; it's ignored for non-simulator
  targets (an explicit --hot still errors clearly).
- SPM runs forward --arg and --env to `swift run` instead of silently
  dropping them, and reject --wait-for-debugger/`--` passthrough with
  clear errors.
- --hot rejects --wait-for-debugger and --no-logs instead of silently
  dropping them.
- Passthrough flags that move build output (-derivedDataPath, SYMROOT=, …)
  now warn that the installed bundle comes from the default location.

Hot reload:
- Protocol reads no longer discard a partially-read frame on a socket
  timeout tick (which permanently desynced the connection); a started
  frame waits up to 30s before erroring.
- The recompiler canonicalizes saved paths, fixing single-file recompiles
  under a relative --project and /var vs /private/var symlinks.
- Build-log command recovery prefers an exact -primary-file path match, so
  same-named files across targets pick the right compile command.
- The watcher follows symlinked source directories (with a cycle guard).

Misc:
- clean: SWEETPAD_CONFIGURATION= (exported empty) means unset, matching
  every other command; `swift package clean` output is captured under
  --json/-o ndjson so it can't corrupt the envelope.
- Color is decided per stream: stderr chatter/spinners/prompts follow
  stderr's TTY-ness, so `2> err.log` gets no ANSI escapes and `> out.txt`
  keeps colored status lines.
- self-update: Homebrew detection no longer matches unrelated paths like
  ~/dev/homebrew-tools/ (uses /Cellar/ and /opt/homebrew/).
- vscode client: a boolean --flag before the method no longer swallows the
  method token as its value (which could silently send the wrong request).
- signals: document that an inherited SIG_IGN for SIGPIPE cannot be
  honored (the Rust runtime clobbers it before main).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019cz5y5WEjUvyjDmh6qMhG4