### PR TITLE
Fix 14 correctness bugs found in the round-5 CLI/Rust audit

### DIFF
--- a/sweetpad-cli/src/cli/devicectl.rs
+++ b/sweetpad-cli/src/cli/devicectl.rs
@@ -168,9 +168,12 @@ pub fn find<'a>(devices: &'a [Device], query: &str) -> Option<&'a Device> {
         .or_else(|| devices.iter().find(|d| d.name == query))
 }
 
-/// Install an `.app` bundle onto a device.
+/// Install an `.app` bundle onto a device. Captures stdout (stderr stays
+/// visible): `devicectl` prints install progress there, which is noise under
+/// the caller's step line — and in `--json` mode it would interleave with the
+/// envelope on the same stream and break the consumer's parse.
 pub fn install(device_id: &str, app_path: &str) -> Result<(), CliError> {
-    process::stream(
+    process::capture(
         "xcrun",
         &[
             "devicectl",
@@ -183,6 +186,7 @@ pub fn install(device_id: &str, app_path: &str) -> Result<(), CliError> {
         ],
         None,
     )
+    .map(|_| ())
     .context("installing the app on the device")
 }
 
@@ -247,9 +251,11 @@ pub fn spawn_console(device_id: &str, bundle_id: &str) -> Result<std::process::C
     )
 }
 
