### PR TITLE
Add settings to pin build scheme and destination

### DIFF
--- a/sweetpad-docs/docs/vscode/build.md
+++ b/sweetpad-docs/docs/vscode/build.md
@@ -157,6 +157,37 @@ If your project contains only one workspace, SweetPad finds it automatically —
 
 :::
 
+## Set the scheme and destination
+
+Pin the scheme and run destination the same way you pin the workspace path — useful for agents, CI-like local
+workflows, or skipping the QuickPick every time:
+
+```json title=".vscode/settings.json"
+{
+  "sweetpad.build.scheme": "MyApp",
+  "sweetpad.build.destination": {
+    "type": "iOSSimulator",
+    "id": "iossimulator-AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+    "name": "iPhone 16"
+  }
+}
+```
+
+- `scheme` — exact scheme name from the Xcode project.
+- `destination` — `{ id, type, name }`. Ids look like `iossimulator-<udid>` or `iosdevice-<udid>`; `type` is one of
+  `iOSSimulator`, `iOSDevice`, `macOS`, and the other platform variants. Use
+  `> SweetPad: Select destination` (or click a destination in the sidebar) and choose to save it to settings to fill
+  this in without copying ids by hand.
+
+Unset = SweetPad asks the first time and remembers the choice in its cache. Settings always win over that cache.
+
+:::note
+
+Simulator UDIDs change if you delete and recreate the simulator. Device UDIDs and `macOS` are stable. If a pinned
+destination disappears, SweetPad asks again and can refresh the setting with your new pick.
+
+:::
+
 ## Set DerivedData path
 
 `xcodebuild` writes its intermediate files into `~/Library/Developer/Xcode/DerivedData/` by default. If you'd rather

