### PR TITLE
docs: group pages into VS Code extension and CLI sidebar categories

### DIFF
--- a/sweetpad-docs/docs/cli/_category_.json
+++ b/sweetpad-docs/docs/cli/_category_.json
@@ -1,0 +1,10 @@
+{
+  "label": "SweetPad CLI",
+  "position": 3,
+  "collapsed": false,
+  "link": {
+    "type": "generated-index",
+    "slug": "/category/cli",
+    "description": "The standalone sweetpad command-line tool — xcodebuild for humans."
+  }
+}

--- a/sweetpad-docs/docs/cli/agent-cli.md
+++ b/sweetpad-docs/docs/cli/agent-cli.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 18
+sidebar_position: 4
+slug: /agent-cli
 ---
 
 # Agent CLI & RPC Server

--- a/sweetpad-docs/docs/cli/cli.md
+++ b/sweetpad-docs/docs/cli/cli.md
@@ -85,8 +85,8 @@ sweetpad devices
 
 ```bash
 sweetpad scheme list             # the schemes SweetPad found
-sweetpad project                 # targets and configurations
-sweetpad settings get            # the resolved build settings
+sweetpad project info            # targets and configurations
+sweetpad settings show           # the resolved build settings
 sweetpad dependency list         # Swift Package dependencies
 ```
 
@@ -106,7 +106,8 @@ sweetpad archive
 ```
 
 There's more — Swift Package tools, git merge helpers, and shell completions among them. Run
-`sweetpad --help` to see the whole list.
+`sweetpad --help` to see the whole list, or browse the [CLI reference](./reference.md) for every
+command on one page.
 
 ## Choosing where to run
 
@@ -161,7 +162,7 @@ Every command can print JSON instead of text, which makes it easy to use from sc
 CI pipelines. Add `--json` for a single JSON result:
 
 ```bash
-sweetpad --json settings get
+sweetpad --json settings show
 ```
 
 A few options help in automation:
@@ -190,6 +191,7 @@ Alongside `--help` on each command, the tool ships a few longer explanations you
 ```bash
 sweetpad help                 # list the guides
 sweetpad help config          # settings you can save
+sweetpad help environment     # every SWEETPAD_* variable
 sweetpad help destinations    # how to describe where to run
 sweetpad help exit-codes      # what each exit code means
 sweetpad help hot-reload      # setting up live reload

--- a/sweetpad-docs/docs/cli/cli.md
+++ b/sweetpad-docs/docs/cli/cli.md
@@ -1,5 +1,7 @@
 ---
-sidebar_position: 17
+sidebar_position: 2
+slug: /cli
+sidebar_label: Overview
 ---
 
 # SweetPad CLI
@@ -8,7 +10,7 @@ The SweetPad CLI is a command-line tool named `sweetpad` that builds, runs, and 
 Swift Package apps from the terminal — no editor needed. If you've ever wished `xcodebuild` were
 friendlier, this is that.
 
-It's the command-line side of SweetPad, alongside the [VSCode extension](./intro.md).
+It's the command-line side of SweetPad, alongside the [VSCode extension](../intro.md).
 
 :::tip
 

--- a/sweetpad-docs/docs/cli/getting-started-cli.md
+++ b/sweetpad-docs/docs/cli/getting-started-cli.md
@@ -132,5 +132,6 @@ sweetpad help config         # settings you can save
 
 - The [SweetPad CLI](./cli.md) page covers every command group, saving your settings, and using the
   CLI in scripts and CI.
+- The [CLI reference](./reference.md) lists every command, flag, config key, and exit code on one page.
 - Prefer working in an editor? The [VSCode extension](../vscode/getting-started-vscode.md) does all of this
   from a sidebar.

--- a/sweetpad-docs/docs/cli/getting-started-cli.md
+++ b/sweetpad-docs/docs/cli/getting-started-cli.md
@@ -1,5 +1,7 @@
 ---
-sidebar_position: 3
+sidebar_position: 1
+slug: /getting-started-cli
+sidebar_label: Get started
 ---
 
 # Get started with the CLI
@@ -130,5 +132,5 @@ sweetpad help config         # settings you can save
 
 - The [SweetPad CLI](./cli.md) page covers every command group, saving your settings, and using the
   CLI in scripts and CI.
-- Prefer working in an editor? The [VSCode extension](./getting-started-vscode.md) does all of this
+- Prefer working in an editor? The [VSCode extension](../vscode/getting-started-vscode.md) does all of this
   from a sidebar.