-/// Uninstall an app from a device.
+/// Uninstall an app from a device. Stdout is captured for the same reason as
+/// [`install`] — keep `devicectl`'s progress chatter off the stream the
+/// `--json` envelope goes to.
 pub fn uninstall(device_id: &str, bundle_id: &str) -> Result<(), CliError> {
-    process::stream(
+    process::capture(
         "xcrun",
         &[
             "devicectl",
@@ -262,6 +268,7 @@ pub fn uninstall(device_id: &str, bundle_id: &str) -> Result<(), CliError> {
         ],
         None,
     )
+    .map(|_| ())
     .context("uninstalling the app from the device")
 }
 

--- a/sweetpad-cli/src/cli/inject/mod.rs
+++ b/sweetpad-cli/src/cli/inject/mod.rs
@@ -50,6 +50,16 @@ impl HotSession {
     }
 }
 
+impl Drop for HotSession {
+    fn drop(&mut self) {
+        // Keeps the doc contract above: a plain drop (e.g. a `?` early return
+        // in the caller) also stops the server's accept loop and connection,
+        // not just the watcher. `InjectServer::shutdown` is idempotent, so the
+        // explicit `shutdown` path re-running this in its drop is harmless.
+        self.server.shutdown();
+    }
+}
+
 /// Map an `xcodebuild` `-destination` specifier to the simulator SDK short name
 /// (the value SDK conditionals and the client dylib lookup key on). Returns
 /// `None` for non-simulator destinations (devices, generic).

--- a/sweetpad-cli/src/cli/inject/recompiler.rs
+++ b/sweetpad-cli/src/cli/inject/recompiler.rs
@@ -270,14 +270,31 @@ impl Recompiler {
                 *guard = Some(self.resolve_all()?);
             }
             if let Some(targets) = guard.as_ref() {
+                // Exact canonical match first: in a multi-target project two
+                // targets can each own a same-named file (App/Settings.swift
+                // vs AppClip/Settings.swift), and a basename first-hit would
+                // return the *other* target's invocation — whose primaries
+                // don't include this file at all (same two-tier logic as
+                // `buildlog_tokens`).
                 for t in targets {
                     if let Some(swift) = &t.swift
                         && swift.input_files.iter().any(|f| {
                             std::fs::canonicalize(f)
                                 .map(|c| c == canon)
                                 .unwrap_or(false)
-                                || path_suffix_matches(f, name)
                         })
+                    {
+                        return Ok(swift.clone());
+                    }
+                }
+                // Fallback: basename suffix, for resolved paths that differ
+                // from the watched path by a symlink prefix.
+                for t in targets {
+                    if let Some(swift) = &t.swift
+                        && swift
+                            .input_files
+                            .iter()
+                            .any(|f| path_suffix_matches(f, name))
                     {
                         return Ok(swift.clone());
                     }
@@ -572,6 +589,14 @@ fn shell_tokens(line: &str) -> Vec<String> {
 /// `b/View.swift` and `View.swift`, but a save of `View.swift` must not
 /// match `GridView.swift` (a bare `ends_with` would, selecting the wrong
 /// module or frontend command).
+/// Whether two path spellings name the same file once symlinks resolve.
+fn canonically_same(a: &str, b: &str) -> bool {
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => false,
+    }
+}
+
 fn path_suffix_matches(path: &str, suffix: &str) -> bool {
     path == suffix
         || (path.len() > suffix.len()
@@ -622,7 +647,15 @@ fn single_file_command(
         }
         if t == "-primary-file" {
             let file = tokens.get(i + 1).ok_or("dangling -primary-file")?;
-            if path_suffix_matches(file, source) || path_suffix_matches(source, file) {
+            // The canonical comparison catches spellings that differ by a
+            // symlink prefix (`/var/…` in the transcript vs the canonicalized
+            // `/private/var/…` source) — neither is a component-boundary
+            // suffix of the other, so the string checks alone would reject
+            // the exact command the build log handed us.
+            if path_suffix_matches(file, source)
+                || path_suffix_matches(source, file)
+                || canonically_same(file, source)
+            {
                 out.push("-primary-file".into());
                 out.push(file.clone());
                 kept_primary = true;

--- a/sweetpad-cli/src/cli/inject/watcher.rs
+++ b/sweetpad-cli/src/cli/inject/watcher.rs
@@ -124,7 +124,11 @@ fn scan_inner(
             }
             scan_inner(&path, visit, seen_links);
         } else if path.extension().is_some_and(|e| e == "swift")
-            && let Ok(mtime) = entry.metadata().and_then(|m| m.modified())
+            // `fs::metadata` (follows symlinks), not `entry.metadata()`: a
+            // symlinked .swift file must report the *target's* mtime — the
+            // link's own mtime never changes on edit, so its saves would
+            // otherwise be invisible.
+            && let Ok(mtime) = std::fs::metadata(&path).and_then(|m| m.modified())
         {
             visit(path, mtime);
         }

--- a/sweetpad-cli/src/cli/state.rs
+++ b/sweetpad-cli/src/cli/state.rs
@@ -225,7 +225,12 @@ impl State {
             std::fs::create_dir_all(parent).map_err(|e| format!("{}: {e}", parent.display()))?;
         }
         let text = toml::to_string_pretty(&self.pruned_view()).map_err(|e| e.to_string())?;
-        let tmp = path.with_extension(format!("toml.tmp.{}", std::process::id()));
+        // PID alone distinguishes processes; the counter distinguishes saves
+        // within this process, so two same-process saves can never interleave
+        // writes into one temp file and rename a torn mix into place.
+        static SAVE_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let seq = SAVE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp = path.with_extension(format!("toml.tmp.{}.{seq}", std::process::id()));
         std::fs::write(&tmp, text).map_err(|e| format!("{}: {e}", tmp.display()))?;
         std::fs::rename(&tmp, &path).map_err(|e| format!("{}: {e}", path.display()))
     }

--- a/sweetpad-cli/src/cli/xcodebuild.rs
+++ b/sweetpad-cli/src/cli/xcodebuild.rs
@@ -478,7 +478,10 @@ pub fn coverage_percent(bundle: &Path) -> Option<f64> {
         None,
     )
     .ok()?;
-    let json: serde_json::Value = serde_json::from_str(out.trim()).ok()?;
+    // Skip any leading non-JSON, like the sibling `xcresulttool` readers do —
+    // a preamble line on stdout would otherwise silently read as "no coverage".
+    let json = out.find('{').map(|i| &out[i..])?;
+    let json: serde_json::Value = serde_json::from_str(json).ok()?;
     json.get("lineCoverage").and_then(serde_json::Value::as_f64)
 }
 

--- a/sweetpad-core/examples/dump_settings.rs
+++ b/sweetpad-core/examples/dump_settings.rs
@@ -7,8 +7,12 @@ use sweetpad_lib::xcspec;
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    let (proj, target, config, sdk, arch, ver) =
-        (&args[0], &args[1], &args[2], &args[3], &args[4], &args[5]);
+    let [proj, target, config, sdk, arch, ver, ..] = args.as_slice() else {
+        eprintln!(
+            "usage: dump_settings <xcodeproj> <target> <config> <sdk> <arch> <xcspec-ver> [KEY ...]"
+        );
+        std::process::exit(2);
+    };
     let root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let xcspec_root = root.join(format!("xcspec-cache/xcode-{ver}"));
     let sdks = xcspec_root.join("sdksettings");

--- a/sweetpad-core/src/bsp/control.rs
+++ b/sweetpad-core/src/bsp/control.rs
@@ -122,7 +122,18 @@ impl TelemetryServer {
     pub(crate) fn broadcast(&self, method: &str, params: Value) {
         let body = json!({ "jsonrpc": "2.0", "method": method, "params": params }).to_string();
         if let Ok(mut clients) = self.clients.lock() {
-            clients.retain_mut(|c| write_message(c, &body).is_ok());
+            clients.retain_mut(|c| {
+                if write_message(c, &body).is_ok() {
+                    return true;
+                }
+                // A failed (or timed-out mid-frame) write may have left half a
+                // frame on the wire, so the stream is unusable. Shut the socket
+                // down — not just drop the write half — so the extension sees
+                // EOF and reconnects instead of blocking forever on the missing
+                // bytes (its reader thread here exits on the same EOF).
+                let _ = c.shutdown(std::net::Shutdown::Both);
+                false
+            });
         }
     }
 

--- a/sweetpad-core/src/bsp/mod.rs
+++ b/sweetpad-core/src/bsp/mod.rs
@@ -13,9 +13,9 @@ mod control;
 
 use std::collections::BTreeMap;
 use std::fs::OpenOptions;
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
@@ -117,6 +117,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
                 // The frame boundary is lost; log why before dying so the
                 // failure is diagnosable instead of a silent exit.
                 server.trace(&format!("fatal framing error: {e}"));
+                server.kill_prepare();
                 server.shutdown_telemetry();
                 return Err(e);
             }
@@ -183,6 +184,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
             }
         }
     }
+    server.kill_prepare();
     server.shutdown_telemetry();
     Ok(())
 }
@@ -218,6 +220,11 @@ struct Server {
     config_path: Option<PathBuf>,
     /// Verbosity of the `bsp/log` stream, retunable live via `bsp/setLogLevel`.
     log_level: Arc<AtomicU8>,
+    /// The in-flight `buildTarget/prepare` xcodebuild, if one is running. Held
+    /// so shutdown can kill it: `build/exit` during a prepare would otherwise
+    /// orphan a minutes-long xcodebuild (reparented to init, still burning CPU
+    /// after every editor restart). The prepare worker reaps it.
+    prepare_child: Mutex<Option<std::process::Child>>,
 }
 
 const TARGET_SCHEME: &str = "sweetpad://target/";
@@ -475,6 +482,7 @@ impl Server {
             telemetry: Mutex::new(None),
             config_path,
             log_level,
+            prepare_child: Mutex::new(None),
         };
         server.bind_telemetry(config.socket.as_deref());
         server.log(&format!(
@@ -984,22 +992,71 @@ impl Server {
         self.log(&format!(
             "prepare: building scheme {scheme} ({destination}) for target {target}"
         ));
-        match cmd.output() {
-            Ok(out) => {
-                let code = out.status.code().unwrap_or(-1);
-                if out.status.success() {
-                    self.log(&format!("prepare: {target} build ok"));
-                } else {
-                    // Best-effort: log the tail and carry on (sourcekit-lsp uses
-                    // whatever modules did build).
-                    let stderr = String::from_utf8_lossy(&out.stderr);
-                    let tail: String = stderr.lines().rev().take(8).collect::<Vec<_>>().join(" | ");
-                    self.log(&format!("prepare: {target} build exit={code}: {tail}"));
-                }
+        // Spawn (rather than `output()`) so the child stays killable: the pipe
+        // handles are taken first, then the child is parked in `prepare_child`
+        // where shutdown can reach it while this thread drains the pipes.
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                self.log(&format!(
+                    "prepare: {target} failed to launch xcodebuild: {e}"
+                ));
+                return;
             }
-            Err(e) => self.log(&format!(
-                "prepare: {target} failed to launch xcodebuild: {e}"
-            )),
+        };
+        let stdout_pipe = child.stdout.take();
+        let stderr_pipe = child.stderr.take();
+        if let Ok(mut slot) = self.prepare_child.lock() {
+            *slot = Some(child);
+        }
+        // Drain stdout on a helper thread so neither pipe fills and wedges the
+        // build; stderr (the interesting stream on failure) drains here.
+        let stdout_drain = stdout_pipe.map(|mut s| {
+            std::thread::spawn(move || {
+                let mut sink = Vec::new();
+                let _ = s.read_to_end(&mut sink);
+            })
+        });
+        let mut stderr_buf = Vec::new();
+        if let Some(mut s) = stderr_pipe {
+            let _ = s.read_to_end(&mut stderr_buf);
+        }
+        if let Some(t) = stdout_drain {
+            let _ = t.join();
+        }
+        // Reap. Shutdown may have killed the child, but it leaves the handle in
+        // the slot for us — `wait` then just collects the killed status.
+        let status = self
+            .prepare_child
+            .lock()
+            .ok()
+            .and_then(|mut slot| slot.take())
+            .and_then(|mut c| c.wait().ok());
+        match status {
+            Some(st) if st.success() => self.log(&format!("prepare: {target} build ok")),
+            Some(st) => {
+                // Best-effort: log the tail and carry on (sourcekit-lsp uses
+                // whatever modules did build).
+                let code = st.code().unwrap_or(-1);
+                let stderr = String::from_utf8_lossy(&stderr_buf);
+                let tail: String = stderr.lines().rev().take(8).collect::<Vec<_>>().join(" | ");
+                self.log(&format!("prepare: {target} build exit={code}: {tail}"));
+            }
+            None => self.log(&format!("prepare: {target} xcodebuild status unavailable")),
+        }
+    }
+
+    /// Kill the in-flight prepare build, if any (the prepare worker still owns
+    /// reaping — the handle stays in the slot). Called on shutdown so
+    /// `build/exit` doesn't orphan a running xcodebuild.
+    fn kill_prepare(&self) {
+        if let Ok(mut slot) = self.prepare_child.lock()
+            && let Some(child) = slot.as_mut()
+        {
+            let _ = child.kill();
         }
     }
 
@@ -1169,9 +1226,21 @@ impl Server {
     }
 
     fn options_for(&self, target: &str, sdk: &str, arch: &str) -> BuildSettingsOptions {
+        // For a `.xcworkspace` root, resolve *through the workspace* rather than
+        // the owning member project: `xcodebuild_prepare` builds with
+        // `-workspace`, so DerivedData is keyed by the workspace path, and the
+        // resolver only hashes that container when the workspace is declared
+        // (container *inference* only finds a workspace in the project's parent
+        // or grandparent dir — a member nested deeper would resolve search
+        // paths in a DerivedData tree the prepare build never populates).
+        let (project, workspace) = if self.is_workspace() {
+            (None, Some(self.project_path.clone()))
+        } else {
+            (Some(self.project_for_target(target)), None)
+        };
         BuildSettingsOptions {
-            project: Some(self.project_for_target(target)),
-            workspace: None,
+            project,
+            workspace,
             scheme: None,
             target: Some(target.to_string()),
             configuration: self.configuration(),
@@ -1241,16 +1310,33 @@ fn parse_flags(args: &[String]) -> BTreeMap<String, String> {
 }
 
 fn target_id(name: &str) -> Value {
-    json!({ "uri": format!("{TARGET_SCHEME}{name}") })
+    // Percent-encode the name so the id is a syntactically valid URI: a target
+    // like `My App` must not emit a raw space — a client that parses and
+    // re-serializes the id would normalize it to `My%20App`, which would then
+    // fail to round-trip back to a known target name on our side.
+    let mut uri = String::from(TARGET_SCHEME);
+    percent_encode_into(&mut uri, name);
+    json!({ "uri": uri })
 }
 
 fn target_name_from_uri(uri: &str) -> String {
-    uri.strip_prefix(TARGET_SCHEME).unwrap_or(uri).to_string()
+    percent_decode(uri.strip_prefix(TARGET_SCHEME).unwrap_or(uri))
 }
 
 fn file_uri(path: &Path) -> String {
     let mut out = String::from("file://");
-    for b in path.to_string_lossy().bytes() {
+    percent_encode_into(&mut out, &path.to_string_lossy());
+    out
+}
+
+fn path_from_uri(uri: &str) -> PathBuf {
+    PathBuf::from(percent_decode(uri.strip_prefix("file://").unwrap_or(uri)))
+}
+
+/// Append `s` to `out` percent-encoded: RFC 3986 unreserved bytes and `/` pass
+/// through, everything else becomes `%XX`.
+fn percent_encode_into(out: &mut String, s: &str) {
+    for b in s.bytes() {
         match b {
             b'/' | b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
                 out.push(b as char);
@@ -1263,11 +1349,9 @@ fn file_uri(path: &Path) -> String {
             }
         }
     }
-    out
 }
 
-fn path_from_uri(uri: &str) -> PathBuf {
-    let raw = uri.strip_prefix("file://").unwrap_or(uri);
+fn percent_decode(raw: &str) -> String {
     let bytes = raw.as_bytes();
     let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
@@ -1289,7 +1373,7 @@ fn path_from_uri(uri: &str) -> PathBuf {
         out.push(bytes[i]);
         i += 1;
     }
-    PathBuf::from(String::from_utf8_lossy(&out).into_owned())
+    String::from_utf8_lossy(&out).into_owned()
 }
 
 /// A change fingerprint for a file — `(len, mtime)`, or `None` if it can't be

--- a/sweetpad-lib/src/compiler_args.rs
+++ b/sweetpad-lib/src/compiler_args.rs
@@ -1078,6 +1078,7 @@ fn condition_holds(cond: &str, settings: &Settings) -> bool {
     let mut p = CondParser {
         toks: &toks,
         pos: 0,
+        depth: 0,
         settings,
     };
     match p.parse_or() {
@@ -1189,8 +1190,15 @@ fn tokenize_condition(cond: &str) -> Option<Vec<CondTok>> {
 struct CondParser<'a> {
     toks: &'a [CondTok],
     pos: usize,
+    depth: usize,
     settings: &'a Settings,
 }
+
+/// Recursion cap for [`CondParser`], matching the sibling parsers' guards
+/// (`condition::MAX_DEPTH` et al.): a pathologically nested condition must
+/// fall back to "applies" (the caller maps `None` to `true`) instead of
+/// overflowing the stack.
+const COND_MAX_DEPTH: usize = 64;
 
 impl CondParser<'_> {
     fn parse_or(&mut self) -> Option<bool> {
@@ -1212,6 +1220,18 @@ impl CondParser<'_> {
     }
 
     fn parse_unary(&mut self) -> Option<bool> {
+        // `parse_or`/`parse_and` iterate; all recursion funnels through here
+        // (`!` and `( … )`), so this is the one spot that needs the cap.
+        if self.depth >= COND_MAX_DEPTH {
+            return None;
+        }
+        self.depth += 1;
+        let v = self.parse_unary_inner();
+        self.depth -= 1;
+        v
+    }
+
+    fn parse_unary_inner(&mut self) -> Option<bool> {
         let toks = self.toks;
         match toks.get(self.pos)? {
             CondTok::Not => {

--- a/sweetpad-lib/src/condition.rs
+++ b/sweetpad-lib/src/condition.rs
@@ -322,6 +322,13 @@ impl Parser {
 
     fn parse_equality(&mut self) -> Expr {
         let mut left = self.parse_unary();
+        // This loop is iterative, but each combine deepens the *left spine* of
+        // the Expr tree by one, and the evaluator recurses down that spine —
+        // so an unbounded `a == b == c == …` chain would overflow the stack at
+        // evaluation time. Cap the chain with the same budget as the nesting
+        // guards; past it, remaining operators degrade to best-effort (the
+        // chain so far stands, the tail is ignored).
+        let mut chain = 0;
         loop {
             let op = match self.peek() {
                 Some(Token::EqEq) => Token::EqEq,
@@ -329,6 +336,10 @@ impl Parser {
                 Some(Token::Contains) => Token::Contains,
                 _ => break,
             };
+            if chain >= MAX_DEPTH {
+                break;
+            }
+            chain += 1;
             self.pos += 1;
             let right = self.parse_unary();
             left = match op {

--- a/sweetpad-lib/src/pbxproj.rs
+++ b/sweetpad-lib/src/pbxproj.rs
@@ -550,7 +550,16 @@ impl<'a> Parser<'a> {
                                 None => return Err(self.error("bad octal escape")),
                             }
                         }
-                        Some(other) => out.push(other as char),
+                        // An unrecognized ASCII escape is the literal char
+                        // (`\/` → `/`, CF semantics).
+                        Some(other) if other.is_ascii() => out.push(other as char),
+                        // A `\` before a multi-byte char also escapes the
+                        // literal char, but `other` here is only its *lead
+                        // byte* — `other as char` would mis-decode it as
+                        // Latin-1 and strand the continuation bytes to fail
+                        // the next run's UTF-8 check. Rewind and let the run
+                        // loop consume (and validate) the whole character.
+                        Some(_) => self.pos -= 1,
                     }
                 }
                 None => return Err(self.error("unterminated string")),
@@ -680,6 +689,16 @@ mod tests {
         assert_eq!(v.get("bmp").and_then(Value::as_str), Some("é"));
         // A lone high surrogate is still rejected.
         assert!(parse(r#"{ bad = "\Ud83d"; }"#).is_err());
+    }
+
+    #[test]
+    fn quoted_string_escaped_non_ascii_is_the_literal_char() {
+        // CF reads an unrecognized `\<char>` escape as the literal char. A
+        // multi-byte char used to be decoded lead-byte-as-Latin-1, stranding
+        // its continuation bytes to fail the UTF-8 check.
+        let v = parse("{ a = \"\\é\"; slash = \"\\/\"; }").unwrap();
+        assert_eq!(v.get("a").and_then(Value::as_str), Some("é"));
+        assert_eq!(v.get("slash").and_then(Value::as_str), Some("/"));
     }
 
     #[test]

--- a/sweetpad-lib/src/workspace.rs
+++ b/sweetpad-lib/src/workspace.rs
@@ -181,11 +181,13 @@ impl Workspace {
 
     /// Locate the `.xcodeproj` member that owns a scheme by name. Returns
     /// the first project with a `<name>.xcscheme` file (shared or per-user).
-    /// When no scheme file exists anywhere — Xcode's autocreation regime,
-    /// the same gate [`Workspace::merged_schemes`] applies — falls back to
-    /// the first project owning a same-named target (an autocreated scheme
-    /// builds exactly its target). Used by callers (the CLI) that need to
-    /// dispatch a scheme-driven build to the right project.
+    /// Otherwise — under the same autocreation gate as
+    /// [`Workspace::merged_schemes`] — falls back to the first project whose
+    /// scheme list ([`project::open`]'s files-plus-autocreated set) includes
+    /// the name: scheme files elsewhere do NOT suppress a member's
+    /// autocreated per-target schemes, so every name `merged_schemes`
+    /// surfaces must dispatch. Used by callers (the CLI) that need to route
+    /// a scheme-driven build to the right project.
     #[must_use]
     pub fn project_for_scheme(&self, scheme_name: &str) -> Option<&Path> {
         if let Some(p) = self
@@ -195,19 +197,14 @@ impl Workspace {
         {
             return Some(p.as_path());
         }
-        let any_scheme_files = !self.schemes.is_empty()
-            || self
-                .project_refs
-                .iter()
-                .any(|p| !crate::scheme::container_schemes(p).is_empty());
-        if any_scheme_files || !crate::scheme::autocreation_allowed(&self.path) {
+        if !crate::scheme::autocreation_allowed(&self.path) {
             return None;
         }
         self.project_refs
             .iter()
             .find(|p| {
                 project::open(p)
-                    .map(|proj| proj.targets.iter().any(|t| t.name == scheme_name))
+                    .map(|proj| proj.schemes.iter().any(|s| s == scheme_name))
                     .unwrap_or(false)
             })
             .map(PathBuf::as_path)
@@ -470,6 +467,9 @@ mod tests {
         );
         // And the user scheme makes the project dispatchable by name.
         assert_eq!(ws.project_for_scheme("ProjPersonal"), Some(proj.as_path()));
+        // The autocreated scheme stays dispatchable even though scheme files
+        // exist elsewhere — every name merged_schemes lists must resolve.
+        assert_eq!(ws.project_for_scheme("Scratch"), Some(proj.as_path()));
     }
 
     #[test]

--- a/sweetpad-lib/src/xcconfig.rs
+++ b/sweetpad-lib/src/xcconfig.rs
@@ -461,8 +461,12 @@ impl Iterator for LineIter<'_> {
 }
 
 fn ends_with_unescaped_backslash(s: &str) -> bool {
+    // A continuation is an ODD run of trailing backslashes: each `\\` pair is
+    // one escaped literal backslash, and only a leftover unpaired `\` continues
+    // the line. Checking just the last two chars would misread `foo\\\` (an
+    // escaped backslash followed by a real continuation) as no continuation.
     let trimmed = s.trim_end();
-    trimmed.ends_with('\\') && !trimmed.ends_with("\\\\")
+    trimmed.bytes().rev().take_while(|&b| b == b'\\').count() % 2 == 1
 }
 
 fn strip_trailing_backslash(s: &str) -> String {
@@ -587,6 +591,17 @@ mod tests {
     fn joins_continuation_lines() {
         let c = parse("FOO = a \\\n    b \\\n    c\n").unwrap();
         assert_eq!(c.entries, vec![assign("FOO", "a b c")]);
+    }
+
+    #[test]
+    fn continuation_counts_the_whole_trailing_backslash_run() {
+        // `\\` = escaped literal backslash, no continuation.
+        let c = parse("FOO = a\\\\\nBAR = b\n").unwrap();
+        assert_eq!(c.entries.len(), 2);
+        // `\\\` = escaped backslash THEN a continuation — the odd leftover
+        // continues the line (the last-two-chars check used to miss this).
+        let c = parse("FOO = a\\\\\\\n    b\n").unwrap();
+        assert_eq!(c.entries, vec![assign("FOO", "a\\\\ b")]);
     }
 
     #[test]

--- a/sweetpad-lib/tests/adversarial_inputs.rs
+++ b/sweetpad-lib/tests/adversarial_inputs.rs
@@ -288,6 +288,13 @@ fn condition_rejects_deeply_nested_parens() {
             let _ = sweetpad_lib::condition::parse(&input);
             let bangs = format!("{}YES", "!".repeat(200_000));
             let _ = sweetpad_lib::condition::parse(&bangs);
+            // Equality chains nest in the *built tree* (left spine), not the
+            // parser's stack, so evaluation is where an uncapped chain would
+            // overflow — evaluate as well as parse.
+            let chain = format!("x{}", " == x".repeat(200_000));
+            if let Some(expr) = sweetpad_lib::condition::parse(&chain) {
+                let _ = sweetpad_lib::condition::evaluate(&expr, &Default::default());
+            }
         })
         .expect("spawn");
     handle.join().expect("condition parse must not overflow");


### PR DESCRIPTION
BSP server (sweetpad-core):
- Resolve editor arguments through the workspace for .xcworkspace roots, so
  the DerivedData container matches what `xcodebuild -workspace` prepare
  builds populate (deeply nested members previously searched the wrong tree
  and cross-module imports stayed unresolved).
- Kill the in-flight prepare xcodebuild on build/exit instead of orphaning a
  minutes-long build (spawn + parked child handle instead of Command::output).
- Shut down a telemetry client's socket on a failed/timed-out broadcast write
  so the peer sees EOF instead of hanging on a truncated frame.
- Percent-encode target names in sweetpad://target/ URIs (and decode on the
  way back) so names with spaces survive client URI normalization.

sweetpad-lib:
- workspace: dispatch autocreated per-target schemes even when scheme files
  exist elsewhere in the workspace — every name merged_schemes lists now
  resolves via project_for_scheme (Kingfisher-style mixed workspaces).
- condition: cap equality-chain length; the left-nested Eq tree previously
  let `a == b == c …` overflow the stack at evaluation time.
- compiler_args: add the missing recursion-depth guard to the xcspec
  Condition parser, matching every sibling parser.
- pbxproj: `\` before a multi-byte UTF-8 char now yields the literal char
  instead of a Latin-1 misdecode plus a spurious invalid-UTF-8 parse error.
- xcconfig: classify line continuations by the parity of the whole trailing
  backslash run, so `foo\\\` + next line still joins.

sweetpad-cli:
- inject/recompiler: exact canonical file match across all targets before the
  basename fallback, so same-named files in sibling targets (App/AppClip)
  resolve to the owning target's swiftc invocation; single_file_command also
  accepts a -primary-file that differs from the source only by a symlink
  prefix (/var vs /private/var).
- inject/watcher: stat symlinked .swift files through the link so their saves
  are detected.
- inject: HotSession now stops the server on drop, as its doc promised.
- devicectl: capture install/uninstall stdout so devicectl progress chatter
  can't corrupt the --json envelope.
- xcodebuild: coverage_percent skips any leading non-JSON preamble like the
  sibling xcresulttool readers.
- state: make the save temp-file name unique per save, not just per PID.
- examples/dump_settings: usage message instead of an index panic.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Shbhi5dLjG7SuCicrHPcTg