--- a/sweetpad-docs/docs/vscode/build.md
+++ b/sweetpad-docs/docs/vscode/build.md
@@ -167,24 +167,59 @@ workflows, or skipping the QuickPick every time:
   "sweetpad.build.scheme": "MyApp",
   "sweetpad.build.destination": {
     "type": "iOSSimulator",
-    "id": "iossimulator-AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
-    "name": "iPhone 16"
+    "id": "iossimulator-AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
   }
 }
 ```
 
-- `scheme` — exact scheme name from the Xcode project.
-- `destination` — `{ id, type, name }`. Ids look like `iossimulator-<udid>` or `iosdevice-<udid>`; `type` is one of
-  `iOSSimulator`, `iOSDevice`, `macOS`, and the other platform variants. Use
-  `> SweetPad: Select destination` (or click a destination in the sidebar) and choose to save it to settings to fill
-  this in without copying ids by hand.
+- `scheme` — exact scheme name from the Xcode project. A name the project doesn't have gets a warning, and builds
+  fail until you fix or remove the setting.
+- `destination` — `id` and `type` are required. Easiest is `> SweetPad: Select destination` (or click a destination in
+  the sidebar) and choose to save it to settings. To write it by hand, paste the plain UDID from `xcrun simctl list`
+  or Xcode's device list — `type` already says what kind of thing it is:
 
-Unset = SweetPad asks the first time and remembers the choice in its cache. Settings always win over that cache.
+```json title=".vscode/settings.json"
+{
+  "sweetpad.build.destination": {
+    "type": "iOSSimulator",
+    "id": "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+  }
+}
+```
+
+The setting holds identity only — no display name. SweetPad resolves the label from the destination itself, so once
+it has listed destinations the status bar reads "iPhone 16" rather than a UDID, and follows along if you rename the
+simulator. Until then it shows the id you wrote.
+
+The picker writes a fully qualified id instead, which is also accepted. Those ids carry a prefix per platform, and it
+doesn't always match the `type` spelling:
+
+| `type`              | `id`                       |
+| ------------------- | -------------------------- |
+| `iOSSimulator`      | `iossimulator-<udid>`      |
+| `watchOSSimulator`  | `watchossimulator-<udid>`  |
+| `tvOSSimulator`     | `tvossimulator-<udid>`     |
+| `visionOSSimulator` | `visionsimulator-<udid>`   |
+| `iOSDevice`         | `iosdevice-<udid>`         |
+| `watchOSDevice`     | `watchosdevice-<udid>`     |
+| `tvOSDevice`        | `tvosdevice-<udid>`        |
+| `visionOSDevice`    | `visionosdevice-<udid>`    |
+| `macOS`             | `macos-<computer name>`    |
+
+Note the two that break the pattern: `visionOSSimulator` drops the `os`, and `macOS` uses your computer's name
+instead of a UDID — which is why pasting the bare value and letting `type` supply the prefix is the safer habit. An
+id SweetPad doesn't recognise isn't reported as an error; it just falls through to the picker on every build.
+
+Unset = SweetPad asks the first time and remembers the choice in its cache. Settings always win over that cache — so
+`> SweetPad: Reset Extension Cache` clears the cache but leaves a pinned setting deciding the answer.
 
 :::note
 
-Simulator UDIDs change if you delete and recreate the simulator. Device UDIDs and `macOS` are stable. If a pinned
-destination disappears, SweetPad asks again and can refresh the setting with your new pick.
+`sweetpad.build.destination` is machine-specific. Simulator UDIDs differ on every Mac and change when you delete and
+recreate a simulator, and the `macOS` id contains your computer's name. When the pinned destination isn't there,
+SweetPad asks you to pick again and rewrites the setting with your choice rather than re-prompting on every build —
+which means a committed `.vscode/settings.json` shows up as a local edit on each machine. For a shared project, pin
+the scheme and leave the destination to each developer.
 
 :::
 

--- a/sweetpad-docs/docs/vscode/settings.md
+++ b/sweetpad-docs/docs/vscode/settings.md
@@ -21,6 +21,8 @@ Covered in depth in [Build & Run](./build.md).
 | ---------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
 | `sweetpad.build.xcodeWorkspacePath`      | —       | Path to the workspace or project to build, absolute or relative to the VSCode folder. Unset = auto-detect (asks if several are found). |
 | `sweetpad.build.configuration`           | —       | Build configuration to use (e.g. `Debug`, `Release`). Unset = asks and remembers.                                  |
+| `sweetpad.build.scheme`                  | —       | Scheme to build. Unset = asks and remembers.                                                                       |
+| `sweetpad.build.destination`             | —       | Destination to build and run on (`id`, `type`, `name`). Unset = asks and remembers.                              |
 | `sweetpad.build.args`                    | `[]`    | Extra arguments appended to every `xcodebuild` invocation.                                                          |
 | `sweetpad.build.env`                     | `{}`    | Environment variables for the `xcodebuild` process itself. `${env:VAR}` expands; `null` unsets an inherited value. |
 | `sweetpad.build.launchArgs`              | `[]`    | Arguments passed to your app when it launches.                                                                      |

--- a/sweetpad-docs/docs/vscode/settings.md
+++ b/sweetpad-docs/docs/vscode/settings.md
@@ -22,7 +22,7 @@ Covered in depth in [Build & Run](./build.md).
 | `sweetpad.build.xcodeWorkspacePath`      | —       | Path to the workspace or project to build, absolute or relative to the VSCode folder. Unset = auto-detect (asks if several are found). |
 | `sweetpad.build.configuration`           | —       | Build configuration to use (e.g. `Debug`, `Release`). Unset = asks and remembers.                                  |
 | `sweetpad.build.scheme`                  | —       | Scheme to build. Unset = asks and remembers.                                                                       |
-| `sweetpad.build.destination`             | —       | Destination to build and run on (`id`, `type`, `name`). Unset = asks and remembers.                              |
+| `sweetpad.build.destination`             | —       | Simulator, device, or Mac to build and run on (`id` + `type`). Unset = asks and remembers.                          |
 | `sweetpad.build.args`                    | `[]`    | Extra arguments appended to every `xcodebuild` invocation.                                                          |
 | `sweetpad.build.env`                     | `{}`    | Environment variables for the `xcodebuild` process itself. `${env:VAR}` expands; `null` unsets an inherited value. |
 | `sweetpad.build.launchArgs`              | `[]`    | Arguments passed to your app when it launches.                                                                      |

--- a/sweetpad-vscode/package.json
+++ b/sweetpad-vscode/package.json
@@ -1022,11 +1022,11 @@
         "sweetpad.build.destination": {
           "type": "object",
           "default": null,
-          "required": false,
+          "required": ["id", "type"],
           "properties": {
             "id": {
               "type": "string",
-              "description": "Destination id (e.g. iossimulator-<udid> or iosdevice-<udid>)."
+              "description": "Which simulator, device, or Mac to use. Paste the plain UDID from 'xcrun simctl list' or Xcode — the type above says what it is. A full id like 'iossimulator-<udid>' also works, and is what the picker writes. For macOS, use your computer's name."
             },
             "type": {
               "type": "string",
@@ -1041,14 +1041,10 @@
                 "tvOSDevice",
                 "visionOSDevice"
               ],
-              "description": "Destination type."
-            },
-            "name": {
-              "type": "string",
-              "description": "Display name for the destination."
+              "description": "What kind of thing the id names. Also how SweetPad expands a plain UDID into a full id."
             }
           },
-          "description": "Destination to build and run on. Unset = asks and remembers."
+          "description": "Simulator, device, or Mac to build and run on. Unset = SweetPad asks the first time and remembers your answer."
         },
         "sweetpad.build.schemes.include": {
           "type": "array",

--- a/sweetpad-vscode/package.json
+++ b/sweetpad-vscode/package.json
@@ -1014,6 +1014,42 @@
           "default": null,
           "description": "Configuration to build."
         },
+        "sweetpad.build.scheme": {
+          "type": "string",
+          "default": null,
+          "description": "Scheme to build. Unset = asks and remembers."
+        },
+        "sweetpad.build.destination": {
+          "type": "object",
+          "default": null,
+          "required": false,
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Destination id (e.g. iossimulator-<udid> or iosdevice-<udid>)."
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "iOSSimulator",
+                "watchOSSimulator",
+                "tvOSSimulator",
+                "visionOSSimulator",
+                "macOS",
+                "iOSDevice",
+                "watchOSDevice",
+                "tvOSDevice",
+                "visionOSDevice"
+              ],
+              "description": "Destination type."
+            },
+            "name": {
+              "type": "string",
+              "description": "Display name for the destination."
+            }
+          },
+          "description": "Destination to build and run on. Unset = asks and remembers."
+        },
         "sweetpad.build.schemes.include": {
           "type": "array",
           "items": {

--- a/sweetpad-vscode/src/__mocks__/vscode.ts
+++ b/sweetpad-vscode/src/__mocks__/vscode.ts
@@ -16,4 +16,7 @@ export const workspace = {
   getConfiguration: vi.fn(() => ({
     get: vi.fn(),
   })),
+  onDidChangeConfiguration: vi.fn(() => ({
+    dispose: vi.fn(),
+  })),
 };

--- a/sweetpad-vscode/src/build/commands.ts
+++ b/sweetpad-vscode/src/build/commands.ts
@@ -4,9 +4,9 @@ import * as vscode from "vscode";
 
 import { getBuildServerProvider } from "../bsp/commands";
 import { showConfigurationPicker, showYesNoQuestion } from "../common/askers";
-import { type XcodeScheme, getBuildConfigurations, getIsNodeInstalled, getIsXBSInstalled } from "../common/cli/scripts";
+import { type XcodeScheme, getBuildConfigurations, getIsNodeInstalled, getIsXBSInstalled, getSchemes } from "../common/cli/scripts";
 import { type AppDeps, warnNodeRuntimeMissing } from "../common/commands";
-import { updateWorkspaceConfig } from "../common/config";
+import { getWorkspaceConfig, updateWorkspaceConfig } from "../common/config";
 import { ExecBaseError } from "../common/errors";
 import { exec } from "../common/exec";
 import { getWorkspaceRelativePath, isFileExists, removeDirectory } from "../common/files";
@@ -293,7 +293,7 @@ export async function selectXcodeWorkspaceCommand(deps: AppDeps) {
 
 export async function selectXcodeSchemeForBuildCommand(deps: AppDeps, item?: BuildTreeItem) {
   if (item) {
-    deps.buildManager.setDefaultSchemeForBuild(item.scheme);
+    await persistSchemeForBuild(deps, item.scheme);
     return;
   }
 
@@ -304,11 +304,43 @@ export async function selectXcodeSchemeForBuildCommand(deps: AppDeps, item?: Bui
   });
 
   deps.progressStatusBar.updateText("Searching for scheme");
-  await askSchemeForBuild(deps.progressStatusBar, deps.buildManager, {
+  const schemes = await getSchemes({ xcworkspace });
+  const selected = await showQuickPick({
     title: "Select scheme to set as default",
-    xcworkspace: xcworkspace,
-    ignoreCache: true,
+    items: schemes.map((s) => ({
+      label: s.name,
+      context: s.name,
+    })),
   });
+
+  await persistSchemeForBuild(deps, selected.context, { askToSaveSettings: true });
+}
+
+/**
+ * Persist the build scheme to settings (when already configured or when the user opts in)
+ * or to workspace-state cache otherwise.
+ */
+async function persistSchemeForBuild(
+  deps: AppDeps,
+  scheme: string,
+  options?: { askToSaveSettings?: boolean },
+): Promise<void> {
+  let saveToSettings = false;
+  if (options?.askToSaveSettings) {
+    saveToSettings = await showYesNoQuestion({
+      title: "Do you want to update the scheme in the workspace settings (.vscode/settings.json)?",
+    });
+  } else if (getWorkspaceConfig("build.scheme")) {
+    // Setting already pins the scheme — keep it in sync when picking from the tree.
+    saveToSettings = true;
+  }
+
+  if (saveToSettings) {
+    await updateWorkspaceConfig("build.scheme", scheme);
+    deps.buildManager.setDefaultSchemeForBuild(undefined);
+  } else {
+    deps.buildManager.setDefaultSchemeForBuild(scheme);
+  }
 }
 
 /**

--- a/sweetpad-vscode/src/build/commands.ts
+++ b/sweetpad-vscode/src/build/commands.ts
@@ -4,7 +4,13 @@ import * as vscode from "vscode";
 
 import { getBuildServerProvider } from "../bsp/commands";
 import { showConfigurationPicker, showYesNoQuestion } from "../common/askers";
-import { type XcodeScheme, getBuildConfigurations, getIsNodeInstalled, getIsXBSInstalled, getSchemes } from "../common/cli/scripts";
+import {
+  type XcodeScheme,
+  getBuildConfigurations,
+  getIsNodeInstalled,
+  getIsXBSInstalled,
+  getSchemes,
+} from "../common/cli/scripts";
 import { type AppDeps, warnNodeRuntimeMissing } from "../common/commands";
 import { getWorkspaceConfig, updateWorkspaceConfig } from "../common/config";
 import { ExecBaseError } from "../common/errors";
@@ -293,7 +299,7 @@ export async function selectXcodeWorkspaceCommand(deps: AppDeps) {
 
 export async function selectXcodeSchemeForBuildCommand(deps: AppDeps, item?: BuildTreeItem) {
   if (item) {
-    await persistSchemeForBuild(deps, item.scheme);
+    await deps.buildManager.persistSchemeForBuild(item.scheme);
     return;
   }
 
@@ -313,33 +319,17 @@ export async function selectXcodeSchemeForBuildCommand(deps: AppDeps, item?: Bui
     })),
   });
 
-  await persistSchemeForBuild(deps, selected.context, { askToSaveSettings: true });
-}
-
-/**
- * Persist the build scheme to settings (when already configured or when the user opts in)
- * or to workspace-state cache otherwise.
- */
-async function persistSchemeForBuild(
-  deps: AppDeps,
-  scheme: string,
-  options?: { askToSaveSettings?: boolean },
-): Promise<void> {
-  let saveToSettings = false;
-  if (options?.askToSaveSettings) {
-    saveToSettings = await showYesNoQuestion({
-      title: "Do you want to update the scheme in the workspace settings (.vscode/settings.json)?",
-    });
-  } else if (getWorkspaceConfig("build.scheme")) {
-    // Setting already pins the scheme — keep it in sync when picking from the tree.
-    saveToSettings = true;
+  // Apply the pick before asking, so dismissing the prompt still selects the scheme.
+  await deps.buildManager.persistSchemeForBuild(selected.context);
+  if (getWorkspaceConfig("build.scheme")) {
+    return;
   }
 
-  if (saveToSettings) {
-    await updateWorkspaceConfig("build.scheme", scheme);
-    deps.buildManager.setDefaultSchemeForBuild(undefined);
-  } else {
-    deps.buildManager.setDefaultSchemeForBuild(scheme);
+  const pin = await showYesNoQuestion({
+    title: "Do you want to update the scheme in the workspace settings (.vscode/settings.json)?",
+  });
+  if (pin) {
+    await deps.buildManager.persistSchemeForBuild(selected.context, { pin: true });
   }
 }
 

--- a/sweetpad-vscode/src/build/manager.ts
+++ b/sweetpad-vscode/src/build/manager.ts
@@ -134,10 +134,16 @@ export class BuildManager {
   }
 
   async start(): Promise<void> {
-    this.on("defaultSchemeForBuildUpdated", (scheme: string | undefined) => {
+    this.on("defaultSchemeForBuildUpdated", () => {
       void this.generateXBSSettingsOnSchemeChange({
-        scheme: scheme,
+        scheme: this.getDefaultSchemeForBuild(),
       });
+    });
+
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration("sweetpad.build.scheme")) {
+        this.emitter.emit("defaultSchemeForBuildUpdated", this.getDefaultSchemeForBuild());
+      }
     });
   }
 
@@ -199,6 +205,10 @@ export class BuildManager {
   }
 
   getDefaultSchemeForBuild(): string | undefined {
+    const fromConfig = getWorkspaceConfig("build.scheme");
+    if (fromConfig) {
+      return fromConfig;
+    }
     return this.workspaceState.get("build.xcodeScheme");
   }
 
@@ -284,8 +294,9 @@ export class BuildManager {
     }
 
     const schemeNames = new Set(this.cache.map((scheme) => scheme.name));
-    const currentBuildScheme = this.getDefaultSchemeForBuild();
-    if (currentBuildScheme && !schemeNames.has(currentBuildScheme)) {
+    // Only clear workspace-state caches — settings are intentional and win over cache.
+    const cachedBuildScheme = this.workspaceState.get("build.xcodeScheme");
+    if (cachedBuildScheme && !schemeNames.has(cachedBuildScheme)) {
       this.setDefaultSchemeForBuild(undefined);
     }
 

--- a/sweetpad-vscode/src/build/manager.ts
+++ b/sweetpad-vscode/src/build/manager.ts
@@ -13,7 +13,7 @@ import {
   getXcodeBuildCommand,
   getXcodeVersionInstalled,
 } from "../common/cli/scripts";
-import { getWorkspaceConfig } from "../common/config";
+import { getWorkspaceConfig, onDidChangeConfiguration, updateWorkspaceConfig } from "../common/config";
 import { ExtensionError } from "../common/errors";
 import { BaseExecutionScope, type ExecutionScopeService } from "../common/execution-scope";
 import { isFileExists, readJsonFile, tempFilePath } from "../common/files";
@@ -140,7 +140,9 @@ export class BuildManager {
       });
     });
 
-    vscode.workspace.onDidChangeConfiguration((event) => {
+    // A pinned scheme outranks the cache, so editing the setting is a scheme change
+    // like any other. Views listen for this event rather than the setting itself.
+    onDidChangeConfiguration((event) => {
       if (event.affectsConfiguration("sweetpad.build.scheme")) {
         this.emitter.emit("defaultSchemeForBuildUpdated", this.getDefaultSchemeForBuild());
       }
@@ -219,6 +221,24 @@ export class BuildManager {
   setDefaultSchemeForBuild(scheme: string | undefined): void {
     this.workspaceState.update("build.xcodeScheme", scheme);
     this.emitter.emit("defaultSchemeForBuildUpdated", scheme);
+  }
+
+  /**
+   * Record a scheme pick where it will actually be read. 'sweetpad.build.scheme'
+   * outranks the workspace-state cache, so caching a pick while that setting is
+   * pinned would report success and change nothing. Pass 'pin' to move a cached
+   * pick into settings.
+   */
+  async persistSchemeForBuild(scheme: string, options?: { pin?: boolean }): Promise<void> {
+    if (!options?.pin && !getWorkspaceConfig("build.scheme")) {
+      this.setDefaultSchemeForBuild(scheme);
+      return;
+    }
+
+    await updateWorkspaceConfig("build.scheme", scheme);
+    // The setting answers for the scheme now, so drop the cached copy quietly —
+    // the configuration change already announced the new value.
+    this.workspaceState.update("build.xcodeScheme", undefined);
   }
 
   setDefaultSchemeForTesting(scheme: string | undefined): void {

--- a/sweetpad-vscode/src/build/tree.ts
+++ b/sweetpad-vscode/src/build/tree.ts
@@ -73,8 +73,8 @@ export class BuildTreeProvider implements vscode.TreeDataProvider<BuildTreeItem>
       this.updateView();
     });
 
-    this.buildManager.on("defaultSchemeForBuildUpdated", (scheme) => {
-      this.defaultSchemeForBuild = scheme;
+    this.buildManager.on("defaultSchemeForBuildUpdated", () => {
+      this.defaultSchemeForBuild = this.buildManager.getDefaultSchemeForBuild();
       this.updateView();
     });
     this.buildManager.on("defaultSchemeForTestingUpdated", (scheme) => {
@@ -93,6 +93,10 @@ export class BuildTreeProvider implements vscode.TreeDataProvider<BuildTreeItem>
         event.affectsConfiguration("sweetpad.build.schemes.exclude")
       ) {
         this.recomputeSchemeFilterPatterns();
+        this.updateView();
+      }
+      if (event.affectsConfiguration("sweetpad.build.scheme")) {
+        this.defaultSchemeForBuild = this.buildManager.getDefaultSchemeForBuild();
         this.updateView();
       }
     });

--- a/sweetpad-vscode/src/build/tree.ts
+++ b/sweetpad-vscode/src/build/tree.ts
@@ -95,10 +95,6 @@ export class BuildTreeProvider implements vscode.TreeDataProvider<BuildTreeItem>
         this.recomputeSchemeFilterPatterns();
         this.updateView();
       }
-      if (event.affectsConfiguration("sweetpad.build.scheme")) {
-        this.defaultSchemeForBuild = this.buildManager.getDefaultSchemeForBuild();
-        this.updateView();
-      }
     });
   }
 

--- a/sweetpad-vscode/src/build/utils.ts
+++ b/sweetpad-vscode/src/build/utils.ts
@@ -18,7 +18,7 @@ import {
   isXcodeBuildCommandCustomized,
   readXBSConfig,
 } from "../common/cli/scripts";
-import { getWorkspaceConfig } from "../common/config";
+import { getWorkspaceConfig, updateWorkspaceConfig } from "../common/config";
 import { ExtensionError } from "../common/errors";
 import { createDirectory, findFilesRecursive, isFileExists, readJsonFile, removeDirectory } from "../common/files";
 import { commonLogger } from "../common/logger";
@@ -100,10 +100,12 @@ export async function askDestinationToRunOn(
     mostUsedSort: true,
   });
 
-  // If we have cached desination, use it
-  const cachedDestination = destinationsManager.getSelectedXcodeDestinationForBuild();
-  if (cachedDestination) {
-    const destination = destinations.find((d) => d.id === cachedDestination.id && d.type === cachedDestination.type);
+  // Prefer settings / workspace-state cache when the destination is still available
+  const preferredDestination = destinationsManager.getSelectedXcodeDestinationForBuild();
+  if (preferredDestination) {
+    const destination = destinations.find(
+      (d) => d.id === preferredDestination.id && d.type === preferredDestination.type,
+    );
     if (destination) {
       return destination;
     }
@@ -119,10 +121,23 @@ export async function askDestinationToRunOn(
   });
   const supportedPlatforms = buildSettings?.supportedPlatforms;
 
-  return await selectDestinationForBuild(destinationsManager, {
+  const destination = await selectDestinationForBuild(destinationsManager, {
     destinations: destinations,
     supportedPlatforms: supportedPlatforms,
   });
+
+  // If a setting pinned a destination that no longer exists, refresh it with the new pick
+  // so we don't re-prompt on every build.
+  if (getWorkspaceConfig("build.destination")) {
+    await updateWorkspaceConfig("build.destination", {
+      id: destination.id,
+      type: destination.type,
+      name: destination.name,
+    });
+    destinationsManager.setWorkspaceDestinationForBuild(undefined);
+  }
+
+  return destination;
 }
 
 export async function selectDestinationForBuild(

--- a/sweetpad-vscode/src/build/utils.ts
+++ b/sweetpad-vscode/src/build/utils.ts
@@ -18,7 +18,7 @@ import {
   isXcodeBuildCommandCustomized,
   readXBSConfig,
 } from "../common/cli/scripts";
-import { getWorkspaceConfig, updateWorkspaceConfig } from "../common/config";
+import { getWorkspaceConfig } from "../common/config";
 import { ExtensionError } from "../common/errors";
 import { createDirectory, findFilesRecursive, isFileExists, readJsonFile, removeDirectory } from "../common/files";
 import { commonLogger } from "../common/logger";
@@ -121,23 +121,12 @@ export async function askDestinationToRunOn(
   });
   const supportedPlatforms = buildSettings?.supportedPlatforms;
 
-  const destination = await selectDestinationForBuild(destinationsManager, {
+  // The picker records the choice, so a setting pinning a destination that no longer
+  // exists is rewritten with this pick instead of re-prompting on every build.
+  return await selectDestinationForBuild(destinationsManager, {
     destinations: destinations,
     supportedPlatforms: supportedPlatforms,
   });
-
-  // If a setting pinned a destination that no longer exists, refresh it with the new pick
-  // so we don't re-prompt on every build.
-  if (getWorkspaceConfig("build.destination")) {
-    await updateWorkspaceConfig("build.destination", {
-      id: destination.id,
-      type: destination.type,
-      name: destination.name,
-    });
-    destinationsManager.setWorkspaceDestinationForBuild(undefined);
-  }
-
-  return destination;
 }
 
 export async function selectDestinationForBuild(
@@ -197,7 +186,7 @@ export async function selectDestinationForBuild(
 
   const destination = selected.context;
 
-  destinationsManager.setWorkspaceDestinationForBuild(destination);
+  await destinationsManager.persistDestinationForBuild(destination);
   return destination;
 }
 

--- a/sweetpad-vscode/src/cli-server/handlers/destination.ts
+++ b/sweetpad-vscode/src/cli-server/handlers/destination.ts
@@ -68,6 +68,6 @@ export const destinationSet: HandlerFn<{ id?: string }, { destination: Destinati
       hint: "sweetpad vscode destination.list",
     });
   }
-  ctx.destinationsManager.setWorkspaceDestinationForBuild(match);
+  await ctx.destinationsManager.persistDestinationForBuild(match);
   return { destination: toEntity(match, match.id) };
 };

--- a/sweetpad-vscode/src/cli-server/handlers/scheme.ts
+++ b/sweetpad-vscode/src/cli-server/handlers/scheme.ts
@@ -39,6 +39,6 @@ export const schemeSet: HandlerFn<{ name?: string }, { scheme: SchemeEntity }> =
       data: { available: names },
     });
   }
-  ctx.buildManager.setDefaultSchemeForBuild(params.name);
+  await ctx.buildManager.persistSchemeForBuild(params.name);
   return { scheme: { name: params.name, isSelected: true } satisfies SchemeEntity };
 };

--- a/sweetpad-vscode/src/common/config.ts
+++ b/sweetpad-vscode/src/common/config.ts
@@ -1,5 +1,7 @@
 import * as vscode from "vscode";
 
+import type { SelectedDestination } from "../destination/types";
+
 type Config = {
   "format.path": string;
   "format.args": string[] | null;
@@ -10,6 +12,8 @@ type Config = {
   "build.swiftCommand": string;
   "build.derivedDataPath": string;
   "build.configuration": string;
+  "build.scheme": string;
+  "build.destination": SelectedDestination;
   "build.schemes.include": string[];
   "build.schemes.exclude": string[];
   "build.arch": "x86_64" | "arm64";

--- a/sweetpad-vscode/src/common/config.ts
+++ b/sweetpad-vscode/src/common/config.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-import type { SelectedDestination } from "../destination/types";
+import type { DestinationType } from "../destination/types";
 
 type Config = {
   "format.path": string;
@@ -13,7 +13,7 @@ type Config = {
   "build.derivedDataPath": string;
   "build.configuration": string;
   "build.scheme": string;
-  "build.destination": SelectedDestination;
+  "build.destination": { id: string; type: DestinationType };
   "build.schemes.include": string[];
   "build.schemes.exclude": string[];
   "build.arch": "x86_64" | "arm64";

--- a/sweetpad-vscode/src/common/workspace-state.ts
+++ b/sweetpad-vscode/src/common/workspace-state.ts
@@ -42,6 +42,7 @@ export type WorkspaceTypes = {
   "build.xcodeSdk": string;
   "build.lastLaunchedApp": LastLaunchedAppContext;
   "build.xbsAutogenreateInfoShown": boolean;
+  "build.missingPinnedSchemeWarned": string;
   "build.xbsMissingNotified": boolean;
   "build.customXcodebuildNoticeShown": boolean;
   "build.lspDiagnosticsEnabled": boolean;

--- a/sweetpad-vscode/src/destination/commands.ts
+++ b/sweetpad-vscode/src/destination/commands.ts
@@ -3,9 +3,8 @@ import * as vscode from "vscode";
 import { selectDestinationForBuild } from "../build/utils";
 import { showYesNoQuestion } from "../common/askers";
 import type { AppDeps } from "../common/commands";
-import { getWorkspaceConfig, updateWorkspaceConfig } from "../common/config";
+import { getWorkspaceConfig } from "../common/config";
 import { selectDestinationForTesting } from "../testing/utils";
-import type { Destination } from "./types";
 import type { DestinationTreeItem } from "./tree";
 
 /**
@@ -19,7 +18,7 @@ export async function searchDestinationsViewCommand(_deps: AppDeps) {
 
 export async function selectDestinationForBuildCommand(deps: AppDeps, item?: DestinationTreeItem) {
   if (item) {
-    await persistDestinationForBuild(deps, item.destination);
+    await deps.destinationsManager.persistDestinationForBuild(item.destination);
     return;
   }
 
@@ -28,44 +27,20 @@ export async function selectDestinationForBuildCommand(deps: AppDeps, item?: Des
     mostUsedSort: true,
   });
 
+  // The picker applies the pick, so dismissing the prompt below still selects it.
   const destination = await selectDestinationForBuild(deps.destinationsManager, {
     destinations: destinations,
     supportedPlatforms: undefined, // All platforms
   });
-
-  await persistDestinationForBuild(deps, destination, { askToSaveSettings: true });
-}
-
-/**
- * Persist the build destination to settings (when already configured or when the user opts in)
- * or to workspace-state cache otherwise.
- */
-async function persistDestinationForBuild(
-  deps: AppDeps,
-  destination: Destination,
-  options?: { askToSaveSettings?: boolean },
-): Promise<void> {
-  let saveToSettings = false;
-  if (options?.askToSaveSettings) {
-    saveToSettings = await showYesNoQuestion({
-      title: "Do you want to update the destination in the workspace settings (.vscode/settings.json)?",
-    });
-  } else if (getWorkspaceConfig("build.destination")) {
-    // Setting already pins the destination — keep it in sync when picking from the tree.
-    saveToSettings = true;
+  if (getWorkspaceConfig("build.destination")) {
+    return;
   }
 
-  const selected = {
-    id: destination.id,
-    type: destination.type,
-    name: destination.name,
-  };
-
-  if (saveToSettings) {
-    await updateWorkspaceConfig("build.destination", selected);
-    deps.destinationsManager.setWorkspaceDestinationForBuild(undefined);
-  } else {
-    deps.destinationsManager.setWorkspaceDestinationForBuild(destination);
+  const pin = await showYesNoQuestion({
+    title: "Do you want to update the destination in the workspace settings (.vscode/settings.json)?",
+  });
+  if (pin) {
+    await deps.destinationsManager.persistDestinationForBuild(destination, { pin: true });
   }
 }
 

--- a/sweetpad-vscode/src/destination/commands.ts
+++ b/sweetpad-vscode/src/destination/commands.ts
@@ -1,8 +1,11 @@
 import * as vscode from "vscode";
 
 import { selectDestinationForBuild } from "../build/utils";
+import { showYesNoQuestion } from "../common/askers";
 import type { AppDeps } from "../common/commands";
+import { getWorkspaceConfig, updateWorkspaceConfig } from "../common/config";
 import { selectDestinationForTesting } from "../testing/utils";
+import type { Destination } from "./types";
 import type { DestinationTreeItem } from "./tree";
 
 /**
@@ -16,7 +19,7 @@ export async function searchDestinationsViewCommand(_deps: AppDeps) {
 
 export async function selectDestinationForBuildCommand(deps: AppDeps, item?: DestinationTreeItem) {
   if (item) {
-    deps.destinationsManager.setWorkspaceDestinationForBuild(item.destination);
+    await persistDestinationForBuild(deps, item.destination);
     return;
   }
 
@@ -25,10 +28,45 @@ export async function selectDestinationForBuildCommand(deps: AppDeps, item?: Des
     mostUsedSort: true,
   });
 
-  await selectDestinationForBuild(deps.destinationsManager, {
+  const destination = await selectDestinationForBuild(deps.destinationsManager, {
     destinations: destinations,
     supportedPlatforms: undefined, // All platforms
   });
+
+  await persistDestinationForBuild(deps, destination, { askToSaveSettings: true });
+}
+
+/**
+ * Persist the build destination to settings (when already configured or when the user opts in)
+ * or to workspace-state cache otherwise.
+ */
+async function persistDestinationForBuild(
+  deps: AppDeps,
+  destination: Destination,
+  options?: { askToSaveSettings?: boolean },
+): Promise<void> {
+  let saveToSettings = false;
+  if (options?.askToSaveSettings) {
+    saveToSettings = await showYesNoQuestion({
+      title: "Do you want to update the destination in the workspace settings (.vscode/settings.json)?",
+    });
+  } else if (getWorkspaceConfig("build.destination")) {
+    // Setting already pins the destination — keep it in sync when picking from the tree.
+    saveToSettings = true;
+  }
+
+  const selected = {
+    id: destination.id,
+    type: destination.type,
+    name: destination.name,
+  };
+
+  if (saveToSettings) {
+    await updateWorkspaceConfig("build.destination", selected);
+    deps.destinationsManager.setWorkspaceDestinationForBuild(undefined);
+  } else {
+    deps.destinationsManager.setWorkspaceDestinationForBuild(destination);
+  }
 }
 
 export async function selectDestinationForTestingCommand(deps: AppDeps, item?: DestinationTreeItem) {

--- a/sweetpad-vscode/src/destination/id-prefixes.spec.ts
+++ b/sweetpad-vscode/src/destination/id-prefixes.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * DESTINATION_ID_PREFIX is a hand-written table, and the ids it describes are built
+ * independently by each destination class. These tests pin the two together, so
+ * renaming a prefix in a class fails here instead of silently breaking a pinned
+ * "sweetpad.build.destination".
+ */
+import { createMockDevice } from "../__mocks__/devices";
+import {
+  iOSDeviceDestination,
+  tvOSDeviceDestination,
+  visionOSDeviceDestination,
+  watchOSDeviceDestination,
+} from "../devices/types";
+import {
+  iOSSimulatorDestination,
+  tvOSSimulatorDestination,
+  visionOSSimulatorDestination,
+  watchOSSimulatorDestination,
+} from "../simulators/types";
+import {
+  ALL_DESTINATION_TYPES,
+  DESTINATION_ID_PREFIX,
+  type Destination,
+  macOSDestination,
+  normalizeDestinationId,
+} from "./types";
+
+const UDID = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
+const FULL_ID_FOR_TEST = `iossimulator-${UDID}`;
+
+function simulator<T>(
+  Ctor: new (options: any) => T,
+  options: { simulatorType: string; os: string; runtime: string },
+): T {
+  return new Ctor({
+    udid: UDID,
+    isAvailable: true,
+    state: "Shutdown",
+    name: "Test Simulator",
+    simulatorType: options.simulatorType,
+    os: options.os,
+    osVersion: "17.0",
+    rawDeviceTypeIdentifier: `com.apple.CoreSimulator.SimDeviceType.${options.simulatorType}`,
+    rawRuntime: options.runtime,
+  });
+}
+
+function device<T>(Ctor: new (options: any) => T): T {
+  return new Ctor({
+    devicectl: createMockDevice({ hardwareProperties: { udid: UDID } as any }),
+  });
+}
+
+const DESTINATIONS: Destination[] = [
+  simulator(iOSSimulatorDestination, {
+    simulatorType: "iPhone",
+    os: "iOS",
+    runtime: "com.apple.CoreSimulator.SimRuntime.iOS-17-0",
+  }),
+  simulator(watchOSSimulatorDestination, {
+    simulatorType: "AppleWatch",
+    os: "watchOS",
+    runtime: "com.apple.CoreSimulator.SimRuntime.watchOS-10-0",
+  }),
+  simulator(tvOSSimulatorDestination, {
+    simulatorType: "AppleTV",
+    os: "tvOS",
+    runtime: "com.apple.CoreSimulator.SimRuntime.tvOS-17-0",
+  }),
+  simulator(visionOSSimulatorDestination, {
+    simulatorType: "AppleVision",
+    os: "xrOS",
+    runtime: "com.apple.CoreSimulator.SimRuntime.xrOS-1-0",
+  }),
+  new macOSDestination({ name: "My Mac", arch: "arm64" }),
+  device(iOSDeviceDestination),
+  device(watchOSDeviceDestination),
+  device(tvOSDeviceDestination),
+  device(visionOSDeviceDestination),
+];
+
+describe("DESTINATION_ID_PREFIX", () => {
+  it("covers every destination type", () => {
+    expect(Object.keys(DESTINATION_ID_PREFIX).toSorted()).toEqual([...ALL_DESTINATION_TYPES].toSorted());
+  });
+
+  it("has one destination under test per type", () => {
+    expect(DESTINATIONS.map((d) => d.type).toSorted()).toEqual([...ALL_DESTINATION_TYPES].toSorted());
+  });
+
+  for (const destination of DESTINATIONS) {
+    it(`matches the id ${destination.type} builds`, () => {
+      expect(destination.id.startsWith(DESTINATION_ID_PREFIX[destination.type])).toBe(true);
+    });
+  }
+});
+
+describe("normalizeDestinationId", () => {
+  it("expands a bare udid using the type", () => {
+    expect(normalizeDestinationId(UDID, "iOSSimulator")).toBe(`iossimulator-${UDID}`);
+    expect(normalizeDestinationId(UDID, "visionOSSimulator")).toBe(`visionsimulator-${UDID}`);
+    expect(normalizeDestinationId("My Mac", "macOS")).toBe("macos-My Mac");
+  });
+
+  it("leaves the id alone for a type the settings file made up", () => {
+    const madeUp = "iossimulator" as never;
+    expect(normalizeDestinationId(FULL_ID_FOR_TEST, madeUp)).toBe(FULL_ID_FOR_TEST);
+    expect(normalizeDestinationId(UDID, madeUp)).toBe(UDID);
+  });
+
+  it("leaves an already-prefixed id alone", () => {
+    for (const destination of DESTINATIONS) {
+      expect(normalizeDestinationId(destination.id, destination.type)).toBe(destination.id);
+    }
+  });
+
+  it("round-trips every type's bare id back to what the class builds", () => {
+    for (const destination of DESTINATIONS) {
+      const bare = destination.id.slice(DESTINATION_ID_PREFIX[destination.type].length);
+      expect(normalizeDestinationId(bare, destination.type)).toBe(destination.id);
+    }
+  });
+});

--- a/sweetpad-vscode/src/destination/manager.ts
+++ b/sweetpad-vscode/src/destination/manager.ts
@@ -1,5 +1,8 @@
 import events from "node:events";
 
+import * as vscode from "vscode";
+
+import { getWorkspaceConfig } from "../common/config";
 import { checkUnreachable } from "../common/types";
 import type { WorkspaceStateService } from "../common/workspace-state";
 import type { DevicesManager } from "../devices/manager";
@@ -68,6 +71,12 @@ export class DestinationsManager {
     });
     this.devicesManager.on("updated", () => {
       this.emitter.emit("devicesUpdated");
+    });
+
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration("sweetpad.build.destination")) {
+        this.emitter.emit("xcodeDestinationForBuildUpdated", this.getSelectedXcodeDestinationForBuild());
+      }
     });
   }
 
@@ -405,9 +414,17 @@ export class DestinationsManager {
   }
 
   /**
-   * Get selected destination from the workspace state
+   * Get selected destination from settings, falling back to workspace state.
    */
   getSelectedXcodeDestinationForBuild(): SelectedDestination | undefined {
+    const fromConfig = getWorkspaceConfig("build.destination");
+    if (fromConfig?.id && fromConfig?.type) {
+      return {
+        id: fromConfig.id,
+        type: fromConfig.type,
+        name: fromConfig.name ?? fromConfig.id,
+      };
+    }
     return this.workspaceState.get("build.xcodeDestination");
   }
 

--- a/sweetpad-vscode/src/destination/manager.ts
+++ b/sweetpad-vscode/src/destination/manager.ts
@@ -1,8 +1,6 @@
 import events from "node:events";
 
-import * as vscode from "vscode";
-
-import { getWorkspaceConfig } from "../common/config";
+import { getWorkspaceConfig, onDidChangeConfiguration, updateWorkspaceConfig } from "../common/config";
 import { checkUnreachable } from "../common/types";
 import type { WorkspaceStateService } from "../common/workspace-state";
 import type { DevicesManager } from "../devices/manager";
@@ -33,12 +31,12 @@ import {
   type DestinationType,
   type SelectedDestination,
   macOSDestination,
+  normalizeDestinationId,
 } from "./types";
 import { getMacOSArchitecture } from "./utils";
 
 type IEventMap = {
-  simulatorsUpdated: [];
-  devicesUpdated: [];
+  destinationsUpdated: [];
   xcodeDestinationForBuildUpdated: [destination: SelectedDestination | undefined];
   xcodeDestinationForTestingUpdated: [destination: SelectedDestination | undefined];
   recentDestinationsUpdated: [];
@@ -54,6 +52,11 @@ export class DestinationsManager {
   // Event emitter to signal changes in the destinations
   private emitter = new events.EventEmitter<IEventMap>();
 
+  // id -> display name for everything scanned so far. Built on demand and dropped when a
+  // scan lands, so resolving the label of a pinned destination is a map hit rather than a
+  // walk over every simulator on the machine.
+  private destinationNames: Map<string, string> | undefined = undefined;
+
   constructor(options: {
     simulatorsManager: SimulatorsManager;
     devicesManager: DevicesManager;
@@ -65,15 +68,21 @@ export class DestinationsManager {
   }
 
   async start(): Promise<void> {
-    // Forward events from simulators and devices managers
+    // Forward events from simulators and devices managers. The name lookup describes the
+    // previous scan, so drop it before announcing — views react by reading back through
+    // this manager, and they subscribe in their constructors, before start() runs.
     this.simulatorsManager.on("updated", () => {
-      this.emitter.emit("simulatorsUpdated");
+      this.destinationNames = undefined;
+      this.emitter.emit("destinationsUpdated");
     });
     this.devicesManager.on("updated", () => {
-      this.emitter.emit("devicesUpdated");
+      this.destinationNames = undefined;
+      this.emitter.emit("destinationsUpdated");
     });
 
-    vscode.workspace.onDidChangeConfiguration((event) => {
+    // A pinned destination outranks the cache, so editing the setting is a selection
+    // change like any other. Views listen for this event rather than the setting itself.
+    onDidChangeConfiguration((event) => {
       if (event.affectsConfiguration("sweetpad.build.destination")) {
         this.emitter.emit("xcodeDestinationForBuildUpdated", this.getSelectedXcodeDestinationForBuild());
       }
@@ -200,6 +209,11 @@ export class DestinationsManager {
   }
 
   async getmacOSDevices(): Promise<macOSDestination[]> {
+    return this.macOSDestinations();
+  }
+
+  /** Describing the local Mac needs no I/O, so this stays available synchronously. */
+  private macOSDestinations(): macOSDestination[] {
     const currentArch = getMacOSArchitecture() ?? "arm64";
     return [
       new macOSDestination({
@@ -302,6 +316,23 @@ export class DestinationsManager {
   }
 
   /**
+   * Display name for a destination that has already been scanned. The async lookups go to
+   * simctl and devicectl, which callers that must answer synchronously cannot wait for;
+   * macOS is always present, since describing it needs no I/O.
+   */
+  private findCachedDestinationName(destinationId: string): string | undefined {
+    if (!this.destinationNames) {
+      const scanned: Destination[] = [
+        ...this.simulatorsManager.getCachedSimulators(),
+        ...this.devicesManager.getCachedDevices(),
+        ...this.macOSDestinations(),
+      ];
+      this.destinationNames = new Map(scanned.map((destination) => [destination.id, destination.name]));
+    }
+    return this.destinationNames.get(destinationId);
+  }
+
+  /**
    * Find a destination by its udid and type
    */
   async findDestination(options: { destinationId: string; type?: DestinationType }): Promise<Destination | undefined> {
@@ -396,6 +427,29 @@ export class DestinationsManager {
     this.emitter.emit("xcodeDestinationForBuildUpdated", selectedDestination);
   }
 
+  /**
+   * Record a destination pick where it will actually be read. 'sweetpad.build.destination'
+   * outranks the workspace-state cache, so caching a pick while that setting is pinned
+   * would report success and change nothing. Pass 'pin' to move a cached pick into settings.
+   */
+  async persistDestinationForBuild(destination: Destination, options?: { pin?: boolean }): Promise<void> {
+    // Persist destination for build in the vscode workspace-state cache
+    if (!options?.pin && !getWorkspaceConfig("build.destination")) {
+      this.setWorkspaceDestinationForBuild(destination);
+      return;
+    }
+
+    // Persist destination for build in vscode .settings.json
+    this.trackSelectedDestination(destination);
+    await updateWorkspaceConfig("build.destination", {
+      id: destination.id,
+      type: destination.type,
+    });
+    // The setting answers for the destination now, so drop the cached copy quietly —
+    // the configuration change already announced the new value.
+    this.workspaceState.update("build.xcodeDestination", undefined);
+  }
+
   setWorkspaceDestinationForTesting(destination: Destination | undefined) {
     if (!destination) {
       this.workspaceState.update("testing.xcodeDestination", undefined);
@@ -419,10 +473,14 @@ export class DestinationsManager {
   getSelectedXcodeDestinationForBuild(): SelectedDestination | undefined {
     const fromConfig = getWorkspaceConfig("build.destination");
     if (fromConfig?.id && fromConfig?.type) {
+      const id = normalizeDestinationId(fromConfig.id, fromConfig.type);
       return {
-        id: fromConfig.id,
+        id: id,
         type: fromConfig.type,
-        name: fromConfig.name ?? fromConfig.id,
+        // The setting has no label, so take it from the destination itself. Before the
+        // first scan lands there is nothing to take it from, so show what was written —
+        // a bare udid reads better than the expanded id.
+        name: this.findCachedDestinationName(id) ?? fromConfig.id,
       };
     }
     return this.workspaceState.get("build.xcodeDestination");

--- a/sweetpad-vscode/src/destination/pinned-label.spec.ts
+++ b/sweetpad-vscode/src/destination/pinned-label.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * "sweetpad.build.destination" stores identity only, so getSelectedXcodeDestinationForBuild
+ * takes the display name from the already-scanned destinations. These tests cover what the
+ * status bar reads before and after a scan has landed.
+ */
+import { workspace as vscodeWorkspace } from "../__mocks__/vscode";
+import type { WorkspaceStateService } from "../common/workspace-state";
+import type { DevicesManager } from "../devices/manager";
+import type { SimulatorsManager } from "../simulators/manager";
+import { iOSSimulatorDestination } from "../simulators/types";
+import { DestinationsManager } from "./manager";
+
+const UDID = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
+const FULL_ID = `iossimulator-${UDID}`;
+
+function simulator(name: string, udid = UDID): iOSSimulatorDestination {
+  return new iOSSimulatorDestination({
+    udid: udid,
+    isAvailable: true,
+    state: "Shutdown",
+    name: name,
+    simulatorType: "iPhone",
+    os: "iOS",
+    osVersion: "17.0",
+    rawDeviceTypeIdentifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
+    rawRuntime: "com.apple.CoreSimulator.SimRuntime.iOS-17-0",
+  });
+}
+
+function pinConfig(value: unknown): void {
+  vi.mocked(vscodeWorkspace.getConfiguration).mockReturnValue({
+    get: (key: string) => (key === "build.destination" ? value : undefined),
+  } as any);
+}
+
+/**
+ * `scanned` stands in for what simctl has already returned; empty means no scan yet.
+ * Mutate the returned array to simulate a later scan, then fire `simulatorsUpdated`.
+ */
+function buildManager(scanned: iOSSimulatorDestination[]): DestinationsManager & { simulateScan: () => void } {
+  const simulatorListeners: (() => void)[] = [];
+  const manager = new DestinationsManager({
+    simulatorsManager: {
+      on: vi.fn((_event: string, listener: () => void) => simulatorListeners.push(listener)),
+      getCachedSimulators: () => scanned,
+    } as unknown as SimulatorsManager,
+    devicesManager: {
+      on: vi.fn(),
+      getCachedDevices: () => [],
+    } as unknown as DevicesManager,
+    workspaceState: {
+      get: vi.fn().mockReturnValue(undefined),
+      update: vi.fn(),
+    } as unknown as WorkspaceStateService,
+  });
+
+  void manager.start();
+  return Object.assign(manager, {
+    simulateScan: () => {
+      for (const listener of simulatorListeners) {
+        listener();
+      }
+    },
+  });
+}
+
+describe("pinned destination label", () => {
+  afterEach(() => {
+    vi.mocked(vscodeWorkspace.getConfiguration).mockReset();
+  });
+
+  it("expands a bare udid into the full id", () => {
+    pinConfig({ id: UDID, type: "iOSSimulator" });
+
+    expect(buildManager([]).getSelectedXcodeDestinationForBuild()).toEqual({
+      id: FULL_ID,
+      type: "iOSSimulator",
+      name: UDID,
+    });
+  });
+
+  it("shows what was written before any scan has landed", () => {
+    pinConfig({ id: UDID, type: "iOSSimulator" });
+
+    expect(buildManager([]).getSelectedXcodeDestinationForBuild()?.name).toBe(UDID);
+  });
+
+  it("takes the name from a scanned destination", () => {
+    pinConfig({ id: UDID, type: "iOSSimulator" });
+
+    expect(buildManager([simulator("iPhone 16")]).getSelectedXcodeDestinationForBuild()?.name).toBe("iPhone 16");
+  });
+
+  it("resolves a fully qualified pin too", () => {
+    pinConfig({ id: FULL_ID, type: "iOSSimulator" });
+
+    expect(buildManager([simulator("iPhone 16")]).getSelectedXcodeDestinationForBuild()?.name).toBe("iPhone 16");
+  });
+
+  it("follows a rename with no state to invalidate", () => {
+    pinConfig({ id: UDID, type: "iOSSimulator" });
+
+    expect(buildManager([simulator("Work Phone")]).getSelectedXcodeDestinationForBuild()?.name).toBe("Work Phone");
+  });
+
+  it("picks up a scan that lands after the name was already looked up", () => {
+    pinConfig({ id: UDID, type: "iOSSimulator" });
+    const scanned: iOSSimulatorDestination[] = [];
+    const manager = buildManager(scanned);
+
+    // Populate the lookup while nothing has been scanned yet.
+    expect(manager.getSelectedXcodeDestinationForBuild()?.name).toBe(UDID);
+
+    scanned.push(simulator("iPhone 16"));
+    manager.simulateScan();
+
+    expect(manager.getSelectedXcodeDestinationForBuild()?.name).toBe("iPhone 16");
+  });
+
+  it("drops a name that a later scan removed", () => {
+    pinConfig({ id: UDID, type: "iOSSimulator" });
+    const scanned = [simulator("iPhone 16")];
+    const manager = buildManager(scanned);
+    expect(manager.getSelectedXcodeDestinationForBuild()?.name).toBe("iPhone 16");
+
+    scanned.length = 0;
+    manager.simulateScan();
+
+    expect(manager.getSelectedXcodeDestinationForBuild()?.name).toBe(UDID);
+  });
+
+  it("keeps showing the id when the pinned destination is absent", () => {
+    pinConfig({ id: UDID, type: "iOSSimulator" });
+
+    expect(buildManager([simulator("iPad Pro", "other-udid")]).getSelectedXcodeDestinationForBuild()?.name).toBe(UDID);
+  });
+
+  it("resolves macOS without a scan", () => {
+    pinConfig({ id: "My Mac", type: "macOS" });
+
+    expect(buildManager([]).getSelectedXcodeDestinationForBuild()).toEqual({
+      id: "macos-My Mac",
+      type: "macOS",
+      name: "My Mac",
+    });
+  });
+
+  it("falls back to workspace state when nothing is pinned", () => {
+    pinConfig(undefined);
+
+    expect(buildManager([]).getSelectedXcodeDestinationForBuild()).toBeUndefined();
+  });
+});

--- a/sweetpad-vscode/src/destination/status-bar.ts
+++ b/sweetpad-vscode/src/destination/status-bar.ts
@@ -21,6 +21,11 @@ export class DestinationStatusBar {
     this.destinationsManager.on("xcodeDestinationForBuildUpdated", () => {
       void this.update();
     });
+    // A destination pinned in settings carries no label, so the name only becomes
+    // available once a scan has run. Redraw when one lands.
+    this.destinationsManager.on("destinationsUpdated", () => {
+      void this.update();
+    });
   }
 
   update() {

--- a/sweetpad-vscode/src/destination/tree.ts
+++ b/sweetpad-vscode/src/destination/tree.ts
@@ -519,8 +519,8 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
     this.manager.on("devicesUpdated", () => {
       this.#onDidChangeTreeData.fire(null);
     });
-    this.manager.on("xcodeDestinationForBuildUpdated", (destination) => {
-      this.selectedDestinationForBuild = destination;
+    this.manager.on("xcodeDestinationForBuildUpdated", () => {
+      this.selectedDestinationForBuild = this.manager.getSelectedXcodeDestinationForBuild();
       this.#onDidChangeTreeData.fire(null); // todo: update only the selected destination
     });
     this.manager.on("xcodeDestinationForTestingUpdated", (destination) => {
@@ -532,6 +532,13 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
     });
     this.selectedDestinationForBuild = this.manager.getSelectedXcodeDestinationForBuild();
     this.selectedDestinationForTesting = this.manager.getSelectedXcodeDestinationForTesting();
+
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration("sweetpad.build.destination")) {
+        this.selectedDestinationForBuild = this.manager.getSelectedXcodeDestinationForBuild();
+        this.#onDidChangeTreeData.fire(null);
+      }
+    });
   }
 
   async getChildren(element?: DestinationGroupTreeItem | DestinationTreeItem): Promise<vscode.TreeItem[]> {

--- a/sweetpad-vscode/src/destination/tree.ts
+++ b/sweetpad-vscode/src/destination/tree.ts
@@ -513,10 +513,7 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
   }
 
   async start(): Promise<void> {
-    this.manager.on("simulatorsUpdated", () => {
-      this.#onDidChangeTreeData.fire(null);
-    });
-    this.manager.on("devicesUpdated", () => {
+    this.manager.on("destinationsUpdated", () => {
       this.#onDidChangeTreeData.fire(null);
     });
     this.manager.on("xcodeDestinationForBuildUpdated", () => {
@@ -532,13 +529,6 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
     });
     this.selectedDestinationForBuild = this.manager.getSelectedXcodeDestinationForBuild();
     this.selectedDestinationForTesting = this.manager.getSelectedXcodeDestinationForTesting();
-
-    vscode.workspace.onDidChangeConfiguration((event) => {
-      if (event.affectsConfiguration("sweetpad.build.destination")) {
-        this.selectedDestinationForBuild = this.manager.getSelectedXcodeDestinationForBuild();
-        this.#onDidChangeTreeData.fire(null);
-      }
-    });
   }
 
   async getChildren(element?: DestinationGroupTreeItem | DestinationTreeItem): Promise<vscode.TreeItem[]> {

--- a/sweetpad-vscode/src/destination/types.ts
+++ b/sweetpad-vscode/src/destination/types.ts
@@ -39,6 +39,42 @@ export const ALL_DESTINATION_TYPES: DestinationType[] = [
 ];
 
 /**
+ * The prefix each destination class puts in front of its udid (or, for macOS, the
+ * computer name) to form an id. Note "visionOSSimulator" drops the "os" and "macOS"
+ * carries no udid, so the prefix cannot be derived from the type name — id-prefixes.spec.ts
+ * pins this table to what the classes actually produce.
+ *
+ * Used to accept a bare udid in "sweetpad.build.destination", where the type is already
+ * given and repeating it in the id is noise.
+ */
+export const DESTINATION_ID_PREFIX: Record<DestinationType, string> = {
+  iOSSimulator: "iossimulator-",
+  watchOSSimulator: "watchossimulator-",
+  tvOSSimulator: "tvossimulator-",
+  visionOSSimulator: "visionsimulator-",
+  macOS: "macos-",
+  iOSDevice: "iosdevice-",
+  watchOSDevice: "watchosdevice-",
+  tvOSDevice: "tvosdevice-",
+  visionOSDevice: "visionosdevice-",
+};
+
+/**
+ * Expand a "sweetpad.build.destination" id into the canonical form the destination
+ * classes produce, so a hand-written setting can name just the udid.
+ */
+export function normalizeDestinationId(id: string, type: DestinationType): string {
+  // A hand-edited setting can name a type that doesn't exist, and there is no prefix to
+  // apply for one. Leave the id alone so a fully qualified one still matches; the picker
+  // rewrites the setting either way.
+  const prefix = DESTINATION_ID_PREFIX[type];
+  if (!prefix) {
+    return id;
+  }
+  return id.startsWith(prefix) ? id : `${prefix}${id}`;
+}
+
+/**
  * Generic interface for a destination (iOS simulator, iOS device, etc.)
  */
 export interface IDestination {

--- a/sweetpad-vscode/src/devices/manager.ts
+++ b/sweetpad-vscode/src/devices/manager.ts
@@ -104,4 +104,12 @@ export class DevicesManager {
     }
     return this.cache;
   }
+
+  /**
+   * What is already known, without going to devicectl. For callers that have to answer
+   * synchronously and can live with an empty list until the first fetch lands.
+   */
+  getCachedDevices(): DeviceDestination[] {
+    return this.cache ?? [];
+  }
 }

--- a/sweetpad-vscode/src/simulators/manager.ts
+++ b/sweetpad-vscode/src/simulators/manager.ts
@@ -128,4 +128,12 @@ export class SimulatorsManager {
     }
     return this.cache;
   }
+
+  /**
+   * What is already known, without going to simctl. For callers that have to answer
+   * synchronously and can live with an empty list until the first fetch lands.
+   */
+  getCachedSimulators(): SimulatorDestination[] {
+    return this.cache ?? [];
+  }
 }


### PR DESCRIPTION
## Summary

When you're settled on a scheme and destination — the usual case once a project (or worktree) is set up — SweetPad still makes you rediscover them through the UI: open the IDE, click the scheme/destination picker, wait while it searches Xcode projects and simulators/devices, then confirm. That search isn't free, and for agents, scripts, or "always build this app on this simulator" workflows it's pure overhead.

This PR adds `sweetpad.build.scheme` and `sweetpad.build.destination` so you can pin those choices in `.vscode/settings.json`, the same way you already can with `sweetpad.build.xcodeWorkspacePath` and `sweetpad.build.configuration`.

That gives you:

- **Faster builds** — skip the QuickPick + discovery when nothing has changed
- **Per-worktree / per-project granularity** — each checkout can declare its own scheme and destination without fighting a shared global cache
- **A clearer contract for consumers** — agents and tooling can rely on settings instead of driving the pickers

Settings win over the extension's workspace-state cache. Selecting a scheme or destination from the command palette can write them for you; picking from the tree keeps an existing setting in sync. Docs are updated on the Build and Settings reference pages.