--- a/sweetpad-docs/docs/cli/reference.md
+++ b/sweetpad-docs/docs/cli/reference.md
@@ -1,0 +1,216 @@
+---
+sidebar_position: 3
+slug: /cli-reference
+sidebar_label: Reference
+---
+
+# CLI reference
+
+The complete surface of the `sweetpad` command-line tool: every command, the global flags, the
+configuration files, destination specifiers, and exit codes. For a guided tour, start with
+[Get started with the CLI](./getting-started-cli.md) or the [overview](./cli.md).
+
+Commands follow a resource-then-action grammar — `sweetpad scheme list`, `sweetpad simulator boot` —
+and the everyday actions have top-level shortcuts (`sweetpad build`, `sweetpad test`, `sweetpad run`).
+`--help` works on every command and shows the options this page doesn't repeat.
+
+## Commands
+
+### Everyday
+
+| Command            | What it does                                                                     |
+| ------------------- | ---------------------------------------------------------------------------------- |
+| `sweetpad run`      | Build, install, launch, and follow logs — the flagship loop. Press `r` to rebuild. |
+| `sweetpad build`    | Compile the resolved scheme. `--watch` rebuilds on every Swift save; `--clean` first cleans. |
+| `sweetpad test`     | Run the tests. Supports `--only-testing`, `--skip-testing`, `--failed`, `--retry-flaky`, `--coverage`, `--junit`, `--watch`. |
+| `sweetpad clean`    | Clean build artifacts; `--purge` also deletes DerivedData.                        |
+| `sweetpad archive`  | Archive and export an `.ipa` (`--export-method`, `--output`).                     |
+| `sweetpad format`   | Format Swift sources (`--check` to verify only; `--tool swiftlint` to lint). Alias: `fmt`. |
+| `sweetpad devices`  | List everything runnable — macOS, simulators, connected devices — most-used first. |
+| `sweetpad status`   | Show the effective build context and where each value comes from.                 |
+| `sweetpad doctor`   | Diagnose the local Xcode/Swift toolchain.                                          |
+
+### Project inspection
+
+| Command                    | What it does                                                       |
+| --------------------------- | -------------------------------------------------------------------- |
+| `sweetpad project info`     | Show targets, configurations, and schemes.                          |
+| `sweetpad project new`      | Scaffold a minimal SwiftUI app (see [options](#sweetpad-project-new)). |
+| `sweetpad scheme list`      | List the schemes SweetPad found.                                     |
+| `sweetpad settings show`    | Show resolved build settings. `--key NAME` prints one bare value for scripts. |
+| `sweetpad dependency list`  | List SPM dependencies and their locked versions. Alias: `dep`.       |
+| `sweetpad dependency add`   | Add a package by URL and link a product to a target.                 |
+| `sweetpad dependency remove`| Remove a package, or unlink one product from one target.             |
+| `sweetpad dependency update`| Update resolved versions, or change a requirement.                   |
+| `sweetpad dependency resolve` | Resolve dependencies into the lockfile.                            |
+
+### App lifecycle
+
+`sweetpad run` is shorthand for `sweetpad app run`; the rest of the lifecycle lives under `app`:
+
+| Command                  | What it does                                              |
+| ------------------------- | ----------------------------------------------------------- |
+| `sweetpad app install`    | Build and install without launching.                       |
+| `sweetpad app launch`     | Launch an already-installed app.                           |
+| `sweetpad app debug`      | Build, install, launch suspended, and attach lldb (simulator). |
+| `sweetpad app logs`       | Stream the running app's logs.                             |
+| `sweetpad app stop`       | Terminate the running app.                                 |
+| `sweetpad app uninstall`  | Remove the app from a simulator or device.                 |
+| `sweetpad app open-url`   | Open a URL on a simulator — deep links and universal links. |
+
+### Simulators
+
+Alias: `sim`. Most take an optional target (name or UDID) and default to the booted simulator.
+
+| Command                        | What it does                                                 |
+| ------------------------------- | --------------------------------------------------------------- |
+| `sweetpad simulator list`       | List available simulators.                                     |
+| `sweetpad simulator boot`       | Boot a simulator (prompts when omitted; `--wait` blocks until ready). |
+| `sweetpad simulator shutdown`   | Shut down a simulator.                                         |
+| `sweetpad simulator open`       | Open the Simulator.app window.                                 |
+| `sweetpad simulator screenshot` | Save a PNG (`--clipboard` copies instead).                     |
+| `sweetpad simulator record`     | Record the screen to an mp4 — Ctrl-C stops and finalizes.      |
+| `sweetpad simulator appearance` | Switch light/dark appearance.                                  |
+| `sweetpad simulator status-bar` | Set a clean status bar for screenshots (9:41, full bars); `--clear` resets. |
+| `sweetpad simulator location`   | Set the simulated GPS location.                                |
+| `sweetpad simulator push`       | Deliver an APNs push payload from a JSON file.                 |
+| `sweetpad simulator privacy`    | Grant, revoke, or reset a privacy permission for an app.       |
+| `sweetpad simulator media-add`  | Add photos and videos to the media library.                    |
+| `sweetpad simulator create`     | Create a new simulator.                                        |
+| `sweetpad simulator clone`      | Clone a shut-down simulator under a new name.                  |
+| `sweetpad simulator erase`      | Erase contents and settings (simulator must be shut down).     |
+| `sweetpad simulator delete`     | Delete a simulator — no undo (`--yes` skips the prompt).       |
+
+### Context and configuration
+
+| Command                     | What it does                                                              |
+| ---------------------------- | ---------------------------------------------------------------------------- |
+| `sweetpad context show`      | Show the remembered scheme, configuration, and destination.                 |
+| `sweetpad context select`    | Change a remembered value interactively (`--testing` for the test context). |
+| `sweetpad context set`       | Set a value without prompting — script- and CI-friendly.                    |
+| `sweetpad context remove`    | Clear one remembered value, or `--all` for the whole context.               |
+| `sweetpad context alias`     | Name a destination (`context alias work-phone <UDID>`), then use `--on work-phone` anywhere. |
+| `sweetpad open <what>`       | Open the project in `xcode`, the `sim` window, the `dd` (DerivedData) folder, or your `config` file. |
+
+### Maintenance and integration
+
+| Command                        | What it does                                                        |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| `sweetpad derived-data path`    | Print this project's DerivedData folder (`--all` for the whole store). Alias: `dd`. |
+| `sweetpad derived-data size`    | Report DerivedData's on-disk size.                                    |
+| `sweetpad derived-data purge`   | Delete DerivedData (`--yes` skips the prompt).                        |
+| `sweetpad merge install`        | Register git merge drivers that resolve `.pbxproj` and `Package.resolved` conflicts semantically (`--global` for all repos). |
+| `sweetpad merge run`            | Resolve conflicted project files in the current merge by hand.        |
+| `sweetpad bsp init`             | Write `buildServer.json` so SourceKit-LSP autocomplete works in any editor. |
+| `sweetpad bsp doctor`           | Check the autocomplete wiring.                                        |
+| `sweetpad completions <shell>`  | Generate completions for bash, zsh, fish, elvish, or PowerShell.      |
+| `sweetpad self-update`          | Update sweetpad (Homebrew installs run brew upgrade instead).         |
+| `sweetpad help [topic]`         | Built-in guides: `config`, `environment`, `exit-codes`, `destinations`, `hot-reload`. |
+| `sweetpad vscode <method>`      | Drive a running VSCode window — see [Agent CLI & RPC server](./agent-cli.md). |
+
+## Global flags
+
+These work on every command:
+
+| Flag                 | What it does                                                                                    |
+| --------------------- | -------------------------------------------------------------------------------------------------- |
+| `-C <dir>`            | Run as if started in that folder, like `git -C`.                                                  |
+| `-o, --output <mode>` | Output mode: `human` (default), `json`, `ndjson`, or `quiet`.                                     |
+| `--json`              | Shorthand for `-o json`.                                                                           |
+| `--non-interactive`   | Never prompt — missing choices become errors. Auto-enabled when `CI` is set.                       |
+| `--gh-annotations`    | Emit GitHub Actions annotations for build/test errors. Not combinable with `-o json`/`ndjson`.     |
+| `--developer-dir <dir>` | Pin the Xcode to use (same as the `DEVELOPER_DIR` environment variable).                          |
+| `--no-color`          | Disable colored output (also honors `NO_COLOR`).                                                   |
+| `-v, --verbose`       | Show raw tool output.                                                                              |
+| `-q, --quiet`         | Suppress progress chatter (wins over `--verbose`).                                                 |
+
+Commands that build or run also take targeting flags: `--workspace`, `--project`, `--scheme`,
+`--configuration`, `--sdk`, and the two ways to say where — `--destination` (a raw specifier) or
+`--on` (a human-friendly reference; the two are mutually exclusive).
+
+## Environment variables
+
+Every targeting flag has an environment-variable twin, so CI pipelines can set the context once:
+`SWEETPAD_WORKSPACE`, `SWEETPAD_PROJECT`, `SWEETPAD_SCHEME`, `SWEETPAD_CONFIGURATION`,
+`SWEETPAD_DESTINATION`, `SWEETPAD_ON`, and `SWEETPAD_SDK`. `SWEETPAD_NONINTERACTIVE=1` (or `CI=1`)
+turns prompts into errors. `NO_COLOR` and `CLICOLOR_FORCE` control color. Run
+`sweetpad help environment` for the full story.
+
+## Configuration files
+
+Three layers, from personal to shared:
+
+- **`~/.config/sweetpad/config.toml`** — your personal defaults. A `[defaults]` table for global
+  values, plus `[projects."<path to .xcodeproj/.xcworkspace/Package.swift>"]` tables for per-project
+  overrides. SweetPad never writes this file; it's yours.
+- **`sweetpad.toml`** next to the project — team defaults, meant to be committed. Same keys
+  (`scheme`, `configuration`, `destination`, `sdk`), plus `developer_dir` and `[run]`, `[format]`,
+  and `[testing]` tables.
+- **Remembered state** — the answers you gave to interactive prompts, stored per project. Inspect and
+  change it with `sweetpad context`, not by editing files.
+
+When the same value is set in several places, the most explicit one wins:
+
+```
+flag  >  environment variable  >  config.toml  >  sweetpad.toml  >  remembered answer  >  auto-detect
+```
+
+Typos are never silently ignored — unknown keys produce a warning on every run. See
+`sweetpad help config` for every key.
+
+## Destinations
+
+`--on` accepts plain descriptions and resolves them against your live device list:
+
+| You write                  | You get                                            |
+| --------------------------- | ----------------------------------------------------- |
+| `--on "iPhone 16 Pro"`      | The simulator or device with the closest name.       |
+| `--on booted`               | Whatever simulator is already running.               |
+| `--on mac`                  | Your Mac (for macOS schemes).                        |
+| `--on device`               | Your connected physical device.                      |
+| `--on ios` / `--on watchos` | Any destination of that platform.                    |
+| `--on work-phone`           | An alias you created with `sweetpad context alias`.  |
+| `--on <UDID>`               | That exact simulator or device.                      |
+
+`--destination` takes the raw, exact form instead — e.g.
+`platform=iOS Simulator,name=iPhone 16 Pro` or `platform=macOS` — which is handy in CI where fuzzy
+matching would be a liability. `sweetpad devices` prints a copy-paste-ready specifier for everything
+it lists.
+
+## Exit codes and JSON output
+
+| Code | Meaning                                                            |
+| ---- | -------------------------------------------------------------------- |
+| 0    | Success.                                                             |
+| 1    | Generic failure.                                                     |
+| 2    | Usage error — bad flags or arguments.                                |
+| 3    | The build or the tests failed.                                       |
+| 4    | Couldn't resolve a target — unknown scheme, destination, simulator…  |
+| 5    | A required tool is missing (xcodebuild, simctl, …).                  |
+| 6    | Cancelled by you — a declined prompt or Ctrl-C.                      |
+
+With `-o json`, results arrive as a one-shot envelope `{"schema": 1, "ok": true, "data": …}`; errors
+go to stderr as `{"schema": 1, "ok": false, "error": {"code", "message"}}` where the code mirrors the
+exit-code taxonomy. `-o ndjson` streams one JSON event per line and ends with a result event — useful
+for long commands like builds where you want progress as it happens.
+
+:::tip
+
+`"ok": true` means "the command executed", not "the outcome was good". A red test suite exits with
+code 3 and reports its failures inside `data` — check the payload, not just the envelope.
+
+:::
+
+## sweetpad project new
+
+Scaffolds a minimal SwiftUI app. With no flags on a terminal it runs a short wizard; any flag you pass
+skips its question.
+
+| Flag                        | Default                | What it does                              |
+| ---------------------------- | ---------------------- | -------------------------------------------- |
+| `--platform <ios\|macos>`    | `ios`                  | Target platform.                            |
+| `--bundle-id <id>`           | `com.example.<Name>`   | Bundle identifier.                          |
+| `--deployment-target <ver>`  | iOS 17.0 / macOS 14.0  | Minimum OS version.                         |
+| `--current-dir`              | off                    | Scaffold into the current folder instead of a new one. |
+| `--no-git`                   | off                    | Skip the initial git init.                   |
+| `--force`                    | off                    | Allow scaffolding into a non-empty folder.   |

--- a/sweetpad-docs/docs/intro.md
+++ b/sweetpad-docs/docs/intro.md
@@ -5,14 +5,14 @@ sidebar_position: 1
 # Introduction
 
 SweetPad helps you build, run, debug, and test your Xcode projects for iOS, macOS, tvOS, watchOS, and
-visionOS — without living inside Xcode. It works with Xcode workspaces and projects, [Tuist](./tuist.md),
+visionOS — without living inside Xcode. It works with Xcode workspaces and projects, [Tuist](./vscode/tuist.md),
 XcodeGen, and Swift Packages.
 
 SweetPad comes in two forms — pick whichever fits how you work:
 
-- **[VSCode extension](./getting-started-vscode.md)** — build, run, and debug from the editor sidebar,
+- **[VSCode extension](./vscode/getting-started-vscode.md)** — build, run, and debug from the editor sidebar,
   with logs, tests, formatting, and autocomplete built in. This works in [Cursor](https://www.cursor.com/) too.
-- **[SweetPad CLI](./getting-started-cli.md)** — the `sweetpad` command-line tool ("xcodebuild for
+- **[SweetPad CLI](./cli/getting-started-cli.md)** — the `sweetpad` command-line tool ("xcodebuild for
   humans") that does the same from the terminal, no editor needed.
 
 :::info
@@ -24,32 +24,32 @@ your Mac.
 
 ## Get started
 
-- New to the extension? Follow [Get started with the extension](./getting-started-vscode.md).
-- Prefer the terminal? Follow [Get started with the CLI](./getting-started-cli.md).
+- New to the extension? Follow [Get started with the extension](./vscode/getting-started-vscode.md).
+- Prefer the terminal? Follow [Get started with the CLI](./cli/getting-started-cli.md).
 
 ## What you get
 
 The VSCode extension gives you:
 
-- 🛠️ **[Build & Run](./build.md)** apps on simulators, macOS, and physical devices straight from the SweetPad sidebar
-  — with support for Xcode workspaces, Xcode projects, [Tuist](./tuist.md), XcodeGen, and Swift Package Manager
+- 🛠️ **[Build & Run](./vscode/build.md)** apps on simulators, macOS, and physical devices straight from the SweetPad sidebar
+  — with support for Xcode workspaces, Xcode projects, [Tuist](./vscode/tuist.md), XcodeGen, and Swift Package Manager
   (`Package.swift`).
-- 🐞 **[Debug](./debug.md)** with breakpoints, step, watch, and the rest of LLDB via the CodeLLDB extension — on the
+- 🐞 **[Debug](./vscode/debug.md)** with breakpoints, step, watch, and the rest of LLDB via the CodeLLDB extension — on the
   Simulator and on physical iOS devices.
 - 📋 **Logs from devices and simulators** stream `os_log` / `Logger` / `print` / `NSLog` into the build terminal so
   you don't have to keep Console.app open.
-- 🧪 **[Tests](./tests.md)** show up in VSCode's native Testing panel with gutter ▶️ buttons; supports XCTest and
+- 🧪 **[Tests](./vscode/tests.md)** show up in VSCode's native Testing panel with gutter ▶️ buttons; supports XCTest and
   Swift Testing.
-- ✍️ **[Format on save](./format.md)** with `swift-format` (Xcode's bundled copy by default) or any other Swift
+- ✍️ **[Format on save](./vscode/format.md)** with `swift-format` (Xcode's bundled copy by default) or any other Swift
   formatter you prefer.
-- 💡 **[Autocomplete](./autocomplete.md)** via SourceKit-LSP backed by `xcode-build-server`, including inline
+- 💡 **[Autocomplete](./vscode/autocomplete.md)** via SourceKit-LSP backed by `xcode-build-server`, including inline
   compiler diagnostics in the Problems panel.
-- 🌳 **[Git worktrees](./worktree.md)** — switch the active workspace between parallel checkouts of the same project
+- 🌳 **[Git worktrees](./vscode/worktree.md)** — switch the active workspace between parallel checkouts of the same project
   in one command.
 
 And the same building, running, and testing is available from the terminal:
 
-- 💻 **[SweetPad CLI](./cli.md)** — the standalone `sweetpad` command-line tool to build, run, and test
+- 💻 **[SweetPad CLI](./cli/cli.md)** — the standalone `sweetpad` command-line tool to build, run, and test
   your projects, and to script them into git hooks and CI.
-- 🤖 **[Agent CLI / RPC server](./agent-cli.md)** — an opt-in server so scripts and AI coding agents can
+- 🤖 **[Agent CLI / RPC server](./cli/agent-cli.md)** — an opt-in server so scripts and AI coding agents can
   drive your VSCode session from the outside.

--- a/sweetpad-docs/docs/intro.md
+++ b/sweetpad-docs/docs/intro.md
@@ -42,8 +42,8 @@ The VSCode extension gives you:
   Swift Testing.
 - ✍️ **[Format on save](./vscode/format.md)** with `swift-format` (Xcode's bundled copy by default) or any other Swift
   formatter you prefer.
-- 💡 **[Autocomplete](./vscode/autocomplete.md)** via SourceKit-LSP backed by `xcode-build-server`, including inline
-  compiler diagnostics in the Problems panel.
+- 💡 **[Autocomplete](./vscode/autocomplete.md)** via SourceKit-LSP — backed by `xcode-build-server` or SweetPad's
+  built-in build server — including inline compiler diagnostics in the Problems panel.
 - 🌳 **[Git worktrees](./vscode/worktree.md)** — switch the active workspace between parallel checkouts of the same project
   in one command.
 
@@ -53,3 +53,11 @@ And the same building, running, and testing is available from the terminal:
   your projects, and to script them into git hooks and CI.
 - 🤖 **[Agent CLI / RPC server](./cli/agent-cli.md)** — an opt-in server so scripts and AI coding agents can
   drive your VSCode session from the outside.
+
+## Reference
+
+When you need the exact name of something:
+
+- [Settings reference](./vscode/settings.md) — every extension setting, grouped by area.
+- [Commands reference](./vscode/commands.md) — every command-palette command.
+- [CLI reference](./cli/reference.md) — every terminal command, flag, config key, and exit code.

--- a/sweetpad-docs/docs/vscode/_category_.json
+++ b/sweetpad-docs/docs/vscode/_category_.json
@@ -1,0 +1,10 @@
+{
+  "label": "VS Code extension",
+  "position": 2,
+  "collapsed": false,
+  "link": {
+    "type": "generated-index",
+    "slug": "/category/vscode-extension",
+    "description": "Build, run, debug, and test Xcode projects from the VS Code (or Cursor) sidebar."
+  }
+}

--- a/sweetpad-docs/docs/vscode/autocomplete.md
+++ b/sweetpad-docs/docs/vscode/autocomplete.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 4
+sidebar_position: 7
+slug: /autocomplete
 ---
 
 # Autocomplete

--- a/sweetpad-docs/docs/vscode/autocomplete.md
+++ b/sweetpad-docs/docs/vscode/autocomplete.md
@@ -5,12 +5,28 @@ slug: /autocomplete
 
 # Autocomplete
 
-This extension wires Xcode's build output into [SourceKit-LSP](https://github.com/swiftlang/sourcekit-lsp) so you get
+SweetPad wires Xcode's build information into [SourceKit-LSP](https://github.com/swiftlang/sourcekit-lsp) so you get
 real autocomplete, jump-to-definition, hover docs, and Swift compiler diagnostics in VSCode.
 
 ![autocomplete](/images/autocomplete-preview.png)
 
-## Setup
+SourceKit-LSP needs a **build server** to tell it how each file is compiled. SweetPad supports two:
+
+- **xcode-build-server** (the default) — a battle-tested external tool that parses Xcode build logs. Works with
+  workspaces, projects, and SPM, but needs a successful build before autocomplete comes alive.
+- **SweetPad's built-in build server** (experimental) — ships inside the extension and reads compiler arguments
+  straight from the project, so autocomplete works **without building first**. Currently limited to plain
+  `.xcodeproj` projects.
+
+:::info
+
+Swift Packages don't need any of this — SourceKit-LSP understands `Package.swift` natively. If your workspace root is
+a Swift Package, autocomplete works as soon as the [Swift extension](https://marketplace.visualstudio.com/items?itemName=swiftlang.swift-vscode)
+is installed.
+
+:::
+
+## Setup with xcode-build-server (default)
 
 1. Install the [Swift](https://marketplace.visualstudio.com/items?itemName=swiftlang.swift-vscode) extension from the
    Marketplace and [xcode-build-server](https://github.com/SolaWing/xcode-build-server) from Homebrew:
@@ -19,7 +35,7 @@ real autocomplete, jump-to-definition, hover docs, and Swift compiler diagnostic
    brew install xcode-build-server --head
    ```
 
-2. From the command palette, run **`> SweetPad: Generate Build Server Config`**. This creates a `buildServer.json` at
+2. From the command palette, run `> SweetPad: Generate Build Server Config`. This creates a `buildServer.json` at
    the workspace root that points SourceKit-LSP at your Xcode build outputs.
 
 3. Build the project once (▶️ in the Build view). Without a successful build there are no build logs for
@@ -27,7 +43,44 @@ real autocomplete, jump-to-definition, hover docs, and Swift compiler diagnostic
 
 After that, autocomplete should work. ✅
 
-## Auto-regenerate `buildServer.json`
+## Setup with the built-in build server (experimental)
+
+If your project is a plain `.xcodeproj`, you can skip installing `xcode-build-server` entirely:
+
+1. Run `> SweetPad: Set up Swift code intelligence (BSP)` from the command palette. This switches
+   `sweetpad.buildServer.provider` to `sweetpad` and writes a `buildServer.json` that launches the bundled server.
+2. Open a Swift file — SourceKit-LSP starts the server, which resolves build settings directly from the project.
+   No prior build needed.
+
+A few things to know:
+
+- The server runs on Node.js, so `node` must be on your `PATH`.
+- `.xcworkspace` and Swift Package projects aren't handled by the built-in server yet — SweetPad falls back to the
+  `xcode-build-server` flow for those.
+- The `buildServer.json` it writes points at a file inside the installed extension. After an extension update that
+  path can go stale — if autocomplete stops working, re-run `> SweetPad: Generate Build Server Config`.
+
+To switch back, set the provider in your settings:
+
+```json title=".vscode/settings.json"
+{
+  "sweetpad.buildServer.provider": "xcode-build-server"
+}
+```
+
+## When autocomplete doesn't work
+
+Run `> SweetPad: Diagnose BSP (Doctor)` from the command palette. It checks the whole chain for your active
+provider — `buildServer.json` is present and valid, the build-server tool (or Node.js) is available, a scheme is
+selected, the Xcode developer directory resolves — and prints a ✓/✗ report with a fix hint for each failure in the
+**SweetPad: BSP** output channel.
+
+To watch what the build server is doing, run `> SweetPad: Show BSP logs`. With the built-in server this opens a
+live log stream; tune its verbosity with `sweetpad.buildServer.logLevel` (`off`, `error`, `info`, or `debug` —
+`debug` includes the raw JSON-RPC traffic). With `xcode-build-server`, logging goes to a file instead — set
+`XBS_LOGPATH` via `sweetpad.xcodebuildserver.serverEnv` (see below).
+
+## Auto-regenerate buildServer.json
 
 By default SweetPad regenerates `buildServer.json` whenever you build or change the default scheme — handy if you
 switch between schemes frequently. If you maintain a custom `buildServer.json` (e.g. backed by Swift Build, or a
@@ -58,7 +111,7 @@ may want to silence SweetPad's pass to avoid duplicate squiggles:
 - `> SweetPad: Disable LSP Diagnostics` — turns the live diagnostic stream off for this workspace.
 - `> SweetPad: Enable LSP Diagnostics` — turns it back on.
 
-## Use a custom `xcode-build-server`
+## Use a custom xcode-build-server
 
 If you've installed `xcode-build-server` somewhere outside `PATH`, or you're using a fork, point SweetPad at the
 binary you want:

--- a/sweetpad-docs/docs/vscode/build.md
+++ b/sweetpad-docs/docs/vscode/build.md
@@ -176,7 +176,7 @@ override the path:
 }
 ```
 
-## Pass extra arguments to `xcodebuild`
+## Pass extra arguments to xcodebuild
 
 Pass any extra `xcodebuild` flags through `sweetpad.build.args`. For example, to skip Swift macro validation:
 
@@ -200,7 +200,7 @@ This is useful for forwarding tokens or paths that your project's build scripts 
 
 Set a value to `null` to explicitly unset an inherited variable.
 
-## Use a different `xcodebuild` (e.g. Xcode-beta)
+## Use a different xcodebuild (e.g. Xcode-beta)
 
 If you need a non-default `xcodebuild` — to build against Xcode-beta, to pin a specific toolchain, or to wrap
 `xcodebuild` with a logger — point SweetPad at the binary you want:

--- a/sweetpad-docs/docs/vscode/build.md
+++ b/sweetpad-docs/docs/vscode/build.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 5
+sidebar_position: 2
+slug: /build
 ---
 
 # Build & Run

--- a/sweetpad-docs/docs/vscode/commands.md
+++ b/sweetpad-docs/docs/vscode/commands.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 17
+slug: /commands
+sidebar_label: Commands reference
+---
+
+# Commands reference
+
+Everything SweetPad can do is exposed as a command. Open the command palette (`⌘⇧P`), type "sweetpad",
+and every command below shows up. Most are also reachable from the sidebar — buttons and right-click
+menus in the Build, Destinations, and Tools views run the same commands.
+
+:::tip
+
+To put a command on a keyboard shortcut, open **Keyboard Shortcuts** (`⌘K ⌘S`) and search for
+"sweetpad" — every command here can be bound to a key.
+
+:::
+
+## Build and run
+
+| Command                                    | What it does                                                                 |
+| ------------------------------------------- | ----------------------------------------------------------------------------- |
+| SweetPad: Build & Run (Launch)              | Build the active scheme and launch it on the active destination.             |
+| SweetPad: Build (without Run)               | Build only.                                                                   |
+| SweetPad: Run (without Build)               | Launch the already-built app without rebuilding.                              |
+| SweetPad: Test                              | Run the scheme's tests.                                                       |
+| SweetPad: Clean                             | Clean the build folder and derived data.                                      |
+| SweetPad: Stop build / running app          | Kill the running build or launched app and free the terminal.                 |
+| SweetPad: Resolve dependencies              | Resolve Swift Package Manager dependencies.                                   |
+| SweetPad: Remove bundle directory           | Delete SweetPad's intermediate app-bundle directory.                          |
+| SweetPad: Set scheme                        | Pick the scheme used for builds.                                              |
+| SweetPad: Select build configuration        | Pick the configuration (Debug/Release/…).                                     |
+| SweetPad: Select Xcode workspace            | Pick which workspace or project SweetPad builds, and save it to settings.     |
+| SweetPad: Refresh schemes                   | Re-read the scheme list from the project.                                     |
+| SweetPad: Search schemes (Build view)       | Filter the Build view by name.                                                |
+| SweetPad: Apply scheme filter (Build view)  | Re-apply the scheme include/exclude filter from settings.                     |
+| SweetPad: Pause scheme filter (Build view)  | Temporarily show all schemes, ignoring the filter.                            |
+| SweetPad: Diagnose build setup              | Walk the workspace-detection logic and print what was (or wasn't) found.      |
+| SweetPad: Switch Git Worktree               | Point the build at another [git worktree](./worktree.md) of the same repo.    |
+| SweetPad: Open Xcode                        | Open the current project in Xcode.                                            |
+
+## Autocomplete and code intelligence
+
+| Command                                            | What it does                                                        |
+| --------------------------------------------------- | --------------------------------------------------------------------- |
+| SweetPad: Generate Build Server Config (buildServer.json) | Write `buildServer.json` for SourceKit-LSP and restart the LSP. |
+| SweetPad: Set up Swift code intelligence (BSP)      | Switch to the built-in build server and write its config.            |
+| SweetPad: Diagnose BSP (Doctor)                     | Check the autocomplete chain and print a ✓/✗ report with fix hints.   |
+| SweetPad: Show BSP logs                             | Open the build server's log stream (built-in provider).              |
+| SweetPad: Enable LSP Diagnostics                    | Turn build-log squiggles in the editor back on.                       |
+| SweetPad: Disable LSP Diagnostics                   | Turn build-log squiggles off (e.g. to avoid duplicates).              |
+
+## Testing
+
+| Command                                                       | What it does                                          |
+| -------------------------------------------------------------- | ------------------------------------------------------- |
+| SweetPad.Testing: Set scheme for testing                        | Pick the scheme used when running tests.               |
+| SweetPad.Testing: Select testing target                         | Pick the test target when a project has several.       |
+| SweetPad.Testing: Select configuration for testing              | Pick the configuration used for test builds.           |
+| SweetPad.Testing: Select destination for testing                | Pick a separate destination just for tests.            |
+| SweetPad.Testing: Build for testing (without running tests)     | Compile the test bundle only.                          |
+| SweetPad.Testing: Test without building                         | Run already-built tests without recompiling.           |
+
+## Destinations, simulators, and devices
+
+| Command                                | What it does                                                        |
+| --------------------------------------- | --------------------------------------------------------------------- |
+| SweetPad: Select destination            | Pick where the app runs — simulator, device, or macOS.               |
+| SweetPad: Search destinations (Destinations view) | Filter the Destinations view by name.                       |
+| SweetPad: Remove recent destination     | Drop an entry from the Recent group.                                 |
+| SweetPad: Start simulator               | Boot a simulator.                                                     |
+| SweetPad: Stop simulator                | Shut a simulator down.                                                |
+| SweetPad: Open simulator                | Open the Simulator.app window.                                        |
+| SweetPad: Remove simulator cache        | Clear the simulator cache (fixes some boot failures).                 |
+| SweetPad: Refresh simulators list       | Re-read installed simulators.                                         |
+| SweetPad: Refresh devices list          | Re-scan for connected devices.                                        |
+| SweetPad: Install pymobiledevice3       | Install the tool used for device log streaming and the iOS 17+ tunnel. |
+
+## Formatting
+
+| Command                     | What it does                                       |
+| ---------------------------- | ---------------------------------------------------- |
+| SweetPad: Format             | Format the current file.                             |
+| SweetPad: Show format logs   | Open the formatter's output channel.                 |
+
+## Tuist and XcodeGen
+
+| Command                                                  | What it does                                    |
+| --------------------------------------------------------- | ------------------------------------------------- |
+| SweetPad: Generate an Xcode project using Tuist            | Run Tuist generate at the workspace root.        |
+| SweetPad: Install Swift Package using Tuist                | Run Tuist install.                               |
+| SweetPad: Clean Tuist project                              | Remove Tuist's generated files.                  |
+| SweetPad: Edit Tuist project (Open project in Xcode)       | Open the Tuist manifests in Xcode.               |
+| SweetPad: Test Generated project using Tuist               | Run Tuist test across every target.              |
+| SweetPad: Generate an Xcode project using XcodeGen         | Run XcodeGen generate at the workspace root.     |
+
+## Debugging
+
+These back the `sweetpad-lldb` debug configuration — you rarely run them by hand. See
+[Debugging](./debug.md).
+
+| Command                              | What it does                                                       |
+| ------------------------------------- | -------------------------------------------------------------------- |
+| SweetPad: Build & Run (for debugging) | Build and launch, signalling the debugger when the app is ready.    |
+| SweetPad: Build (for debugging)       | Build only, as a debug pre-launch step.                             |
+| SweetPad: Run (for debugging)         | Launch without building, as a debug pre-launch step.                |
+| SweetPad: Get app path for debugging  | Resolve the last-built app's path (used as a launch.json variable). |
+
+## Tools
+
+| Command                            | What it does                                             |
+| ----------------------------------- | ---------------------------------------------------------- |
+| SweetPad: Install tool              | Install one of the integrated tools via Homebrew.         |
+| SweetPad: Open tool documentation   | Open a tool's docs in the browser.                        |
+| SweetPad: Refresh tools list        | Re-check which tools are installed.                       |
+
+## Agent CLI
+
+See [Agent CLI & RPC server](../cli/agent-cli.md).
+
+| Command                             | What it does                                    |
+| ------------------------------------ | ------------------------------------------------- |
+| SweetPad: Show RPC server status     | Print the server name, socket path, and process info. |
+| SweetPad: Copy RPC server name       | Copy the server name to the clipboard.           |
+| SweetPad: Restart RPC server         | Restart the server after settings changes or a stuck state. |
+
+## Housekeeping and troubleshooting
+
+See [Troubleshooting](./troubleshooting.md).
+
+| Command                                        | What it does                                                    |
+| ----------------------------------------------- | ----------------------------------------------------------------- |
+| SweetPad: Reset Extension Cache                 | Forget remembered choices (workspace, scheme, destination, …).   |
+| SweetPad: Refresh shell environment             | Re-read `PATH` and friends from your login shell.                |
+| SweetPad: Open Terminal Panel                   | Reveal SweetPad's terminal panel.                                |
+| SweetPad: Create Issue on GitHub                | Open a pre-filled bug report.                                    |
+| SweetPad: Create Issue on GitHub (No Schemes)   | Open a bug report pre-filled with scheme-detection diagnostics.  |
+| SweetPad: Test Error Reporting                  | Fire a test error to verify Sentry reporting is wired up.        |

--- a/sweetpad-docs/docs/vscode/debug.md
+++ b/sweetpad-docs/docs/vscode/debug.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 6
+sidebar_position: 3
+slug: /debug
 ---
 
 # Debugging

--- a/sweetpad-docs/docs/vscode/debug.md
+++ b/sweetpad-docs/docs/vscode/debug.md
@@ -58,7 +58,7 @@ extension — powered by [LLDB](https://lldb.llvm.org/) — so you can debug you
 
    ![Breakpoints](/images/debug-breakpoints.png)
 
-## Customize `preLaunchTask`
+## Customize preLaunchTask
 
 If you need more control, you can point the `preLaunchTask` property to a custom task defined in `.vscode/tasks.json`.  
 For example, the task below builds the app with the **Release** scheme before launching the debugger:
@@ -132,7 +132,7 @@ generally work out of the box, but there are some differences compared to the si
 On iOS 17+ the device launch goes through a developer tunnel managed by `pymobiledevice3`; see
 [Devices → iOS 17+: the developer tunnel](./devices.md#ios-17-the-developer-tunnel) for the one-time setup.
 
-### Merging `codelldbAttributes`
+### Merging codelldbAttributes
 
 When attaching to an app running **on a physical device**, SweetPad injects its own LLDB commands into
 `initCommands`, `preRunCommands`, and `processCreateCommands`. If you supply your own commands through
@@ -148,9 +148,8 @@ When attaching to an app running **on a physical device**, SweetPad injects its 
 }
 ```
 
-For the exact commands SweetPad injects, see
-[resolveDeviceDebugConfiguration](https://github.com/sweetpad-dev/sweetpad/blob/main/src/debugger/provider.ts) in the
-extension source.
+SweetPad's injected commands take care of connecting to the device and finding the remote process. Your commands run
+first, so anything you set up (logging, breakpoint behavior) is in place before SweetPad's connection steps run.
 
 ### Stop on attach
 

--- a/sweetpad-docs/docs/vscode/destinations.md
+++ b/sweetpad-docs/docs/vscode/destinations.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
+slug: /destinations
 ---
 
 # Destinations

--- a/sweetpad-docs/docs/vscode/devices.md
+++ b/sweetpad-docs/docs/vscode/devices.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 8
+sidebar_position: 11
+slug: /devices
 ---
 
 # iOS Devices

--- a/sweetpad-docs/docs/vscode/devices.md
+++ b/sweetpad-docs/docs/vscode/devices.md
@@ -48,7 +48,7 @@ Pairing only needs to happen once per device/Mac combination:
 4. Back in VSCode, click ↻ on the Destinations panel or run `> SweetPad: Refresh devices list` to pick up the new
    device.
 
-## Stream `os_log` and `print` output from the device
+## Stream os_log and print output from the device
 
 By default, when you launch an app on a physical device, SweetPad streams the device's syslog into the build terminal
 and filters it down to your app — `os_log`, `Logger`, `print`, and `NSLog` output all surface there, alongside the
@@ -103,7 +103,7 @@ which only runs for simulators and macOS. See
 
 :::
 
-### Pass extra args to `pymobiledevice3`
+### Pass extra args to pymobiledevice3
 
 If you need flags that aren't covered above, append them with:
 
@@ -113,7 +113,7 @@ If you need flags that aren't covered above, append them with:
 }
 ```
 
-### Use a non-default `pymobiledevice3`
+### Use a non-default pymobiledevice3
 
 If the binary isn't on `PATH`, point at it explicitly:
 

--- a/sweetpad-docs/docs/vscode/format.md
+++ b/sweetpad-docs/docs/vscode/format.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 11
+sidebar_position: 6
+slug: /format
 ---
 
 # Format code

--- a/sweetpad-docs/docs/vscode/getting-started-vscode.md
+++ b/sweetpad-docs/docs/vscode/getting-started-vscode.md
@@ -1,5 +1,7 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
+slug: /getting-started-vscode
+sidebar_label: Get started
 ---
 
 import ReactPlayer from 'react-player'
@@ -59,7 +61,7 @@ That's it — you just built and ran an Xcode app from VSCode. 🎉
 - [Configure format on save](./format.md) so your Swift files tidy themselves up as you save.
 - Install `xcbeautify` from the [Tools](./tools.md) panel for cleaner build logs.
 - Set up [debugging](./debug.md) with breakpoints.
-- Browse the full [feature list](./intro.md#what-you-get).
+- Browse the full [feature list](../intro.md#what-you-get).
 
 ## Demo
 

--- a/sweetpad-docs/docs/vscode/hot-reload.md
+++ b/sweetpad-docs/docs/vscode/hot-reload.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 6.5
+sidebar_position: 4
+slug: /hot-reload
 ---
 
 # Hot reload

--- a/sweetpad-docs/docs/vscode/settings.md
+++ b/sweetpad-docs/docs/vscode/settings.md
@@ -1,0 +1,129 @@
+---
+sidebar_position: 16
+slug: /settings
+sidebar_label: Settings reference
+---
+
+# Settings reference
+
+Every setting the SweetPad extension reads, in one place. Put them in `.vscode/settings.json` to keep
+them per-project (recommended — most of these describe the project, not you), or in your user settings
+to apply them everywhere.
+
+Each table lists the setting key, its default, and what it does. Settings that deserve a longer story
+link to the page that tells it.
+
+## Build
+
+Covered in depth in [Build & Run](./build.md).
+
+| Setting                                  | Default | What it does                                                                                                       |
+| ---------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| `sweetpad.build.xcodeWorkspacePath`      | —       | Path to the workspace or project to build, absolute or relative to the VSCode folder. Unset = auto-detect (asks if several are found). |
+| `sweetpad.build.configuration`           | —       | Build configuration to use (e.g. `Debug`, `Release`). Unset = asks and remembers.                                  |
+| `sweetpad.build.args`                    | `[]`    | Extra arguments appended to every `xcodebuild` invocation.                                                          |
+| `sweetpad.build.env`                     | `{}`    | Environment variables for the `xcodebuild` process itself. `${env:VAR}` expands; `null` unsets an inherited value. |
+| `sweetpad.build.launchArgs`              | `[]`    | Arguments passed to your app when it launches.                                                                      |
+| `sweetpad.build.launchEnv`               | `{}`    | Environment variables passed to your app when it launches.                                                          |
+| `sweetpad.build.derivedDataPath`         | —       | Custom DerivedData location, absolute or relative to the VSCode folder.                                             |
+| `sweetpad.build.xcodebuildCommand`       | —       | Alternative `xcodebuild` binary — e.g. Xcode-beta's copy. `${env:VAR}` expands.                                     |
+| `sweetpad.build.swiftCommand`            | —       | Alternative `swift` binary, for Swift Package builds. `${env:VAR}` expands.                                          |
+| `sweetpad.build.arch`                    | —       | Force an architecture (`arm64` or `x86_64`). Useful for Rosetta builds on Apple Silicon.                             |
+| `sweetpad.build.rosettaDestination`      | `false` | Prefer the Rosetta variant of the target simulator.                                                                  |
+| `sweetpad.build.allowProvisioningUpdates`| `true`  | Let Xcode refresh provisioning profiles during the build.                                                            |
+| `sweetpad.build.xcbeautifyEnabled`       | `true`  | Pipe build logs through `xcbeautify` when it's installed.                                                            |
+| `sweetpad.build.bringSimulatorToForeground` | `true` | Bring the Simulator window to the front when launching the app. Turn off to stay in VSCode.                        |
+| `sweetpad.build.schemes.include`         | `[]`    | Only show schemes matching these patterns in the Build view (`*` wildcard). Empty = show all.                       |
+| `sweetpad.build.schemes.exclude`         | `[]`    | Hide schemes matching these patterns, applied after `include`.                                                      |
+| `sweetpad.build.autoRefreshSchemes`      | `true`  | Re-read the scheme list when project files change (`Package.swift`, `.xcodeproj`, `.xcworkspace`).                  |
+| `sweetpad.build.autoRefreshSchemesDelay` | `500`   | Milliseconds to wait after a file change before refreshing schemes.                                                 |
+
+## App logs
+
+How log streaming works — and which settings apply to which destination — is covered in
+[Simulators](./simulators.md#logs-from-the-simulator) and [Devices](./devices.md#stream-os_log-and-print-output-from-the-device).
+
+| Setting                                             | Default         | What it does                                                                             |
+| ---------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------------- |
+| `sweetpad.build.logStreamEnabled`                    | `true`          | Stream your app's logs into the build terminal on launch.                                 |
+| `sweetpad.build.logStreamPredicate`                  | —               | Custom predicate for Apple's log tool (simulators and macOS only). `${bundleId}` and `${processName}` are substituted. |
+| `sweetpad.build.pymobiledevice3Path`                 | `pymobiledevice3` | Binary used to stream logs from physical devices. Leave as-is to resolve via `PATH`.     |
+| `sweetpad.build.pymobiledevice3ExtraArgs`            | `[]`            | Extra arguments appended to the device log stream command.                                |
+| `sweetpad.build.pymobiledevice3SubsystemAllowList`   | `[]`            | When non-empty, keep only device log entries whose subsystem matches (e.g. `com.myapp.*`). |
+| `sweetpad.build.pymobiledevice3SubsystemDenyList`    | `["com.apple.*"]` | Drop device log entries whose subsystem matches.                                        |
+| `sweetpad.build.deviceTunnelAutoStart`               | `false`         | Auto-start the iOS 17+ developer tunnel (needs sudo) before launching on a device.        |
+
+## Autocomplete and code intelligence
+
+Covered in depth in [Autocomplete](./autocomplete.md).
+
+| Setting                                        | Default              | What it does                                                                              |
+| ----------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------ |
+| `sweetpad.buildServer.provider`                 | `xcode-build-server` | Which build server backs SourceKit-LSP: `xcode-build-server` (parses build logs) or `sweetpad` (built-in, experimental, no build needed). |
+| `sweetpad.buildServer.logLevel`                 | `info`               | Verbosity of the built-in server's live log stream (`off`, `error`, `info`, `debug`). The log file always captures everything. |
+| `sweetpad.buildServer.logPath`                  | —                    | Custom location for the built-in server's log file. Relative paths and `${workspaceFolder}` resolve against the workspace. |
+| `sweetpad.build.autoGenerateBuildServerConfig`  | `true`               | Regenerate `buildServer.json` on build and scheme change. Turn off if you maintain your own file. |
+| `sweetpad.build.autoRestartSwiftLSP`            | `true`               | Restart the Swift language server after builds and project regeneration.                   |
+| `sweetpad.xcodebuildserver.autogenerate`        | `true`               | Regenerate the build server config when the default scheme changes.                        |
+| `sweetpad.xcodebuildserver.path`                | —                    | Custom `xcode-build-server` binary, if it's not on `PATH`.                                  |
+| `sweetpad.xcodebuildserver.serverEnv`           | `{}`                 | Environment variables for the long-running xcode-build-server process (e.g. `XBS_LOGPATH`). |
+
+## Testing
+
+Covered in depth in [Tests](./tests.md).
+
+| Setting                          | Default | What it does                                              |
+| --------------------------------- | ------- | ----------------------------------------------------------- |
+| `sweetpad.testing.configuration`  | —       | Build configuration used when running tests (e.g. `Testing`). Unset = same flow as building. |
+
+## Formatting
+
+Covered in depth in [Format code](./format.md).
+
+| Setting                          | Default | What it does                                                                                             |
+| --------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `sweetpad.format.path`            | Xcode's bundled swift-format | Formatter executable — a command on `PATH` or an absolute path.                             |
+| `sweetpad.format.args`            | —       | Arguments for the formatter. `${file}` is replaced with the file path (as its own array item).             |
+| `sweetpad.format.selectionArgs`   | —       | Arguments for format-selection. Placeholders: `${file}`, `${startLine}`, `${endLine}`, `${startOffset}`, `${endOffset}`. Unset = whole file is formatted. |
+
+## Hot reload
+
+Covered in depth in [Hot reload](./hot-reload.md).
+
+| Setting                        | Default | What it does                                                                    |
+| ------------------------------- | ------- | --------------------------------------------------------------------------------- |
+| `sweetpad.hotReload.enabled`    | `false` | Launch simulator/macOS builds with InjectionNext wired up so saves reload live.  |
+| `sweetpad.hotReload.dylibPath`  | —       | Override the injection dylib path when InjectionNext isn't in `/Applications/`.   |
+
+## Project generators
+
+Covered in depth in [Tuist](./tuist.md) and [XcodeGen](./xcodegen.md).
+
+| Setting                        | Default | What it does                                                                     |
+| ------------------------------- | ------- | ---------------------------------------------------------------------------------- |
+| `sweetpad.tuist.autogenerate`   | `false` | Re-run Tuist generate when Swift files are added or removed. Restart VSCode to apply. |
+| `sweetpad.tuist.generate.env`   | `{}`    | Environment variables for every Tuist generate run (dynamic configuration).       |
+| `sweetpad.xcodegen.autogenerate`| `false` | Re-run XcodeGen when Swift files are added or removed. Restart VSCode to apply.    |
+
+## Agent CLI
+
+Covered in depth in [Agent CLI & RPC server](../cli/agent-cli.md).
+
+| Setting                      | Default | What it does                                                                        |
+| ----------------------------- | ------- | ------------------------------------------------------------------------------------- |
+| `sweetpad.cliServer.enabled`  | `false` | Run the JSON-RPC server so the `sweetpad vscode` CLI (and AI agents) can drive this window. |
+
+## System
+
+Most of these matter when something misbehaves — see [Troubleshooting](./troubleshooting.md).
+
+| Setting                                | Default | What it does                                                                             |
+| --------------------------------------- | ------- | ------------------------------------------------------------------------------------------ |
+| `sweetpad.system.logLevel`              | `info`  | Extension log verbosity (`debug`, `info`, `warn`, `error`). Restart VSCode to apply.       |
+| `sweetpad.system.taskExecutor`          | `v3`    | How tasks run: `v3` uses a real pseudoterminal (colors, TUI support); `v2` uses plain pipes. |
+| `sweetpad.system.autoRevealTerminal`    | `true`  | Bring the terminal panel forward when a command or task starts.                             |
+| `sweetpad.system.showProgressStatusBar` | `true`  | Show task progress in the status bar.                                                       |
+| `sweetpad.system.xcodebuildFallback`    | `false` | If the bundled build-settings resolver fails, retry via `xcodebuild -showBuildSettings` (slower, but survives exotic projects). |
+| `sweetpad.system.enableSentry`          | `false` | Send error reports to the maintainers. Off by default; reports may include project details. |
+| `sweetpad.shellEnv.shell`               | `$SHELL` | Shell used to resolve your login environment (`PATH` etc.).                                |
+| `sweetpad.shellEnv.timeout`             | `5000`  | Milliseconds to wait for the login shell to dump its environment.                           |

--- a/sweetpad-docs/docs/vscode/simulators.md
+++ b/sweetpad-docs/docs/vscode/simulators.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+slug: /simulators
 ---
 
 import ReactPlayer from 'react-player'

--- a/sweetpad-docs/docs/vscode/tests.md
+++ b/sweetpad-docs/docs/vscode/tests.md
@@ -79,7 +79,7 @@ without needing a scheme selection:
 
 See [Tuist](./tuist.md) for the rest of the Tuist integration.
 
-## Tasks for `tasks.json`
+## Tasks for tasks.json
 
 You can wire SweetPad's test action into VSCode tasks:
 

--- a/sweetpad-docs/docs/vscode/tests.md
+++ b/sweetpad-docs/docs/vscode/tests.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 12
+sidebar_position: 5
+slug: /tests
 ---
 
 # Tests

--- a/sweetpad-docs/docs/vscode/tools.md
+++ b/sweetpad-docs/docs/vscode/tools.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 13
+sidebar_position: 12
+slug: /tools
 ---
 
 # Tools

--- a/sweetpad-docs/docs/vscode/tools.md
+++ b/sweetpad-docs/docs/vscode/tools.md
@@ -16,7 +16,8 @@ The tools listed in the panel:
 - [**Homebrew**](https://brew.sh/) — package manager used to install most of the others.
 - [**swift-format**](https://github.com/apple/swift-format) — the default Swift formatter. Xcode 16+ ships it
   bundled; older Xcodes need a Homebrew install. See [Format code](./format.md).
-- [**XcodeGen**](https://github.com/yonaskolb/XcodeGen) — generates `.xcodeproj` from a YAML manifest.
+- [**XcodeGen**](https://github.com/yonaskolb/XcodeGen) — generates `.xcodeproj` from a YAML manifest. SweetPad has
+  deeper integration here; see [XcodeGen](./xcodegen.md).
 - [**SwiftLint**](https://github.com/realm/SwiftLint) — Swift linter.
 - [**xcbeautify**](https://github.com/cpisciotta/xcbeautify) — formats `xcodebuild` output into something readable.
 - [**xcode-build-server**](https://github.com/SolaWing/xcode-build-server) — exposes Xcode's build outputs to

--- a/sweetpad-docs/docs/vscode/troubleshooting.md
+++ b/sweetpad-docs/docs/vscode/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 15
+sidebar_position: 18
+slug: /troubleshooting
 ---
 
 # Troubleshooting

--- a/sweetpad-docs/docs/vscode/tuist.md
+++ b/sweetpad-docs/docs/vscode/tuist.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 14
+sidebar_position: 13
+slug: /tuist
 ---
 
 # Tuist

--- a/sweetpad-docs/docs/vscode/tuist.md
+++ b/sweetpad-docs/docs/vscode/tuist.md
@@ -17,7 +17,7 @@ SweetPad surfaces the most common Tuist commands directly in the VSCode command 
 - **SweetPad: Test Generated project using Tuist** — runs `tuist test`, building and testing every target Tuist
   knows about. Useful as a one-shot "did I break anything" check without picking a scheme.
 
-## Auto-regenerate on `.swift` file changes
+## Auto-regenerate on .swift file changes
 
 If you frequently add or remove `.swift` files, let SweetPad re-run `tuist generate` automatically when those files
 change so new files show up in the project without a manual regeneration:

--- a/sweetpad-docs/docs/vscode/watchos-simulators.md
+++ b/sweetpad-docs/docs/vscode/watchos-simulators.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 10
+slug: /watchos-simulators
 ---
 
 # watchOS Simulators

--- a/sweetpad-docs/docs/vscode/worktree.md
+++ b/sweetpad-docs/docs/vscode/worktree.md
@@ -1,5 +1,6 @@
 ---
-sidebar_position: 16
+sidebar_position: 15
+slug: /worktree
 ---
 
 # Git Worktrees

--- a/sweetpad-docs/docs/vscode/xcodegen.md
+++ b/sweetpad-docs/docs/vscode/xcodegen.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 14
+slug: /xcodegen
+---
+
+# XcodeGen
+
+[XcodeGen](https://github.com/yonaskolb/XcodeGen) generates your `.xcodeproj` from a YAML manifest
+(`project.yml`), so the project file never has to be edited — or merged — by hand. SweetPad works with
+XcodeGen projects out of the box: generate the project, and the schemes show up in the Build view like
+any other.
+
+Install XcodeGen from the [Tools](./tools.md) panel in the SweetPad sidebar, or with Homebrew:
+
+```bash
+brew install xcodegen
+```
+
+## Generate the project
+
+Run `> SweetPad: Generate an Xcode project using XcodeGen` from the command palette. SweetPad runs
+`xcodegen generate` at the workspace root and refreshes the scheme list when it finishes.
+
+## Auto-regenerate when Swift files change
+
+XcodeGen projects list their source files in the generated project, so every added or deleted `.swift`
+file needs a regeneration. Let SweetPad do that automatically:
+
+```json title=".vscode/settings.json"
+{
+  "sweetpad.xcodegen.autogenerate": true
+}
+```
+
+Then restart VSCode to apply the change. SweetPad watches for new or removed Swift files and re-runs
+`xcodegen generate` in the background, so the project stays in sync while you work. The watcher only
+activates when a `project.yml` exists at the workspace root.
+
+:::tip
+
+Prefer [Tuist](./tuist.md)? SweetPad has the same integration for it — including the matching
+`sweetpad.tuist.autogenerate` setting.
+
+:::


### PR DESCRIPTION
Move the flat 18-page list into three groups — Introduction plus the two
quickstarts at the top, then a 'VS Code extension' category and a
'SweetPad CLI' category. Every page keeps its old URL via an explicit
slug, so existing links (including the landing-page cards) still work.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018vNJ1jW4wn5yaGx3Byo6Xp