### PR TITLE
docs: document the SweetPad CLI as a standalone product

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,39 @@
 # SweetPad
 
-Develop Swift/iOS projects from VS Code and the terminal
+Develop Swift/iOS projects from VS Code and the terminal.
+
+SweetPad builds, runs, debugs, and tests your Xcode projects for iOS, macOS, tvOS, watchOS, and
+visionOS. It's built on top of Xcode's own command-line tools, so you still need Xcode installed — but
+you don't need to open it. There are two ways to use it: the VS Code extension and the standalone CLI.
+
+## VS Code extension
+
+The primary way to use SweetPad. Build, run, debug, and test straight from the editor sidebar — with
+device/simulator logs, format-on-save, autocomplete via SourceKit-LSP, and native Testing-panel
+integration.
+
+- Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sweetpad.sweetpad)
+  (works in [Cursor](https://www.cursor.com/) too).
+- Read the [documentation](https://sweetpad.hyzyla.dev/docs/intro).
+
+## SweetPad CLI
+
+The same power from the terminal — a single native `sweetpad` binary ("xcodebuild for humans") that
+builds, runs, and tests the same projects with no editor running. Every command speaks JSON, so it
+drops into scripts, git hooks, and CI.
+
+```bash
+brew install sweetpad-dev/tap/sweetpad
+```
+
+Read the [CLI documentation](https://sweetpad.hyzyla.dev/docs/cli).
+
+## Repository layout
+
+This repository is a monorepo. The two products above are built from a shared Rust core:
 
 - [`sweetpad-vscode/`](./sweetpad-vscode) — VS Code extension ([Marketplace](https://marketplace.visualstudio.com/items?itemName=sweetpad.sweetpad)); the N-API addon bridging it to the Rust core lives in [`sweetpad-vscode/native/`](./sweetpad-vscode/native)
 - [`sweetpad-cli/`](./sweetpad-cli) — the standalone `sweetpad` CLI
 - [`sweetpad-core/`](./sweetpad-core) — business logic shared by the CLI and the extension (build-settings resolution, BSP server)
-- [`sweetpad-lib/`](./sweetpad-lib) — interface-agnostic Xcode file/format utilities and the build-settings resolver
-- [`sweetpad-docs/`](./sweetpad-docs) — documentation site
+- [`sweetpad-lib/`](./sweetpad-lib) — interface-agnostic Xcode file/format utilities (in development)
+- [`sweetpad-docs/`](./sweetpad-docs) — [documentation site](https://sweetpad.hyzyla.dev)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # SweetPad
 
-Develop Swift/iOS projects from VS Code and the terminal.
+SweetPad is a family of tools for developing Swift/iOS projects — building, running, debugging, and
+testing your Xcode projects for iOS, macOS, tvOS, watchOS, and visionOS without living inside Xcode.
 
-SweetPad builds, runs, debugs, and tests your Xcode projects for iOS, macOS, tvOS, watchOS, and
-visionOS. It's built on top of Xcode's own command-line tools, so you still need Xcode installed — but
-you don't need to open it. There are two ways to use it: the VS Code extension and the standalone CLI.
+Everything is built on top of Xcode's own command-line tools (so you still need Xcode installed) and a
+shared Rust core. There are two separate products, and you can use either on its own:
 
 ## VS Code extension
 
-The primary way to use SweetPad. Build, run, debug, and test straight from the editor sidebar — with
-device/simulator logs, format-on-save, autocomplete via SourceKit-LSP, and native Testing-panel
-integration.
+Build, run, debug, and test straight from the editor sidebar — with device/simulator logs,
+format-on-save, autocomplete via SourceKit-LSP, and native Testing-panel integration.
 
 - Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sweetpad.sweetpad)
   (works in [Cursor](https://www.cursor.com/) too).
@@ -18,8 +17,8 @@ integration.
 
 ## SweetPad CLI
 
-The same power from the terminal — a single native `sweetpad` binary ("xcodebuild for humans") that
-builds, runs, and tests the same projects with no editor running. Every command speaks JSON, so it
+A single native `sweetpad` binary ("xcodebuild for humans") that builds, runs, and tests Xcode and
+Swift Package projects from the terminal, with no editor running. Every command speaks JSON, so it
 drops into scripts, git hooks, and CI.
 
 ```bash
@@ -30,7 +29,7 @@ Read the [CLI documentation](https://sweetpad.hyzyla.dev/docs/cli).
 
 ## Repository layout
 
-This repository is a monorepo. The two products above are built from a shared Rust core:
+This repository is a monorepo. Both products are built from a shared Rust core:
 
 - [`sweetpad-vscode/`](./sweetpad-vscode) — VS Code extension ([Marketplace](https://marketplace.visualstudio.com/items?itemName=sweetpad.sweetpad)); the N-API addon bridging it to the Rust core lives in [`sweetpad-vscode/native/`](./sweetpad-vscode/native)
 - [`sweetpad-cli/`](./sweetpad-cli) — the standalone `sweetpad` CLI

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 SweetPad is a family of tools for developing Swift/iOS projects — building, running, debugging, and
 testing your Xcode projects for iOS, macOS, tvOS, watchOS, and visionOS without living inside Xcode.
 
-Everything is built on top of Xcode's own command-line tools (so you still need Xcode installed) and a
-shared Rust core. There are two separate products, and you can use either on its own:
+There are two separate products, and you can use either on its own:
 
 ## VS Code extension
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 SweetPad is a family of tools for developing Swift/iOS projects — building, running, debugging, and
 testing your Xcode projects for iOS, macOS, tvOS, watchOS, and visionOS without living inside Xcode.
 
-There are two separate products, and you can use either on its own:
+It comes in two forms — pick whichever fits how you work:
 
 ## VS Code extension
 

--- a/sweetpad-docs/docs/agent-cli.md
+++ b/sweetpad-docs/docs/agent-cli.md
@@ -26,8 +26,7 @@ to build and run your app, use the SweetPad sidebar and skip this page.
 
 ## Install
 
-The `sweetpad` CLI is distributed via Homebrew — a signed, notarized universal macOS binary,
-independent of the VS Code extension:
+The `sweetpad` CLI is distributed via Homebrew:
 
 ```bash
 brew install sweetpad-dev/tap/sweetpad

--- a/sweetpad-docs/docs/agent-cli.md
+++ b/sweetpad-docs/docs/agent-cli.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 18
 ---
 
 # Agent CLI & RPC Server

--- a/sweetpad-docs/docs/agent-cli.md
+++ b/sweetpad-docs/docs/agent-cli.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 ---
 
 # Agent CLI & RPC Server
@@ -8,14 +8,14 @@ SweetPad ships a standalone `sweetpad` command-line tool plus an opt-in JSON-RPC
 processes — scripts, CI jobs, AI coding agents — can drive your Xcode project and your live VS Code
 session without screen-scraping the UI.
 
-The CLI has two halves:
+The `sweetpad` binary has two halves:
 
 - **`sweetpad <command>`** — a standalone, headless CLI ("xcodebuild for humans"): inspect schemes
   and destinations, build, run, manage simulators, resolve Swift Package dependencies, and more. It
-  needs nothing running — run `sweetpad --help` to explore.
+  needs nothing running. This half has its own page — [SweetPad CLI](./cli.md).
 - **`sweetpad vscode <method>`** — a JSON-RPC client that talks to a running VS Code window's SweetPad
   server (read state, trigger builds, drive simulators _inside_ your editor session). This page is
-  mostly about this half.
+  about this half.
 
 :::tip
 

--- a/sweetpad-docs/docs/autocomplete.md
+++ b/sweetpad-docs/docs/autocomplete.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 4
 ---
 
 # Autocomplete

--- a/sweetpad-docs/docs/build.md
+++ b/sweetpad-docs/docs/build.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 5
 ---
 
 # Build & Run

--- a/sweetpad-docs/docs/cli.md
+++ b/sweetpad-docs/docs/cli.md
@@ -1,189 +1,205 @@
 ---
-sidebar_position: 15
+sidebar_position: 17
 ---
 
 # SweetPad CLI
 
-The SweetPad CLI is a standalone `sweetpad` command-line tool — "xcodebuild for humans". It builds,
-runs, tests, and inspects Xcode and Swift Package projects from the terminal, with no editor running.
+The SweetPad CLI is a command-line tool named `sweetpad` that builds, runs, and tests your Xcode and
+Swift Package apps from the terminal — no editor needed. If you've ever wished `xcodebuild` were
+friendlier, this is that.
 
-It's one of the two SweetPad products, a sibling to the [VSCode extension](./intro.md) — use either on
-its own. It's a single native macOS binary (no Node runtime), and it shares the same build-settings
-resolver the extension uses, so a scheme, destination, or configuration you pick on the command line
-resolves exactly the way it would in the sidebar.
+It's one of the two SweetPad products, a sibling to the [VSCode extension](./intro.md). The two are
+completely independent: the CLI is a standalone tool, so you **don't** need VSCode (or the extension)
+installed to use it, and it doesn't touch your editor.
 
-:::info
+:::tip
 
-Like the extension, the CLI drives Xcode's own command-line tools under the hood, so you still need
-Xcode installed.
+New here? Start with [Get started with the CLI](./getting-started-cli.md) — install, then build and
+run your app in a few minutes. This page is the fuller tour.
 
 :::
 
-## Install
+## Installing and updating
 
-The CLI is distributed via Homebrew as a signed, notarized universal binary, independent of the VSCode
-extension:
+Install with [Homebrew](https://brew.sh/):
 
 ```bash
 brew install sweetpad-dev/tap/sweetpad
 ```
 
-Verify it:
+Update it later the same way you update anything else with Homebrew:
 
 ```bash
-sweetpad --version
+brew upgrade sweetpad
 ```
 
-Upgrade it later with `brew upgrade sweetpad`.
+You'll need Xcode installed too — SweetPad uses Xcode's own tools to do the actual building.
 
-## Quick start
+## How commands are shaped
 
-Run `sweetpad` from inside a project — a folder containing an `.xcworkspace`, `.xcodeproj`, or
-`Package.swift`. It finds the project by walking up from the current directory, the same way `git`
-finds its repo.
+Most commands read as a thing followed by an action — for example `sweetpad simulator list` or
+`sweetpad scheme list`. The common actions have a shortcut, so you can usually just say the thing:
+
+- `sweetpad build` builds your app.
+- `sweetpad test` runs your tests.
+- `sweetpad run` builds, launches, and shows the logs.
+
+Not sure what's available? `--help` always works:
 
 ```bash
-cd ~/Developer/MyApp
+sweetpad --help              # every command
+sweetpad run --help          # options for one command
+```
 
-# Where am I? Show the resolved build context.
-sweetpad status
+## Everyday commands
 
-# List everything you can run on — simulators, devices, macOS.
+Run these from inside your project folder.
+
+**Build and run.** `sweetpad run` is the one you'll use most — it builds the app, launches it on your
+chosen simulator or device, and streams the logs into your terminal.
+
+```bash
+sweetpad run                       # build, launch, and follow logs
+sweetpad run --on "iPhone 16 Pro"  # ...on a specific simulator
+sweetpad build                     # just build
+sweetpad test                      # run the tests
+```
+
+**See where you can run.** `sweetpad devices` lists every simulator, connected device, and macOS —
+each with a copy-paste-ready name.
+
+```bash
 sweetpad devices
-
-# Build, install, launch, and stream logs — the flagship loop.
-sweetpad run
 ```
 
-The first time you run inside a project, SweetPad prompts you to pick a scheme and a destination, then
-remembers them per project so later commands don't ask again. Run `sweetpad status` any time to see
-what's currently selected and where each value came from.
-
-## What the CLI can do
-
-The command tree is resource-first — a noun, then a verb (`sweetpad simulator list`). Most nouns also
-have a bare shortcut for their most common verb, so `sweetpad build` is `sweetpad build start` and
-`sweetpad test` is `sweetpad test run`. Run `sweetpad --help` to explore the full tree, or
-`sweetpad <command> --help` for one command.
-
-The main groups:
-
-- **Build & run** — `build`, `run` (build + install + launch + logs), `test`, `archive` (export an
-  `.ipa`), and `clean`.
-- **Explore the project** — `scheme`, `project` (targets and configurations), `settings` (resolved
-  build settings), and `dependency` (Swift Package dependencies).
-- **Pick where to run** — `devices` lists every runnable target with its ready specifier; `simulator`
-  and `context` (the remembered selection) manage the details.
-- **Format** — `format` runs or lints Swift sources with `swift-format` or a formatter you point it at.
-- **Maintenance** — `doctor` diagnoses the local toolchain, `derived-data` inspects and purges Xcode's
-  DerivedData, and `open` jumps to the project in Xcode, the Simulator, or the config file.
-- **Utilities** — `bsp` sets up SourceKit-LSP autocomplete, `merge` installs git merge drivers for
-  `project.pbxproj` and `Package.resolved`, `completions` generates shell completions, and
-  `self-update` upgrades the binary.
-
-### Hot reload
-
-`sweetpad run --hot` recompiles and injects each Swift save into the running app without relaunching,
-preserving state — the CLI counterpart of the extension's [hot reload](./hot-reload.md). It's iOS
-Simulator only. See `sweetpad help hot-reload` for the SwiftUI setup and recompiler options.
-
-## Selecting a target
-
-Every build command needs to know four things: which project container, which scheme, which
-configuration, and which destination. You can supply any of them explicitly, but you rarely have to —
-SweetPad resolves each value from the first source that has it, highest priority first:
-
-1. An explicit flag (`--scheme`, `--configuration`, `--on`, `--destination`).
-2. A `SWEETPAD_*` environment variable.
-3. Your personal config file.
-4. A committed `sweetpad.toml` next to the project (team-shared defaults).
-5. The selection SweetPad remembered from a previous run.
-6. Auto-discovery (a single obvious scheme, a booted simulator, and so on).
-
-The friendliest way to choose a destination is `--on`, which takes a human reference — a fuzzy
-simulator name, `booted`, `mac`, `device`, or a platform word:
+**Look at your project.** Handy when you're not sure what's inside a project:
 
 ```bash
-sweetpad run --on "iPhone 16 Pro"
-sweetpad build --on mac
-sweetpad test --on booted
+sweetpad scheme list             # the schemes SweetPad found
+sweetpad project                 # targets and configurations
+sweetpad settings get            # the resolved build settings
+sweetpad dependency list         # Swift Package dependencies
 ```
 
-`--destination` remains the raw escape hatch when you need to pass an exact `xcodebuild` specifier.
-Run `sweetpad help destinations` for the full grammar.
+**Tidy up and fix things.**
 
-## Configuration
+```bash
+sweetpad format                  # format your Swift files
+sweetpad clean                   # remove build artifacts
+sweetpad doctor                  # check your Xcode setup for problems
+sweetpad open xcode              # open the project in Xcode
+```
 
-SweetPad reads two hand-authored files, and never writes to either:
+**Ship a build.** `sweetpad archive` produces an `.ipa` you can upload or distribute.
 
-- Your personal `~/.config/sweetpad/config.toml` holds global defaults plus per-project overrides.
-- A committed `sweetpad.toml` next to the project is the team-shared defaults layer — scheme,
-  configuration, destination, the Xcode to use, and more — that everyone on the project inherits.
+```bash
+sweetpad archive
+```
 
-Remembered selections live separately in a machine-managed state file; inspect and edit them with
-`sweetpad context`, not by hand. For the full list of keys and the resolution precedence, run:
+There's more — Swift Package tools, git merge helpers, and shell completions among them. Run
+`sweetpad --help` to see the whole list.
+
+## Choosing where to run
+
+Commands like `build`, `run`, and `test` need to know which scheme to build and where to run it. The
+easiest way to say where is `--on`, which understands plain descriptions:
+
+```bash
+sweetpad run --on "iPhone 16 Pro"   # a simulator by name
+sweetpad build --on mac             # your Mac
+sweetpad test --on booted           # whatever simulator is already open
+```
+
+You usually don't have to say any of this, though. The first time you build in a project, SweetPad
+asks which scheme and destination to use, then **remembers your answer** so it won't ask again. Check
+what's currently chosen — and where each choice came from — with:
+
+```bash
+sweetpad status
+```
+
+To change or clear the remembered choices, use `sweetpad context`. For all the ways to describe a
+destination, run `sweetpad help destinations`.
+
+## Live reload while you edit
+
+`sweetpad run --hot` keeps your app running and applies each Swift file you save without a full
+rebuild — so the app updates in place, keeping its current screen and state. It works on the iOS
+Simulator. SwiftUI needs one small setup step; run `sweetpad help hot-reload` for the details.
+
+```bash
+sweetpad run --hot
+```
+
+## Saving your settings
+
+If you'd rather not answer the scheme/destination prompt each time — or you want your whole team to
+share the same defaults — you can write them down.
+
+- Put your personal defaults in `~/.config/sweetpad/config.toml`.
+- Put shared, checked-in defaults in a `sweetpad.toml` file next to your project, so everyone who
+  clones the repo gets them.
+
+For the exact keys you can set, run:
 
 ```bash
 sweetpad help config
 ```
 
-## Scripting and CI
+## Using the CLI in scripts and CI
 
-Every command speaks JSON, so the CLI drops into scripts, git hooks, and CI without screen-scraping.
-Pass `--json` (or `-o json`) for a single result envelope, or `-o ndjson` to stream one event per line
-from the long-running verbs (`build`, `test`, logs):
+Every command can print JSON instead of text, which makes it easy to use from scripts, git hooks, and
+CI pipelines. Add `--json` for a single JSON result:
 
 ```bash
-sweetpad -o json settings get
-sweetpad -o ndjson build
+sweetpad --json settings get
 ```
 
-A few flags earn their keep in automation:
+A few options help in automation:
 
-- `--non-interactive` (also `SWEETPAD_NONINTERACTIVE`, and implied by `CI`) never prompts — a missing
-  scheme or destination becomes an error instead of a picker.
-- `-C DIR` runs as if started in `DIR`, like `git -C`.
-- `--developer-dir` pins the Xcode every spawned tool uses.
-- `--gh-annotations` emits GitHub Actions `::error` annotations for build and test diagnostics, so
-  failures surface inline on the PR.
+- `--non-interactive` never stops to ask a question — a missing scheme or destination becomes an error
+  instead of a prompt. (SweetPad also turns this on automatically when it detects a CI environment.)
+- `-C <folder>` runs as if you'd started in that folder.
+- `--gh-annotations` makes build and test errors show up inline on your GitHub pull request.
 
-Commands exit with a small, stable set of codes — `0` success, `3` build/test failure, `4` target
-resolution failed, `5` a required tool is missing, and so on — so a script can branch on the outcome.
-Run `sweetpad help exit-codes` for the full table.
+Commands also return meaningful exit codes — `0` when everything's fine, and specific non-zero codes
+for a failed build, a missing tool, and so on — so a script can react to what happened. Run
+`sweetpad help exit-codes` for the list.
 
 :::tip
 
-`ok: true` in the JSON envelope means the command ran, not that the outcome was good. A red test suite
-still exits non-zero with `passed: false` in its payload — read the payload's own status field.
+When you ask for JSON, a successful response means "the command ran," not "the result was good." A
+failing test run, for example, still reports its own failure inside the result — so check the status
+in the payload, not just whether the command completed.
 
 :::
 
-## Built-in help topics
+## Built-in guides
 
-Beyond `--help` on each command, the CLI ships longer-form topics you can read offline:
+Alongside `--help` on each command, the tool ships a few longer explanations you can read offline:
 
 ```bash
-sweetpad help                 # list the topics
-sweetpad help config          # the config file: keys and precedence
-sweetpad help environment     # every SWEETPAD_* variable
-sweetpad help destinations    # destination specifiers and the picker
+sweetpad help                 # list the guides
+sweetpad help config          # settings you can save
+sweetpad help destinations    # how to describe where to run
 sweetpad help exit-codes      # what each exit code means
-sweetpad help hot-reload      # requirements and recompilers for --hot
+sweetpad help hot-reload      # setting up live reload
 ```
 
 ## Shell completions
 
-Generate a completion script for your shell and load it however your shell prefers:
+Turn on tab-completion for your shell. For example, with zsh:
 
 ```bash
 sweetpad completions zsh > /path/to/completions/_sweetpad
 ```
 
-`bash`, `zsh`, `fish`, `elvish`, and `powershell` are all supported.
+Bash, zsh, fish, elvish, and PowerShell are all supported.
 
-## Driving a live VSCode session
+## Optional: controlling VSCode from the terminal
 
-The same binary has a second half — `sweetpad vscode <method>` — that talks over JSON-RPC to a running
-VSCode window, so a script or AI agent can read state and trigger builds _inside_ your editor session
-rather than in a headless project. That's covered on its own page:
-[Agent CLI & RPC server](./agent-cli.md).
+If you _do_ use the VSCode extension, the `sweetpad` tool has a second, optional side —
+`sweetpad vscode` — that can talk to a running VSCode window so a script or an AI coding agent can
+trigger builds and read results inside your editor session. This is entirely optional and unrelated to
+the standalone commands above; it only matters if you want the CLI and the extension to work together.
+It has its own page: [Agent CLI & RPC server](./agent-cli.md).

--- a/sweetpad-docs/docs/cli.md
+++ b/sweetpad-docs/docs/cli.md
@@ -4,13 +4,13 @@ sidebar_position: 15
 
 # SweetPad CLI
 
-SweetPad ships a standalone `sweetpad` command-line tool — "xcodebuild for humans". It builds, runs,
-tests, and inspects the same Xcode and Swift Package projects the [VSCode extension](./intro.md) does,
-but from the terminal, with no editor running.
+The SweetPad CLI is a standalone `sweetpad` command-line tool — "xcodebuild for humans". It builds,
+runs, tests, and inspects Xcode and Swift Package projects from the terminal, with no editor running.
 
-It's a single native macOS binary (no Node runtime), and it shares the same build-settings resolver
-the extension uses — so a scheme, destination, or configuration you pick on the command line resolves
-exactly the way it would in the sidebar.
+It's one of the two SweetPad products, a sibling to the [VSCode extension](./intro.md) — use either on
+its own. It's a single native macOS binary (no Node runtime), and it shares the same build-settings
+resolver the extension uses, so a scheme, destination, or configuration you pick on the command line
+resolves exactly the way it would in the sidebar.
 
 :::info
 

--- a/sweetpad-docs/docs/cli.md
+++ b/sweetpad-docs/docs/cli.md
@@ -53,7 +53,16 @@ sweetpad run --help          # options for one command
 
 ## Everyday commands
 
-Run these from inside your project folder.
+**Start a project.** `sweetpad project new` scaffolds a minimal SwiftUI app — run it with no options
+for a short wizard, or pass a name to use defaults. Already have a project? Skip this and just `cd`
+into it.
+
+```bash
+sweetpad project new              # answer a few questions
+sweetpad project new MyApp        # or use defaults
+```
+
+The rest of these run from inside your project folder.
 
 **Build and run.** `sweetpad run` is the one you'll use most — it builds the app, launches it on your
 chosen simulator or device, and streams the logs into your terminal.

--- a/sweetpad-docs/docs/cli.md
+++ b/sweetpad-docs/docs/cli.md
@@ -8,9 +8,7 @@ The SweetPad CLI is a command-line tool named `sweetpad` that builds, runs, and 
 Swift Package apps from the terminal — no editor needed. If you've ever wished `xcodebuild` were
 friendlier, this is that.
 
-It's one of the two SweetPad products, a sibling to the [VSCode extension](./intro.md). The two are
-completely independent: the CLI is a standalone tool, so you **don't** need VSCode (or the extension)
-installed to use it, and it doesn't touch your editor.
+It's the command-line side of SweetPad, alongside the [VSCode extension](./intro.md).
 
 :::tip
 
@@ -205,10 +203,8 @@ sweetpad completions zsh > /path/to/completions/_sweetpad
 
 Bash, zsh, fish, elvish, and PowerShell are all supported.
 
-## Optional: controlling VSCode from the terminal
+## Controlling VSCode from the terminal
 
-If you _do_ use the VSCode extension, the `sweetpad` tool has a second, optional side —
-`sweetpad vscode` — that can talk to a running VSCode window so a script or an AI coding agent can
-trigger builds and read results inside your editor session. This is entirely optional and unrelated to
-the standalone commands above; it only matters if you want the CLI and the extension to work together.
-It has its own page: [Agent CLI & RPC server](./agent-cli.md).
+The `sweetpad` tool has a second side — `sweetpad vscode` — that talks to a running VSCode window so a
+script or an AI coding agent can trigger builds and read results inside your editor session. It's an
+advanced topic with its own page: [Agent CLI & RPC server](./agent-cli.md).

--- a/sweetpad-docs/docs/cli.md
+++ b/sweetpad-docs/docs/cli.md
@@ -1,0 +1,189 @@
+---
+sidebar_position: 15
+---
+
+# SweetPad CLI
+
+SweetPad ships a standalone `sweetpad` command-line tool — "xcodebuild for humans". It builds, runs,
+tests, and inspects the same Xcode and Swift Package projects the [VSCode extension](./intro.md) does,
+but from the terminal, with no editor running.
+
+It's a single native macOS binary (no Node runtime), and it shares the same build-settings resolver
+the extension uses — so a scheme, destination, or configuration you pick on the command line resolves
+exactly the way it would in the sidebar.
+
+:::info
+
+Like the extension, the CLI drives Xcode's own command-line tools under the hood, so you still need
+Xcode installed.
+
+:::
+
+## Install
+
+The CLI is distributed via Homebrew as a signed, notarized universal binary, independent of the VSCode
+extension:
+
+```bash
+brew install sweetpad-dev/tap/sweetpad
+```
+
+Verify it:
+
+```bash
+sweetpad --version
+```
+
+Upgrade it later with `brew upgrade sweetpad`.
+
+## Quick start
+
+Run `sweetpad` from inside a project — a folder containing an `.xcworkspace`, `.xcodeproj`, or
+`Package.swift`. It finds the project by walking up from the current directory, the same way `git`
+finds its repo.
+
+```bash
+cd ~/Developer/MyApp
+
+# Where am I? Show the resolved build context.
+sweetpad status
+
+# List everything you can run on — simulators, devices, macOS.
+sweetpad devices
+
+# Build, install, launch, and stream logs — the flagship loop.
+sweetpad run
+```
+
+The first time you run inside a project, SweetPad prompts you to pick a scheme and a destination, then
+remembers them per project so later commands don't ask again. Run `sweetpad status` any time to see
+what's currently selected and where each value came from.
+
+## What the CLI can do
+
+The command tree is resource-first — a noun, then a verb (`sweetpad simulator list`). Most nouns also
+have a bare shortcut for their most common verb, so `sweetpad build` is `sweetpad build start` and
+`sweetpad test` is `sweetpad test run`. Run `sweetpad --help` to explore the full tree, or
+`sweetpad <command> --help` for one command.
+
+The main groups:
+
+- **Build & run** — `build`, `run` (build + install + launch + logs), `test`, `archive` (export an
+  `.ipa`), and `clean`.
+- **Explore the project** — `scheme`, `project` (targets and configurations), `settings` (resolved
+  build settings), and `dependency` (Swift Package dependencies).
+- **Pick where to run** — `devices` lists every runnable target with its ready specifier; `simulator`
+  and `context` (the remembered selection) manage the details.
+- **Format** — `format` runs or lints Swift sources with `swift-format` or a formatter you point it at.
+- **Maintenance** — `doctor` diagnoses the local toolchain, `derived-data` inspects and purges Xcode's
+  DerivedData, and `open` jumps to the project in Xcode, the Simulator, or the config file.
+- **Utilities** — `bsp` sets up SourceKit-LSP autocomplete, `merge` installs git merge drivers for
+  `project.pbxproj` and `Package.resolved`, `completions` generates shell completions, and
+  `self-update` upgrades the binary.
+
+### Hot reload
+
+`sweetpad run --hot` recompiles and injects each Swift save into the running app without relaunching,
+preserving state — the CLI counterpart of the extension's [hot reload](./hot-reload.md). It's iOS
+Simulator only. See `sweetpad help hot-reload` for the SwiftUI setup and recompiler options.
+
+## Selecting a target
+
+Every build command needs to know four things: which project container, which scheme, which
+configuration, and which destination. You can supply any of them explicitly, but you rarely have to —
+SweetPad resolves each value from the first source that has it, highest priority first:
+
+1. An explicit flag (`--scheme`, `--configuration`, `--on`, `--destination`).
+2. A `SWEETPAD_*` environment variable.
+3. Your personal config file.
+4. A committed `sweetpad.toml` next to the project (team-shared defaults).
+5. The selection SweetPad remembered from a previous run.
+6. Auto-discovery (a single obvious scheme, a booted simulator, and so on).
+
+The friendliest way to choose a destination is `--on`, which takes a human reference — a fuzzy
+simulator name, `booted`, `mac`, `device`, or a platform word:
+
+```bash
+sweetpad run --on "iPhone 16 Pro"
+sweetpad build --on mac
+sweetpad test --on booted
+```
+
+`--destination` remains the raw escape hatch when you need to pass an exact `xcodebuild` specifier.
+Run `sweetpad help destinations` for the full grammar.
+
+## Configuration
+
+SweetPad reads two hand-authored files, and never writes to either:
+
+- Your personal `~/.config/sweetpad/config.toml` holds global defaults plus per-project overrides.
+- A committed `sweetpad.toml` next to the project is the team-shared defaults layer — scheme,
+  configuration, destination, the Xcode to use, and more — that everyone on the project inherits.
+
+Remembered selections live separately in a machine-managed state file; inspect and edit them with
+`sweetpad context`, not by hand. For the full list of keys and the resolution precedence, run:
+
+```bash
+sweetpad help config
+```
+
+## Scripting and CI
+
+Every command speaks JSON, so the CLI drops into scripts, git hooks, and CI without screen-scraping.
+Pass `--json` (or `-o json`) for a single result envelope, or `-o ndjson` to stream one event per line
+from the long-running verbs (`build`, `test`, logs):
+
+```bash
+sweetpad -o json settings get
+sweetpad -o ndjson build
+```
+
+A few flags earn their keep in automation:
+
+- `--non-interactive` (also `SWEETPAD_NONINTERACTIVE`, and implied by `CI`) never prompts — a missing
+  scheme or destination becomes an error instead of a picker.
+- `-C DIR` runs as if started in `DIR`, like `git -C`.
+- `--developer-dir` pins the Xcode every spawned tool uses.
+- `--gh-annotations` emits GitHub Actions `::error` annotations for build and test diagnostics, so
+  failures surface inline on the PR.
+
+Commands exit with a small, stable set of codes — `0` success, `3` build/test failure, `4` target
+resolution failed, `5` a required tool is missing, and so on — so a script can branch on the outcome.
+Run `sweetpad help exit-codes` for the full table.
+
+:::tip
+
+`ok: true` in the JSON envelope means the command ran, not that the outcome was good. A red test suite
+still exits non-zero with `passed: false` in its payload — read the payload's own status field.
+
+:::
+
+## Built-in help topics
+
+Beyond `--help` on each command, the CLI ships longer-form topics you can read offline:
+
+```bash
+sweetpad help                 # list the topics
+sweetpad help config          # the config file: keys and precedence
+sweetpad help environment     # every SWEETPAD_* variable
+sweetpad help destinations    # destination specifiers and the picker
+sweetpad help exit-codes      # what each exit code means
+sweetpad help hot-reload      # requirements and recompilers for --hot
+```
+
+## Shell completions
+
+Generate a completion script for your shell and load it however your shell prefers:
+
+```bash
+sweetpad completions zsh > /path/to/completions/_sweetpad
+```
+
+`bash`, `zsh`, `fish`, `elvish`, and `powershell` are all supported.
+
+## Driving a live VSCode session
+
+The same binary has a second half — `sweetpad vscode <method>` — that talks over JSON-RPC to a running
+VSCode window, so a script or AI agent can read state and trigger builds _inside_ your editor session
+rather than in a headless project. That's covered on its own page:
+[Agent CLI & RPC server](./agent-cli.md).

--- a/sweetpad-docs/docs/debug.md
+++ b/sweetpad-docs/docs/debug.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 6
 ---
 
 # Debugging

--- a/sweetpad-docs/docs/destinations.md
+++ b/sweetpad-docs/docs/destinations.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 7
 ---
 
 # Destinations

--- a/sweetpad-docs/docs/devices.md
+++ b/sweetpad-docs/docs/devices.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 8
 ---
 
 # iOS Devices

--- a/sweetpad-docs/docs/format.md
+++ b/sweetpad-docs/docs/format.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 11
 ---
 
 # Format code

--- a/sweetpad-docs/docs/getting-started-cli.md
+++ b/sweetpad-docs/docs/getting-started-cli.md
@@ -1,0 +1,108 @@
+---
+sidebar_position: 3
+---
+
+# Get started with the CLI
+
+The `sweetpad` command-line tool builds, runs, and tests your Xcode apps from the terminal — no editor
+needed. This page gets you from install to a running app in a few minutes. You need a Mac with Xcode
+installed.
+
+## 1. Install
+
+Install with [Homebrew](https://brew.sh/):
+
+```bash
+brew install sweetpad-dev/tap/sweetpad
+```
+
+Check that it worked:
+
+```bash
+sweetpad --version
+```
+
+## 2. Go to your project
+
+Open a terminal and `cd` into your project folder — anywhere inside a folder that has an `.xcworkspace`,
+`.xcodeproj`, or `Package.swift`. SweetPad finds the project by looking in the current folder and its
+parents, just like `git` does.
+
+```bash
+cd ~/Developer/MyApp
+```
+
+## 3. See where you are
+
+Run `sweetpad status` to see what SweetPad thinks it's working with:
+
+```bash
+sweetpad status
+```
+
+The first time, it may not have picked a scheme or a place to run yet — that's fine, the next step
+sorts it out.
+
+## 4. Build and run
+
+Run your app with a single command:
+
+```bash
+sweetpad run
+```
+
+The first time in a project, SweetPad asks which scheme to build and which simulator or device to run
+on, then remembers your choice so it won't ask again. It builds the app, launches it, and streams the
+app's logs right in your terminal.
+
+Want to skip the questions and just say where to run? Use `--on` with a simulator name, `mac`, or
+`booted` (whatever simulator is already open):
+
+```bash
+sweetpad run --on "iPhone 16 Pro"
+```
+
+## 5. Try a few more commands
+
+Here are the everyday ones:
+
+```bash
+# See everywhere you can run — simulators, devices, and macOS
+sweetpad devices
+
+# Just build, don't run
+sweetpad build
+
+# Run your tests
+sweetpad test
+
+# Format your Swift files
+sweetpad format
+```
+
+Most commands ask you to pick a scheme or destination the first time, then remember it. Run
+`sweetpad status` any time to see the current choices, or change them with `sweetpad context`.
+
+## Getting help
+
+Every command explains itself with `--help`:
+
+```bash
+sweetpad --help              # all commands
+sweetpad run --help          # options for one command
+```
+
+And there are a few longer guides built right into the tool:
+
+```bash
+sweetpad help                # list the guides
+sweetpad help destinations   # how to pick where to run
+sweetpad help config         # settings you can save
+```
+
+## Where to go next
+
+- The [SweetPad CLI](./cli.md) page covers every command group, saving your settings, and using the
+  CLI in scripts and CI.
+- Prefer working in an editor? The [VSCode extension](./getting-started-vscode.md) does all of this
+  from a sidebar.

--- a/sweetpad-docs/docs/getting-started-cli.md
+++ b/sweetpad-docs/docs/getting-started-cli.md
@@ -22,9 +22,35 @@ Check that it worked:
 sweetpad --version
 ```
 
-## 2. Go to your project
+## 2. Get a project
 
-Open a terminal and `cd` into your project folder — anywhere inside a folder that has an `.xcworkspace`,
+You can start a brand-new app or point SweetPad at one you already have.
+
+### Create a new project
+
+`sweetpad project new` scaffolds a minimal SwiftUI app. Run it with no options and it walks you through
+a short set of questions — project name, iOS or macOS, bundle identifier, and so on — then creates the
+project for you:
+
+```bash
+sweetpad project new
+```
+
+Prefer to skip the questions? Pass a name (and any options you want) and it uses sensible defaults:
+
+```bash
+sweetpad project new MyApp --platform ios
+```
+
+When it's done, hop into the new folder:
+
+```bash
+cd MyApp
+```
+
+### Or use an existing project
+
+Already have a project? Just `cd` into it — anywhere inside a folder that has an `.xcworkspace`,
 `.xcodeproj`, or `Package.swift`. SweetPad finds the project by looking in the current folder and its
 parents, just like `git` does.
 

--- a/sweetpad-docs/docs/getting-started-vscode.md
+++ b/sweetpad-docs/docs/getting-started-vscode.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 2
+---
+
+import ReactPlayer from 'react-player'
+
+# Get started with the extension
+
+This is a five-minute walkthrough: install the extension, open an Xcode project, and run your app on a
+simulator — all inside VSCode. You need a Mac with Xcode installed.
+
+:::tip
+
+Everything here works in [Cursor](https://www.cursor.com/) too — it's a fork of VSCode, so the
+extension installs and behaves the same way.
+
+:::
+
+## 1. Install the extension
+
+Install [VSCode](https://code.visualstudio.com/) if you don't have it, then install SweetPad from the
+[VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=SweetPad.sweetpad).
+
+![Install extension](/images/intro/install-extension.png)
+
+## 2. Get an Xcode project
+
+Any Swift app project works. If you're starting fresh, you can create one in Xcode, or use a project
+generator like [XcodeGen](https://github.com/yonaskolb/XcodeGen) or [Tuist](https://tuist.io/) that
+keeps your project structure in a config file. A plain Swift Package works too — just a folder with a
+`Package.swift` in it.
+
+![Xcode](/images/intro/create-project.png)
+
+## 3. Open the project folder
+
+Open the project's **root folder** in VSCode — the folder that contains your `.xcodeproj` or
+`.xcworkspace`, not the `.xcodeproj`/`.xcworkspace` itself.
+
+Once it opens, look for the SweetPad lollipop icon 🍭 in the left sidebar. That's your home base.
+
+![Opened project](/images/intro/open-project.png)
+
+The sidebar has a few sections:
+
+- **Build** — your schemes, each with a ▶️ button to build and run.
+- **Destinations** — everywhere you can run: simulators, connected devices, and macOS.
+- **Tools** — one-click install for the helper tools SweetPad can use.
+
+## 4. Build and run
+
+Click ▶️ next to a scheme. SweetPad asks which simulator or device to use, builds the app, boots the
+simulator, and launches it. Wait for the build to finish and your app appears.
+
+That's it — you just built and ran an Xcode app from VSCode. 🎉
+
+## Where to go next
+
+- [Configure format on save](./format.md) so your Swift files tidy themselves up as you save.
+- Install `xcbeautify` from the [Tools](./tools.md) panel for cleaner build logs.
+- Set up [debugging](./debug.md) with breakpoints.
+- Browse the full [feature list](./intro.md#what-you-get).
+
+## Demo
+
+Here's the whole flow in a few seconds:
+
+<ReactPlayer src="/images/intro/build-demo.mp4" controls style={{ width: '100%', height: '100%' }} />

--- a/sweetpad-docs/docs/hot-reload.md
+++ b/sweetpad-docs/docs/hot-reload.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4.5
+sidebar_position: 6.5
 ---
 
 # Hot reload

--- a/sweetpad-docs/docs/intro.md
+++ b/sweetpad-docs/docs/intro.md
@@ -13,6 +13,10 @@ like [xcode-build-server](https://github.com/SolaWing/xcode-build-server),
 [swift-format](https://github.com/swiftlang/swift-format), and
 [pymobiledevice3](https://github.com/doronz88/pymobiledevice3).
 
+Prefer the terminal? The same power ships as a standalone [`sweetpad` CLI](./cli.md) — a single native
+binary that builds, runs, and tests the same projects without an editor. This guide is about the
+extension; the [SweetPad CLI](./cli.md) page covers the command-line tool.
+
 :::info
 
 You still need to have Xcode installed on your machine to use the extension because it heavily relies on the Xcode CLI
@@ -37,8 +41,10 @@ tools to build and run your project.
   compiler diagnostics in the Problems panel.
 - 🌳 **[Git worktrees](./worktree.md)** — switch the active workspace between parallel checkouts of the same project
   in one command.
-- 🤖 **[Agent CLI / RPC server](./agent-cli.md)** — opt-in JSON-RPC server and bundled `sweetpad` CLI so scripts and
-  AI coding agents can drive your VSCode session from the outside.
+- 💻 **[SweetPad CLI](./cli.md)** — the standalone `sweetpad` command-line tool ("xcodebuild for humans")
+  to build, run, and test the same projects straight from the terminal.
+- 🤖 **[Agent CLI / RPC server](./agent-cli.md)** — opt-in JSON-RPC server so scripts and AI coding agents
+  can drive your VSCode session from the outside.
 
 ## Getting started
 

--- a/sweetpad-docs/docs/intro.md
+++ b/sweetpad-docs/docs/intro.md
@@ -13,9 +13,10 @@ like [xcode-build-server](https://github.com/SolaWing/xcode-build-server),
 [swift-format](https://github.com/swiftlang/swift-format), and
 [pymobiledevice3](https://github.com/doronz88/pymobiledevice3).
 
-Prefer the terminal? The same power ships as a standalone [`sweetpad` CLI](./cli.md) — a single native
-binary that builds, runs, and tests the same projects without an editor. This guide is about the
-extension; the [SweetPad CLI](./cli.md) page covers the command-line tool.
+SweetPad is a family of tools. This extension is one product; its sibling is the standalone
+[SweetPad CLI](./cli.md) — a single native binary that builds, runs, and tests the same projects from
+the terminal, no editor needed. This guide is about the extension; the [CLI](./cli.md) page covers the
+command-line tool.
 
 :::info
 

--- a/sweetpad-docs/docs/intro.md
+++ b/sweetpad-docs/docs/intro.md
@@ -2,30 +2,38 @@
 sidebar_position: 1
 ---
 
-import ReactPlayer from 'react-player'
-
 # Introduction
 
-SweetPad is a VSCode extension that lets you build, run, debug, and test your Xcode projects for iOS, macOS, tvOS,
-watchOS, and visionOS without leaving VSCode. It's built on top of the Xcode CLI tools, plus a handful of open-source tools
-like [xcode-build-server](https://github.com/SolaWing/xcode-build-server),
-[xcbeautify](https://github.com/cpisciotta/xcbeautify),
-[swift-format](https://github.com/swiftlang/swift-format), and
-[pymobiledevice3](https://github.com/doronz88/pymobiledevice3).
+SweetPad helps you build, run, debug, and test your Xcode projects for iOS, macOS, tvOS, watchOS, and
+visionOS — without living inside Xcode. It works with Xcode workspaces and projects, [Tuist](./tuist.md),
+XcodeGen, and Swift Packages.
 
-SweetPad is a family of tools. This extension is one product; its sibling is the standalone
-[SweetPad CLI](./cli.md) — a single native binary that builds, runs, and tests the same projects from
-the terminal, no editor needed. This guide is about the extension; the [CLI](./cli.md) page covers the
-command-line tool.
+SweetPad is a family of tools, and there are two separate products:
+
+- **[VSCode extension](./getting-started-vscode.md)** — build, run, and debug from the editor sidebar,
+  with logs, tests, formatting, and autocomplete built in. This works in [Cursor](https://www.cursor.com/) too.
+- **[SweetPad CLI](./getting-started-cli.md)** — the standalone `sweetpad` command-line tool
+  ("xcodebuild for humans") that does the same from the terminal, no editor needed.
+
+The two are independent. Pick whichever fits how you work — you can use either one on its own, and
+neither requires the other. (If you happen to use both, they can also
+[work together](./agent-cli.md), but that's entirely optional.)
 
 :::info
 
-You still need to have Xcode installed on your machine to use the extension because it heavily relies on the Xcode CLI
-tools to build and run your project.
+Both products drive Xcode's own command-line tools under the hood, so you still need Xcode installed on
+your Mac.
 
 :::
 
+## Get started
+
+- New to the extension? Follow [Get started with the extension](./getting-started-vscode.md).
+- Prefer the terminal? Follow [Get started with the CLI](./getting-started-cli.md).
+
 ## What you get
+
+The VSCode extension gives you:
 
 - 🛠️ **[Build & Run](./build.md)** apps on simulators, macOS, and physical devices straight from the SweetPad sidebar
   — with support for Xcode workspaces, Xcode projects, [Tuist](./tuist.md), XcodeGen, and Swift Package Manager
@@ -42,56 +50,10 @@ tools to build and run your project.
   compiler diagnostics in the Problems panel.
 - 🌳 **[Git worktrees](./worktree.md)** — switch the active workspace between parallel checkouts of the same project
   in one command.
-- 💻 **[SweetPad CLI](./cli.md)** — the standalone `sweetpad` command-line tool ("xcodebuild for humans")
-  to build, run, and test the same projects straight from the terminal.
-- 🤖 **[Agent CLI / RPC server](./agent-cli.md)** — opt-in JSON-RPC server so scripts and AI coding agents
-  can drive your VSCode session from the outside.
 
-## Getting started
+And the same building, running, and testing is available from the terminal:
 
-:::tip
-
-This tutorial also works for [Cursor](https://www.cursor.com/), an AI-first code editor that's a fork of VSCode.
-
-:::
-
-First, install [VSCode](https://code.visualstudio.com/) and the extension from the
-[VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=SweetPad.sweetpad).
-
-![Install extension](/images/intro/install-extension.png)
-
-Next, create an Xcode project. We highly recommend [XcodeGen](https://github.com/yonaskolb/XcodeGen) or
-[Tuist](https://tuist.io/), which let you define the project structure in configuration files — but plain Xcode is
-fine too. SweetPad also works directly with Swift Packages: open a folder that contains a `Package.swift` and you're
-good to go.
-
-![Xcode](/images/intro/create-project.png)
-
-Once you have a working Xcode project, open the project's root folder in VSCode — not the `.xcodeproj` or
-`.xcworkspace` folder itself.
-
-If you installed the extension correctly, you should see the SweetPad lollipop icon 🍭 in the left sidebar of the
-editor. This is the main entry point for using the extension.
-
-The main panels of the extension are:
-
-1. **Build** — shows the list of schemes and the "Launch" button to build and run the project.
-2. **Destinations** — lists every place you can run on: recently used destinations, simulators, and connected devices.
-3. **Tools** — installs and links to docs for the third-party tools SweetPad uses.
-
-![Opened project](/images/intro/open-project.png)
-
-To build and run the project, click ▶️ next to the scheme and wait for the build to finish. SweetPad then boots the
-simulator and launches the app.
-
-That's it — you've built and run your first Xcode project in VSCode. From here:
-
-- [Configure format on save](./format.md) so Swift files reformat themselves on save.
-- Install `xcbeautify` for readable build logs — the [Tools](./tools.md) panel handles it.
-- Explore the rest of the [features](#what-you-get).
-
-## Demo
-
-Here is a short demo of building and running an Xcode project in VSCode:
-
-<ReactPlayer src="/images/intro/build-demo.mp4" controls style={{ width: '100%', height: '100%' }} />
+- 💻 **[SweetPad CLI](./cli.md)** — the standalone `sweetpad` command-line tool to build, run, and test
+  your projects, and to script them into git hooks and CI.
+- 🤖 **[Agent CLI / RPC server](./agent-cli.md)** — an opt-in server so scripts and AI coding agents can
+  drive your VSCode session from the outside.

--- a/sweetpad-docs/docs/intro.md
+++ b/sweetpad-docs/docs/intro.md
@@ -8,16 +8,12 @@ SweetPad helps you build, run, debug, and test your Xcode projects for iOS, macO
 visionOS — without living inside Xcode. It works with Xcode workspaces and projects, [Tuist](./tuist.md),
 XcodeGen, and Swift Packages.
 
-SweetPad is a family of tools, and there are two separate products:
+SweetPad comes in two forms — pick whichever fits how you work:
 
 - **[VSCode extension](./getting-started-vscode.md)** — build, run, and debug from the editor sidebar,
   with logs, tests, formatting, and autocomplete built in. This works in [Cursor](https://www.cursor.com/) too.
-- **[SweetPad CLI](./getting-started-cli.md)** — the standalone `sweetpad` command-line tool
-  ("xcodebuild for humans") that does the same from the terminal, no editor needed.
-
-The two are independent. Pick whichever fits how you work — you can use either one on its own, and
-neither requires the other. (If you happen to use both, they can also
-[work together](./agent-cli.md), but that's entirely optional.)
+- **[SweetPad CLI](./getting-started-cli.md)** — the `sweetpad` command-line tool ("xcodebuild for
+  humans") that does the same from the terminal, no editor needed.
 
 :::info
 

--- a/sweetpad-docs/docs/simulators.md
+++ b/sweetpad-docs/docs/simulators.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 9
 ---
 
 import ReactPlayer from 'react-player'

--- a/sweetpad-docs/docs/tests.md
+++ b/sweetpad-docs/docs/tests.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 12
 ---
 
 # Tests

--- a/sweetpad-docs/docs/tools.md
+++ b/sweetpad-docs/docs/tools.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 13
 ---
 
 # Tools

--- a/sweetpad-docs/docs/troubleshooting.md
+++ b/sweetpad-docs/docs/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 15
 ---
 
 # Troubleshooting

--- a/sweetpad-docs/docs/tuist.md
+++ b/sweetpad-docs/docs/tuist.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 14
 ---
 
 # Tuist

--- a/sweetpad-docs/docs/watchos-simulators.md
+++ b/sweetpad-docs/docs/watchos-simulators.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 ---
 
 # watchOS Simulators

--- a/sweetpad-docs/docs/worktree.md
+++ b/sweetpad-docs/docs/worktree.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 16
 ---
 
 # Git Worktrees

--- a/sweetpad-docs/src/pages/index.tsx
+++ b/sweetpad-docs/src/pages/index.tsx
@@ -9,20 +9,53 @@ function HeroBanner() {
 			<div className={styles.heroTextAndImage}>
 				<div className={styles.heroTextAndButtons}>
 					<span className={styles.heroText}>
-						Build <b>iOS/Swift</b> apps using <b>Visual Studio Code</b>
+						Build <b>iOS/Swift</b> apps from <b>VS Code</b> or the{" "}
+						<b>terminal</b>
 					</span>
 					<div className={styles.heroButtons}>
 						<Link
 							className="button button--primary button--lg"
-							to="/docs/intro"
+							to="/docs/getting-started-vscode"
 						>
-							Get Started
+							VS Code extension
+						</Link>
+						<Link
+							className="button button--secondary button--lg"
+							to="/docs/getting-started-cli"
+						>
+							Command-line tool
 						</Link>
 					</div>
 				</div>
 				<img className={styles.heroImage} src="/images/logo.png" alt="Hero" />
 			</div>
 		</div>
+	);
+}
+
+function Products() {
+	return (
+		<section className={styles.features}>
+			<div className="container">
+				<p style={{ textAlign: "center", maxWidth: 760, margin: "0 auto 2rem" }}>
+					SweetPad is two separate tools for iOS/Swift development. Pick whichever
+					fits how you work — you can use either one on its own, and neither
+					needs the other.
+				</p>
+				<div className="row">
+					<FeatureItem
+						title="🧩 VS Code extension"
+						description="Build, run, debug, and test from the editor sidebar. Works in Cursor too."
+						link="/docs/getting-started-vscode"
+					/>
+					<FeatureItem
+						title="💻 Command-line tool"
+						description="The standalone sweetpad CLI: build, run, and test from the terminal — no editor required."
+						link="/docs/getting-started-cli"
+					/>
+				</div>
+			</div>
+		</section>
 	);
 }
 
@@ -45,6 +78,9 @@ function Features() {
 	return (
 		<section className={styles.features}>
 			<div className="container">
+				<h2 style={{ textAlign: "center", marginBottom: "2rem" }}>
+					Inside the VS Code extension
+				</h2>
 				<div className="row">
 					<FeatureItem
 						title="✅ Autocomplete"
@@ -104,6 +140,7 @@ export default function Home(): React.JSX.Element {
 		>
 			<main>
 				<HeroBanner />
+				<Products />
 				<Features />
 			</main>
 		</Layout>

--- a/sweetpad-docs/src/pages/index.tsx
+++ b/sweetpad-docs/src/pages/index.tsx
@@ -38,9 +38,8 @@ function Products() {
 		<section className={styles.features}>
 			<div className="container">
 				<p style={{ textAlign: "center", maxWidth: 760, margin: "0 auto 2rem" }}>
-					SweetPad is two separate tools for iOS/Swift development. Pick whichever
-					fits how you work — you can use either one on its own, and neither
-					needs the other.
+					SweetPad works two ways — from your editor, or from the terminal. Pick
+					whichever fits how you work.
 				</p>
 				<div className="row">
 					<FeatureItem


### PR DESCRIPTION
- Add a dedicated SweetPad CLI docs page (install, command surface,
  target resolution, config, scripting/CI, help topics, completions)
- Refocus the Agent CLI / RPC page on the vscode RPC half and link the
  new CLI page (URL and anchors preserved)
- Introduce both the extension and the CLI in the intro
- Rewrite the root README to lead with the VS Code extension, then the
  CLI; keep sweetpad-lib listed as internal/in-development

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NJjPWgbZEdzqNDK5yK2APy