### PR TITLE
docs: sync package-lock so npm ci works

### DIFF
--- a/sweetpad-docs/package-lock.json
+++ b/sweetpad-docs/package-lock.json
@@ -18220,16 +18220,13 @@
       }
     },
     "node_modules/sockjs/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/sort-css-media-queries": {


### PR DESCRIPTION
## Problem

`npm ci` in `sweetpad-docs/` fails, breaking any install/publish that uses it:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Invalid: lock file's uuid@11.1.1 does not satisfy uuid@8.3.2
```

`package.json` has an override forcing `webpack-dev-server → sockjs → uuid` to `^11.1.1`, but that dependency path no longer exists in the Docusaurus 3 tree, so the override is a no-op. sockjs actually resolves `uuid@8.3.2`, while the lockfile had drifted to the un-appliable `11.1.1` — leaving the two out of sync.

## Fix

Regenerate the lockfile so the sockjs `uuid` entry records `8.3.2`, the version actually resolved. Minimal change — one dependency node.

## Verification

With the synced lockfile:

- `npm ci` → exit 0
- `npm run build` (docusaurus, `onBrokenLinks: throw`) → success
- `npm run typecheck` (tsc) → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJjPWgbZEdzqNDK5yK2APy)_