### PR TITLE
Find projects that sit below the working directory

### DIFF
--- a/sweetpad-cli/CLI_DESIGN.md
+++ b/sweetpad-cli/CLI_DESIGN.md
@@ -246,7 +246,35 @@ explicit flag  >  env var  >  config file  >  remembered state  >  auto-discover
 - **Auto-discovery:** find the `.xcworkspace` / `.xcodeproj` / `Package.swift`
   in the working directory (deterministic: same-kind siblings resolve to the
   alphabetically first, with a warning; pass `--workspace`/`--project` to
-  disambiguate).
+  disambiguate). The search walks *up* toward the git root, so a command works
+  from a nested source directory.
+- **Container resolution** runs on its own shorter ladder — `--workspace` /
+  `--project` > a `sweetpad.toml` `workspace`/`project` key > auto-discovery —
+  because every layer below it (per-project config, remembered state) is
+  *keyed by* the container and so can't take part in finding it.
+- **Downward scan**, once the upward walk finds nothing: look below the working
+  directory, then below the repository root, at most two levels down. This is
+  what makes the common nested layouts work with no configuration at all —
+  `ios/App.xcodeproj`, `Sources/App.xcodeproj`, `apps/ios/App.xcodeproj` — none
+  of which the upward walk can reach from the repository root. Build output and
+  vendored trees (`Pods`, `node_modules`, `Carthage`, `vendor`, `DerivedData`,
+  `build`, dotfiles) are never entered, so `Pods/Pods.xcodeproj` is never a
+  candidate, and symlinks are never followed.
+  - The **shallowest** level holding anything wins outright, and within a
+    single directory the usual workspace > project > package ordering applies
+    — so a `ios/` holding both a workspace and a project resolves silently to
+    the workspace, as CocoaPods and React Native layouts want.
+  - Directories **tied at that depth** (Flutter's `ios/` and `macos/`, a
+    monorepo's `apps/*`) are a real choice, not a tiebreak: the command errors
+    with every candidate listed and names both ways to settle it. This is a
+    deliberate split from same-kind siblings *in* the working directory, which
+    warn and take the alphabetically first — standing in a directory is a
+    signal of intent, a hit two levels down is not.
+  - A scan-resolved container is **announced** (`using Sources/App.xcodeproj
+    (found below the current directory)`), since the user never named it.
+  - Bare `sweetpad` treats a tie as "no container" and prints the help wall:
+    the status-or-help probe has nowhere to put a question, and `sweetpad
+    status` reports the ambiguity properly a keystroke later.
 - **Env vars:** `SWEETPAD_SCHEME`, `SWEETPAD_DESTINATION`,
   `SWEETPAD_CONFIGURATION`, `SWEETPAD_SDK`, `SWEETPAD_PROJECT` /
   `SWEETPAD_WORKSPACE` (value-carrying, folded into the flag layer — but an
@@ -310,17 +338,32 @@ configuration = "Test"
   selector is given.
 
 ### Project file — committed, team-shared
-- An *optional, hand-authored* `sweetpad.toml` at the project root (next to
-  the container). This is how a team standardizes: it travels with the clone,
-  needs no absolute paths, and sweetpad still **never writes** to the project
-  root — the file is read-only to the tool, like the user config.
+- An *optional, hand-authored* `sweetpad.toml` at the project root. This is how
+  a team standardizes: it travels with the clone, needs no absolute paths, and
+  sweetpad still **never writes** to the project root — the file is read-only
+  to the tool, like the user config.
 - Precedence slot: **user config > sweetpad.toml > remembered state**.
-- Keys: `scheme`, `configuration`, `destination`, `sdk`, a `[testing]`
-  sub-table (`scheme`/`configuration`/`destination`/`target`), plus the tool
-  defaults that previously had flags but no home:
+- **Located by walking up** from the working directory to the git root, so one
+  file serves the whole checkout. It may sit beside the container (the common
+  case) or above it, where `workspace`/`project` names a container nested
+  below — the layout `xcodebuild` can't be pointed at without `-C`:
+
+```
+App/
+  sweetpad.toml          project = "Sources/App.xcodeproj"
+  Scripts/               `sweetpad build` works from here too
+  Sources/App.xcodeproj
+```
+
+- Keys: `workspace`/`project` (which container this file belongs to, relative
+  to the file — `workspace` wins if both are set), `scheme`, `configuration`,
+  `destination`, `sdk`, a `[testing]` sub-table
+  (`scheme`/`configuration`/`destination`/`target`), plus the tool defaults
+  that previously had flags but no home:
 
 ```toml
 # sweetpad.toml (committed)
+project = "Sources/MyApp.xcodeproj"   # only when it isn't a sibling
 scheme = "MyApp"
 configuration = "Debug"
 
@@ -336,7 +379,14 @@ tool = "swiftlint"
 ```
 
 - Unknown keys are warned about; a malformed file is warned about and ignored
-  (a broken committed file must not brick every teammate's CLI).
+  (a broken committed file must not brick every teammate's CLI). An absolute
+  `workspace`/`project` warns too — it resolves to nothing on every other
+  machine, the one mistake that makes a committed file worse than none.
+- A declared container that doesn't exist is an **error**, never a fallback to
+  discovery: the file said which project this is, and quietly building a
+  different one is worse than stopping. When `generator` is set, the error
+  names the tool to run — the usual cause is a project that hasn't been
+  generated yet.
 
 ### State — machine-managed
 - `~/.local/state/sweetpad/state.toml` (honoring `XDG_STATE_HOME`).

--- a/sweetpad-cli/src/cli/commands/help_topics.rs
+++ b/sweetpad-cli/src/cli/commands/help_topics.rs
@@ -46,10 +46,29 @@ Resolution precedence, highest first:
   explicit flag > env var > config file > sweetpad.toml > remembered state
   > auto-discovery
 
-A committed 'sweetpad.toml' next to the project is the team-shared defaults
-layer (scheme/configuration/destination/sdk, 'developer_dir', '[run]',
-'[format]', '[testing]') — personal config beats it, remembered picks yield
-to it. Remembered state lives separately in
+A committed 'sweetpad.toml' is the team-shared defaults layer
+(scheme/configuration/destination/sdk, 'developer_dir', '[run]', '[format]',
+'[testing]') — personal config beats it, remembered picks yield to it. It is
+found by walking up from the working directory to the git root, so one file
+serves the whole checkout.
+
+When the project is not a sibling of that file, name it with 'workspace' or
+'project', relative to the file itself:
+
+  # App/sweetpad.toml
+  project = \"Sources/App.xcodeproj\"
+
+Every command then works from anywhere in the checkout, with no '-C'. The
+container resolves as: --workspace/--project > this key > auto-discovery.
+
+Auto-discovery searches upward to the git root, then up to two levels down
+(skipping Pods, node_modules, Carthage, vendor, DerivedData, build and
+dotfiles), so nested layouts like 'ios/App.xcodeproj' need no setup at all.
+Projects tied at the same depth — say 'ios/' and 'macos/' — are reported as an
+error listing each one, rather than picked for you; name the one you want with
+--project or the 'project' key above.
+
+Remembered state lives separately in
 ~/.local/state/sweetpad/state.toml (machine-managed — inspect and edit it
 with 'sweetpad context', not by hand).",
     },

--- a/sweetpad-cli/src/cli/config.rs
+++ b/sweetpad-cli/src/cli/config.rs
@@ -8,7 +8,7 @@
 //! Honors `XDG_CONFIG_HOME`, falling back to `~/.config`.
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
@@ -257,6 +257,14 @@ pub(crate) fn edit_distance(a: &str, b: &str) -> usize {
 #[derive(Debug, Default, Deserialize)]
 #[serde(default)]
 pub struct ProjectFile {
+    /// Names the `.xcworkspace` this file belongs to, relative to the file's
+    /// own directory — so a `sweetpad.toml` at the repo root can point at a
+    /// container nested below it and every command works from anywhere in the
+    /// tree. Wins over `project` when both are set.
+    pub workspace: Option<String>,
+    /// Names the `.xcodeproj`, relative to the file's own directory. See
+    /// [`workspace`](Self::workspace).
+    pub project: Option<String>,
     pub scheme: Option<String>,
     pub configuration: Option<String>,
     pub destination: Option<String>,
@@ -336,8 +344,90 @@ impl ProjectFile {
     }
 }
 
+/// A `sweetpad.toml` located by walking up from the working directory, paired
+/// with the directory holding it.
+///
+/// The walk is what lets one file serve a whole checkout: the file may sit
+/// beside the container (the common case) or above it at the repo root, where
+/// its [`workspace`](ProjectFile::workspace)/[`project`](ProjectFile::project)
+/// key names a container nested below. Paths in the file resolve against
+/// [`dir`](Self::dir) rather than the cwd, so the same file works from every
+/// directory in the tree and needs no absolute paths.
+#[derive(Debug)]
+pub struct RootFile {
+    /// The directory holding the file — the base for its relative paths.
+    pub dir: PathBuf,
+    pub file: ProjectFile,
+}
+
+impl RootFile {
+    /// The nearest `sweetpad.toml` at or above `start`. The walk stops at the
+    /// git root, the same boundary container discovery honors, so a checkout
+    /// above this one never donates its defaults; it also stops at the
+    /// filesystem root. Returns the file's lint warnings for the caller to
+    /// surface once.
+    #[must_use]
+    pub fn find_upward(start: &Path) -> Option<(Self, Vec<String>)> {
+        let mut dir = start.to_path_buf();
+        loop {
+            if dir.join("sweetpad.toml").exists() {
+                let (file, warnings) = ProjectFile::load_for(&dir);
+                return Some((Self { dir, file }, warnings));
+            }
+            if dir.join(".git").exists() {
+                return None;
+            }
+            dir = dir.parent()?.to_path_buf();
+        }
+    }
+
+    /// The container this file names, resolved against [`dir`](Self::dir).
+    /// `workspace` wins when both keys are set (matching `--workspace` beating
+    /// `--project`, and auto-discovery preferring a workspace). The path is
+    /// returned unchecked — a declared container that doesn't exist is an
+    /// error the resolver reports, not a reason to fall back to discovery and
+    /// build something else.
+    #[must_use]
+    pub fn declared(&self) -> Option<crate::cli::resolve::Container> {
+        use crate::cli::resolve::Container;
+        if let Some(ws) = &self.file.workspace {
+            return Some(Container::Workspace(self.dir.join(ws)));
+        }
+        self.file
+            .project
+            .as_ref()
+            .map(|p| Container::Project(self.dir.join(p)))
+    }
+
+    /// Whether this file is `container`'s project file.
+    ///
+    /// Naming a container is a statement of identity: a file with a
+    /// `workspace`/`project` key covers that container and no other, so a
+    /// `--project` pointing somewhere else doesn't inherit a scheme meant for
+    /// the declared one — even when the two sit side by side. Without a
+    /// declaration the file covers the container beside it, which is both the
+    /// long-standing layout and what keeps that file from being read and
+    /// linted a second time.
+    #[must_use]
+    pub fn covers(&self, container: &crate::cli::resolve::Container) -> bool {
+        let same = |a: &Path, b: &Path| match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+            (Ok(a), Ok(b)) => a == b,
+            _ => false,
+        };
+        if let Some(declared) = self.declared() {
+            return same(declared.path(), container.path());
+        }
+        container
+            .path()
+            .parent()
+            .is_some_and(|parent| same(parent, &self.dir))
+    }
+}
+
 /// The keys a `sweetpad.toml` accepts at the top level.
-const PROJECT_FILE_KEYS: [&str; 9] = [
+const PROJECT_FILE_KEYS: [&str; 11] = [
+    "workspace",
+    "project",
     "scheme",
     "configuration",
     "destination",
@@ -352,8 +442,27 @@ const PROJECT_FILE_KEYS: [&str; 9] = [
 /// Report every `sweetpad.toml` key serde would silently drop.
 fn lint_project_file(raw: &toml::Value, warnings: &mut Vec<String>) {
     let Some(top) = raw.as_table() else { return };
+    if top.contains_key("workspace") && top.contains_key("project") {
+        warnings.push(
+            "sweetpad.toml: `workspace` and `project` are both set; using `workspace`".to_string(),
+        );
+    }
     for (key, value) in top {
         match key.as_str() {
+            // A committed file that names its container with an absolute path
+            // resolves to nothing on every other machine — the one mistake
+            // that makes the file worse than no file at all.
+            "workspace" | "project" => {
+                if value
+                    .as_str()
+                    .is_some_and(|s| std::path::Path::new(s).is_absolute())
+                {
+                    warnings.push(format!(
+                        "sweetpad.toml: `{key}` is an absolute path, which won't resolve for \
+                         anyone else with this repo — make it relative to sweetpad.toml"
+                    ));
+                }
+            }
             "testing" => {
                 if let Some(t) = value.as_table() {
                     for tkey in t.keys() {
@@ -557,5 +666,133 @@ mod tests {
         assert_eq!(d.testing.scheme.as_deref(), Some("AppTests"));
         // A testing field left unset stays None (test resolution falls back to build).
         assert_eq!(d.testing.destination, None);
+    }
+
+    /// A scratch directory laid out like the reported case: a git root holding
+    /// the file, a sibling directory to run from, and the project one level
+    /// down.
+    fn nested_repo(tag: &str) -> PathBuf {
+        let n = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("sweetpad-rootfile-{tag}-{n}"));
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::create_dir_all(root.join("Scripts")).unwrap();
+        std::fs::create_dir_all(root.join("Sources/App.xcodeproj")).unwrap();
+        root
+    }
+
+    #[test]
+    fn find_upward_reaches_the_file_from_a_nested_directory() {
+        let root = nested_repo("nested");
+        std::fs::write(
+            root.join("sweetpad.toml"),
+            "project = \"Sources/App.xcodeproj\"",
+        )
+        .unwrap();
+
+        // Found from the root itself and from a sibling directory below it.
+        for start in [root.clone(), root.join("Scripts")] {
+            let (found, warnings) = RootFile::find_upward(&start).expect("file found");
+            assert!(warnings.is_empty(), "{warnings:?}");
+            assert_eq!(found.dir, root);
+            // Relative to the file, not to the directory the walk started in.
+            let declared = found.declared().expect("declares a project");
+            assert_eq!(declared.path(), root.join("Sources/App.xcodeproj"));
+        }
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn find_upward_stops_at_the_git_root() {
+        let outer = nested_repo("outer");
+        // A file above the repository must not donate its defaults.
+        let above = outer.parent().unwrap().join(format!(
+            "{}-above",
+            outer.file_name().unwrap().to_string_lossy()
+        ));
+        std::fs::create_dir_all(&above).unwrap();
+        std::fs::write(above.join("sweetpad.toml"), "scheme = \"Stray\"").unwrap();
+
+        assert!(RootFile::find_upward(&outer.join("Scripts")).is_none());
+
+        std::fs::remove_dir_all(&outer).unwrap();
+        std::fs::remove_dir_all(&above).unwrap();
+    }
+
+    #[test]
+    fn declared_prefers_workspace_and_absolute_paths_pass_through() {
+        let root = nested_repo("both");
+        std::fs::write(
+            root.join("sweetpad.toml"),
+            "workspace = \"Sources/App.xcworkspace\"\nproject = \"Sources/App.xcodeproj\"\n",
+        )
+        .unwrap();
+
+        let (found, warnings) = RootFile::find_upward(&root).unwrap();
+        assert!(
+            warnings.iter().any(|w| w.contains("both set")),
+            "{warnings:?}"
+        );
+        assert!(matches!(
+            found.declared(),
+            Some(crate::cli::resolve::Container::Workspace(_))
+        ));
+
+        // An absolute value warns but still resolves, `join` yielding the value.
+        std::fs::write(
+            root.join("sweetpad.toml"),
+            "project = \"/abs/Other.xcodeproj\"",
+        )
+        .unwrap();
+        let (found, warnings) = RootFile::find_upward(&root).unwrap();
+        assert!(
+            warnings.iter().any(|w| w.contains("absolute path")),
+            "{warnings:?}"
+        );
+        assert_eq!(
+            found.declared().unwrap().path(),
+            Path::new("/abs/Other.xcodeproj")
+        );
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn covers_the_container_it_names_and_its_own_siblings() {
+        let root = nested_repo("covers");
+        std::fs::write(
+            root.join("sweetpad.toml"),
+            "project = \"Sources/App.xcodeproj\"",
+        )
+        .unwrap();
+        let (found, _) = RootFile::find_upward(&root).unwrap();
+
+        // The named container, reached by a different spelling of the path.
+        let spelled = root.join("Scripts/../Sources/App.xcodeproj");
+        assert!(found.covers(&crate::cli::resolve::Container::Project(spelled)));
+
+        // An unrelated container in the same checkout is not this file's —
+        // including one sitting right beside the file, since naming a
+        // container rules out every other.
+        std::fs::create_dir_all(root.join("Other/Other.xcodeproj")).unwrap();
+        std::fs::create_dir_all(root.join("Beside.xcodeproj")).unwrap();
+        assert!(!found.covers(&crate::cli::resolve::Container::Project(
+            root.join("Other/Other.xcodeproj")
+        )));
+        assert!(!found.covers(&crate::cli::resolve::Container::Project(
+            root.join("Beside.xcodeproj")
+        )));
+
+        // A sibling of the file is covered once nothing is declared.
+        std::fs::write(root.join("sweetpad.toml"), "scheme = \"App\"").unwrap();
+        let (plain, _) = RootFile::find_upward(&root).unwrap();
+        assert!(plain.covers(&crate::cli::resolve::Container::Project(
+            root.join("Beside.xcodeproj")
+        )));
+
+        std::fs::remove_dir_all(&root).unwrap();
     }
 }

--- a/sweetpad-cli/src/cli/mod.rs
+++ b/sweetpad-cli/src/cli/mod.rs
@@ -643,14 +643,49 @@ pub struct Context {
     /// The committed `sweetpad.toml`, loaded once on first use (see
     /// [`Context::project_file`]).
     project_toml: std::cell::OnceCell<config::ProjectFile>,
+    /// The nearest `sweetpad.toml` at or above the cwd, resolved *before* the
+    /// container so its `workspace`/`project` key can name one (see
+    /// [`Context::root_file`]).
+    root_toml: std::cell::OnceCell<Option<config::RootFile>>,
 }
 
 impl Context {
-    /// The committed `sweetpad.toml` next to `container` — the team-shared
+    /// The nearest committed `sweetpad.toml` at or above the working
+    /// directory, or `None` when this checkout has none. Consulted during
+    /// container resolution, so it loads before a container exists — which is
+    /// the point: its `workspace`/`project` key is what names one when the
+    /// container sits in a subdirectory the upward walk never reaches.
+    pub fn root_file(&self) -> Option<&config::RootFile> {
+        self.root_toml
+            .get_or_init(|| {
+                let cwd = std::env::current_dir().ok()?;
+                let (root, warnings) = config::RootFile::find_upward(&cwd)?;
+                for w in &warnings {
+                    self.out.warn(w);
+                }
+                pin_developer_dir(&root.file);
+                Some(root)
+            })
+            .as_ref()
+    }
+
+    /// The committed `sweetpad.toml` for `container` — the team-shared
     /// defaults layer between the user config and remembered state. Loaded
     /// once per process; lint warnings surface on that first load, and a
     /// pinned `developer_dir` takes effect (unless a flag/env already set it).
+    ///
+    /// The root file serves as the project file whenever it covers this
+    /// container, so the file that named a nested container also supplies its
+    /// defaults, and the beside-the-container case isn't read and linted twice.
+    /// A file that names some *other* container supplies nothing here — its
+    /// defaults belong to the project it named, even for a container sitting
+    /// beside it.
     pub fn project_file(&self, container: &resolve::Container) -> &config::ProjectFile {
+        if let Some(root) = self.root_file()
+            && root.covers(container)
+        {
+            return &root.file;
+        }
         self.project_toml.get_or_init(|| {
             let dir = container
                 .path()
@@ -661,18 +696,28 @@ impl Context {
                     std::path::Path::to_path_buf,
                 );
             let (pf, warnings) = config::ProjectFile::load_for(&dir);
+            let beside = config::RootFile { dir, file: pf };
+            if !beside.covers(container) {
+                return config::ProjectFile::default();
+            }
             for w in &warnings {
                 self.out.warn(w);
             }
-            if let Some(dev_dir) = &pf.developer_dir
-                && std::env::var_os("DEVELOPER_DIR").is_none()
-            {
-                // Safety: first project-file access happens on the main thread
-                // before tool children spawn.
-                unsafe { std::env::set_var("DEVELOPER_DIR", dev_dir) };
-            }
-            pf
+            pin_developer_dir(&beside.file);
+            beside.file
         })
+    }
+}
+
+/// Apply a project file's `developer_dir`, unless a flag or the ambient
+/// environment already chose an Xcode.
+fn pin_developer_dir(pf: &config::ProjectFile) {
+    if let Some(dev_dir) = &pf.developer_dir
+        && std::env::var_os("DEVELOPER_DIR").is_none()
+    {
+        // Safety: first project-file access happens on the main thread before
+        // tool children spawn.
+        unsafe { std::env::set_var("DEVELOPER_DIR", dev_dir) };
     }
 }
 
@@ -792,6 +837,7 @@ pub fn run(argv: &[String]) -> ExitCode {
         state,
         out,
         project_toml: std::cell::OnceCell::new(),
+        root_toml: std::cell::OnceCell::new(),
     };
 
     // Bare `sweetpad`: the status view inside a project (the daily "where am

--- a/sweetpad-cli/src/cli/resolve.rs
+++ b/sweetpad-cli/src/cli/resolve.rs
@@ -11,6 +11,13 @@
 //! stdout is a TTY, commands may drop to an interactive picker; in non-TTY/CI
 //! contexts that's a hard error instead. The picker itself lands with the
 //! first command that needs it — this module wires the precedence.
+//!
+//! The *container* resolves on its own ladder, since the layers below it are
+//! keyed by the container and so can't help find it:
+//!
+//! ```text
+//! --workspace/--project  >  sweetpad.toml workspace/project  >  auto-discovery
+//! ```
 
 use std::path::{Path, PathBuf};
 
@@ -70,11 +77,12 @@ fn absolutize(path: &Path) -> PathBuf {
     out
 }
 
-/// Resolve the project container from explicit flags, else by auto-discovery in
-/// the current directory (warning when same-kind siblings make the pick
-/// ambiguous). An explicitly flagged path must exist: passing it through would
-/// mint state entries for typos (silently pruned or kept as garbage) and die
-/// later inside xcodebuild with a worse message.
+/// Resolve the project container from explicit flags, else from a committed
+/// `sweetpad.toml` that names one, else by auto-discovery in the current
+/// directory (warning when same-kind siblings make the pick ambiguous). An
+/// explicitly flagged path must exist: passing it through would mint state
+/// entries for typos (silently pruned or kept as garbage) and die later inside
+/// xcodebuild with a worse message.
 pub fn container(ctx: &Context) -> Result<Container, CliError> {
     let must_exist = |path: &Path, flag: &str| -> Result<(), CliError> {
         if path.exists() {
@@ -94,24 +102,55 @@ pub fn container(ctx: &Context) -> Result<Container, CliError> {
         must_exist(proj, "--project")?;
         return Ok(Container::Project(proj.clone()));
     }
+    if let Some(declared) = declared_container(ctx) {
+        if !declared.path().exists() {
+            return Err(declared_missing(ctx, &declared));
+        }
+        return Ok(declared);
+    }
     let cwd =
         std::env::current_dir().map_err(|e| CliError::new(format!("cannot read cwd: {e}")))?;
-    let found = discover_walk_up(&cwd);
+    let (found, repo_root) = discover_walk_up(&cwd);
     if let Some(ambiguous) = found.ambiguity() {
         ctx.out.warn(&ambiguous);
     }
-    found.best().ok_or_else(|| {
-        CliError::new(
-            "no .xcworkspace, .xcodeproj, or Package.swift found in the current \
-             directory or its ancestors (pass --workspace/--project)",
-        )
-        .kind(ErrorKind::TargetResolution)
-    })
+    if let Some(container) = found.best() {
+        return Ok(container);
+    }
+    let (hits, base) = scan_below(&cwd, repo_root.as_deref());
+    let [hit] = hits.as_slice() else {
+        return Err(if hits.is_empty() {
+            nothing_found()
+        } else {
+            ambiguous_below(&hits, &base, &cwd)
+        });
+    };
+    if let Some(ambiguous) = hit.ambiguity() {
+        ctx.out.warn(&ambiguous);
+    }
+    let container = hit.best().ok_or_else(nothing_found)?;
+    // The user didn't point at this project, so say which one answered —
+    // building something unnamed without a word is how the wrong app ships.
+    let where_ = if base == cwd {
+        "below the current directory".to_string()
+    } else {
+        format!("in {}", relative_to(&base, &cwd))
+    };
+    ctx.out.note(&format!(
+        "using {} (found {where_})",
+        relative_to(container.path(), &base)
+    ));
+    Ok(container)
 }
 
 /// The container the bare-`sweetpad` gate probes — the same resolution as
 /// [`container`], minus the ambiguity warning: the status view resolves again
 /// immediately after and warns exactly once.
+///
+/// Several projects below the working directory read as "no container" here,
+/// so a bare `sweetpad` shows the help wall rather than choosing one. The
+/// probe has nowhere to put a question, and `sweetpad status` reports the
+/// ambiguity properly a keystroke later.
 #[must_use]
 pub fn container_silently(ctx: &Context) -> Option<Container> {
     if let Some(ws) = &ctx.targeting.workspace {
@@ -120,8 +159,53 @@ pub fn container_silently(ctx: &Context) -> Option<Container> {
     if let Some(proj) = &ctx.targeting.project {
         return Some(Container::Project(proj.clone()));
     }
+    // A declared container rides through even when the path is missing, so the
+    // status view reports what the file promised instead of the help wall.
+    if let Some(declared) = declared_container(ctx) {
+        return Some(declared);
+    }
     let cwd = std::env::current_dir().ok()?;
-    discover_walk_up(&cwd).best()
+    let (found, repo_root) = discover_walk_up(&cwd);
+    if let Some(container) = found.best() {
+        return Some(container);
+    }
+    match scan_below(&cwd, repo_root.as_deref()).0.as_slice() {
+        [hit] => hit.best(),
+        _ => None,
+    }
+}
+
+/// The container named by the nearest committed `sweetpad.toml`, if it names
+/// one. Sits between the flag layer and auto-discovery: a typed
+/// `--workspace`/`--project` still redirects the whole command elsewhere.
+fn declared_container(ctx: &Context) -> Option<Container> {
+    ctx.root_file()
+        .and_then(crate::cli::config::RootFile::declared)
+}
+
+/// The error for a `sweetpad.toml` naming a container that isn't there. A
+/// generated project is the common cause, and the file's own `generator` key
+/// says which tool to run — a far better answer than "nothing found here".
+fn declared_missing(ctx: &Context, declared: &Container) -> CliError {
+    let key = match declared {
+        Container::Workspace(_) => "workspace",
+        _ => "project",
+    };
+    let hint = match ctx
+        .root_file()
+        .and_then(|r| r.file.generator.as_deref())
+        .map(str::trim)
+    {
+        Some("xcodegen") => " — run 'xcodegen generate' to generate it".to_string(),
+        Some("tuist") => " — run 'tuist generate' to generate it".to_string(),
+        Some(tool) if !tool.is_empty() => format!(" — generated by {tool}; run it first"),
+        _ => String::new(),
+    };
+    CliError::new(format!(
+        "sweetpad.toml declares {key} {}, which does not exist{hint}",
+        declared.path().display()
+    ))
+    .kind(ErrorKind::TargetResolution)
 }
 
 /// Walk from `start` up toward the root, returning the first directory whose
@@ -129,16 +213,25 @@ pub fn container_silently(ctx: &Context) -> Option<Container> {
 /// `Sources/Feature/` like git/cargo/npm would. The walk stops at the git root
 /// (a repository above this one must not donate its project) and at the
 /// filesystem root.
-fn discover_walk_up(start: &Path) -> Discovery {
+///
+/// The second value is the repository root the walk stopped at, which the
+/// downward scan needs as its widest search boundary. It is `None` when the
+/// walk ended without meeting a `.git` — scanning down from the filesystem
+/// root is never something to do — and when a container turned up first, since
+/// then the walk stopped before learning where the repository begins.
+fn discover_walk_up(start: &Path) -> (Discovery, Option<PathBuf>) {
     let mut dir = start.to_path_buf();
     loop {
         let found = discover_all(&dir);
-        if found.best().is_some() || dir.join(".git").exists() {
-            return found;
+        if found.best().is_some() {
+            return (found, None);
+        }
+        if dir.join(".git").exists() {
+            return (found, Some(dir));
         }
         match dir.parent() {
             Some(parent) => dir = parent.to_path_buf(),
-            None => return found,
+            None => return (found, None),
         }
     }
 }
@@ -217,6 +310,146 @@ fn discover_all(dir: &Path) -> Discovery {
     found.workspaces.sort();
     found.projects.sort();
     found
+}
+
+/// How far below a directory the downward scan looks. One level reaches the
+/// layouts that motivate it at all (`ios/App.xcodeproj`,
+/// `Sources/App.xcodeproj`), two reaches `apps/ios/App.xcodeproj`; past that
+/// the cost and the odds of picking the wrong project both climb, and naming
+/// the container in `sweetpad.toml` is the better answer.
+const MAX_SCAN_DEPTH: usize = 2;
+
+/// Build output and vendored dependency trees, which hold projects that are
+/// never the one meant — `Pods/Pods.xcodeproj` above all.
+const VENDORED_DIRS: [&str; 6] = [
+    "node_modules",
+    "Pods",
+    "Carthage",
+    "vendor",
+    "DerivedData",
+    "build",
+];
+
+/// Directories the scan never enters: [vendored trees](VENDORED_DIRS), dotted
+/// directories, and bundles — which are directories on macOS and so would
+/// otherwise be walked like ordinary ones.
+fn skip_dir(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return true;
+    };
+    if name.starts_with('.') {
+        return true;
+    }
+    VENDORED_DIRS.contains(&name)
+        || matches!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("xcodeproj" | "xcworkspace" | "app" | "framework" | "bundle" | "playground")
+        )
+}
+
+/// Search below `root`, breadth-first, returning one [`Discovery`] per
+/// directory at the shallowest level that holds anything — a project one level
+/// down beats three of them two levels down, the same "nearest wins" the
+/// upward walk applies. More than one entry means directories tied at that
+/// depth, which is the ambiguity no policy should silently resolve.
+///
+/// Symlinks are skipped for free: [`std::fs::DirEntry::file_type`] doesn't
+/// follow them, so a link to a directory never reports `is_dir`, and the scan
+/// can't cycle or escape the tree it was pointed at.
+fn scan_down(root: &Path) -> Vec<Discovery> {
+    let mut frontier = vec![root.to_path_buf()];
+    for _ in 0..MAX_SCAN_DEPTH {
+        let mut hits = Vec::new();
+        let mut next = Vec::new();
+        for parent in &frontier {
+            let Ok(entries) = std::fs::read_dir(parent) else {
+                continue;
+            };
+            let mut dirs: Vec<PathBuf> = entries
+                .flatten()
+                .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+                .map(|e| e.path())
+                .filter(|p| !skip_dir(p))
+                .collect();
+            // Sorted so a same-depth tie resolves the same way on every
+            // machine, `read_dir` order being arbitrary.
+            dirs.sort();
+            for dir in dirs {
+                let found = discover_all(&dir);
+                if found.best().is_some() {
+                    hits.push(found);
+                } else {
+                    next.push(dir);
+                }
+            }
+        }
+        if !hits.is_empty() {
+            return hits;
+        }
+        frontier = next;
+    }
+    Vec::new()
+}
+
+/// Look below the working directory, then below the repository root — nearest
+/// first, so standing next to one project doesn't surface every project in the
+/// repository. The second sweep is what makes a command work from a sibling
+/// directory (`App/Scripts/`) rather than only from the root above the
+/// container.
+/// Returns the hits alongside the directory they were found under, which the
+/// caller needs to describe them: paths read relative to that base, and the
+/// wording differs between "below where you are" and "elsewhere in the repo".
+fn scan_below(cwd: &Path, repo_root: Option<&Path>) -> (Vec<Discovery>, PathBuf) {
+    let hits = scan_down(cwd);
+    if !hits.is_empty() {
+        return (hits, cwd.to_path_buf());
+    }
+    match repo_root {
+        Some(root) if root != cwd => (scan_down(root), root.to_path_buf()),
+        _ => (Vec::new(), cwd.to_path_buf()),
+    }
+}
+
+/// The error when nothing was found anywhere — the plain "no project here".
+fn nothing_found() -> CliError {
+    CliError::new(
+        "no .xcworkspace, .xcodeproj, or Package.swift found in the current \
+         directory, its ancestors, or below it (pass --workspace/--project)",
+    )
+    .kind(ErrorKind::TargetResolution)
+}
+
+/// The error when the scan found projects in several directories at the same
+/// depth. Unlike same-kind siblings in the working directory, there's no
+/// standing-here signal to justify a policy pick, so this lists what it found
+/// and names both ways to settle it.
+fn ambiguous_below(hits: &[Discovery], base: &Path, cwd: &Path) -> CliError {
+    let mut candidates: Vec<String> = hits
+        .iter()
+        .filter_map(Discovery::best)
+        .map(|c| relative_to(c.path(), base))
+        .collect();
+    candidates.sort();
+    let where_ = if base == cwd {
+        "below the current directory".to_string()
+    } else {
+        format!("in {}", relative_to(base, cwd))
+    };
+    CliError::new(format!(
+        "several projects {where_} ({}) — pass --workspace/--project, or name \
+         one in sweetpad.toml with 'project = \"…\"'",
+        candidates.join(", ")
+    ))
+    .kind(ErrorKind::TargetResolution)
+}
+
+/// A path written relative to `base` when it sits under it, else in full — the
+/// short form for the common case without ever printing something misleading.
+fn relative_to(path: &Path, base: &Path) -> String {
+    path.strip_prefix(base)
+        .unwrap_or(path)
+        .display()
+        .to_string()
 }
 
 /// The fully resolved targeting for a command, after layering.
@@ -1613,6 +1846,7 @@ mod tests {
             state: State::default(),
             out,
             project_toml: std::cell::OnceCell::new(),
+            root_toml: std::cell::OnceCell::new(),
         }
     }
 
@@ -1670,6 +1904,158 @@ mod tests {
         let dir = temp_dir("empty");
         assert!(discover(&dir).is_none());
         std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// The single container a scan settled on, or `None` when it found nothing
+    /// or couldn't choose.
+    fn scanned(root: &std::path::Path) -> Option<Container> {
+        match scan_down(root).as_slice() {
+            [hit] => hit.best(),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn scan_down_finds_a_project_below_the_search_root() {
+        let root = temp_dir("below");
+        std::fs::create_dir_all(root.join("Scripts")).unwrap();
+        std::fs::create_dir_all(root.join("Sources/App.xcodeproj")).unwrap();
+
+        assert_eq!(
+            scanned(&root).map(|c| c.path().to_path_buf()),
+            Some(root.join("Sources/App.xcodeproj"))
+        );
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn scan_down_stops_at_the_shallowest_level_that_has_anything() {
+        let root = temp_dir("shallow");
+        std::fs::create_dir_all(root.join("ios/App.xcodeproj")).unwrap();
+        // Two candidates a level deeper would be ambiguous on their own; the
+        // nearer one settles it before they are ever considered.
+        std::fs::create_dir_all(root.join("nested/one/One.xcodeproj")).unwrap();
+        std::fs::create_dir_all(root.join("nested/two/Two.xcodeproj")).unwrap();
+
+        assert_eq!(
+            scanned(&root).map(|c| c.path().to_path_buf()),
+            Some(root.join("ios/App.xcodeproj"))
+        );
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn scan_down_prefers_a_workspace_within_one_directory() {
+        let root = temp_dir("wsdir");
+        std::fs::create_dir_all(root.join("ios/App.xcodeproj")).unwrap();
+        std::fs::create_dir_all(root.join("ios/App.xcworkspace")).unwrap();
+
+        // The CocoaPods/React Native layout: one directory, both kinds, and no
+        // ambiguity to report — the workspace wins as it does anywhere else.
+        assert!(matches!(scanned(&root), Some(Container::Workspace(_))));
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn scan_down_refuses_to_choose_between_directories_at_one_depth() {
+        let root = temp_dir("tied");
+        std::fs::create_dir_all(root.join("ios/Runner.xcodeproj")).unwrap();
+        std::fs::create_dir_all(root.join("macos/Runner.xcodeproj")).unwrap();
+
+        assert_eq!(scan_down(&root).len(), 2);
+        assert!(scanned(&root).is_none());
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn scan_down_skips_vendored_and_hidden_directories() {
+        let root = temp_dir("vendored");
+        for junk in [
+            "Pods/Pods.xcodeproj",
+            "node_modules/pkg/Pkg.xcodeproj",
+            "build/Stale.xcodeproj",
+            ".hidden/Hidden.xcodeproj",
+            "Carthage/Checkouts/Dep.xcodeproj",
+        ] {
+            std::fs::create_dir_all(root.join(junk)).unwrap();
+        }
+        assert!(scanned(&root).is_none());
+
+        // The real project is found through the same noise.
+        std::fs::create_dir_all(root.join("Sources/App.xcodeproj")).unwrap();
+        assert_eq!(
+            scanned(&root).map(|c| c.path().to_path_buf()),
+            Some(root.join("Sources/App.xcodeproj"))
+        );
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn scan_down_does_not_reach_past_its_depth_limit() {
+        let root = temp_dir("deep");
+        std::fs::create_dir_all(root.join("a/b/c/Deep.xcodeproj")).unwrap();
+        assert!(scanned(&root).is_none());
+
+        // One level shallower is within reach.
+        std::fs::create_dir_all(root.join("x/y/Reachable.xcodeproj")).unwrap();
+        assert_eq!(
+            scanned(&root).map(|c| c.path().to_path_buf()),
+            Some(root.join("x/y/Reachable.xcodeproj"))
+        );
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn scan_below_widens_to_the_repository_root() {
+        let root = temp_dir("widen");
+        std::fs::create_dir_all(root.join("Scripts")).unwrap();
+        std::fs::create_dir_all(root.join("Sources/App.xcodeproj")).unwrap();
+
+        // Nothing below the sibling directory the command ran from, so the
+        // sweep widens to the repository root and finds the project there.
+        let from = root.join("Scripts");
+        assert!(scan_down(&from).is_empty());
+        let (hits, base) = scan_below(&from, Some(&root));
+        assert_eq!(
+            hits.first()
+                .and_then(Discovery::best)
+                .map(|c| c.path().to_path_buf()),
+            Some(root.join("Sources/App.xcodeproj"))
+        );
+        // The base rides back so the caller can say where it looked.
+        assert_eq!(base, root);
+
+        // Without a repository root there is nothing to widen to — scanning
+        // down from the filesystem root is never the answer.
+        assert!(scan_below(&from, None).0.is_empty());
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn walk_up_reports_the_repository_root_it_stopped_at() {
+        let root = temp_dir("repo");
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::create_dir_all(root.join("Scripts")).unwrap();
+
+        let (found, repo_root) = discover_walk_up(&root.join("Scripts"));
+        assert!(found.best().is_none());
+        assert_eq!(repo_root.as_deref(), Some(root.as_path()));
+
+        // A container found on the way up ends the walk before the repository
+        // root is known, and none is reported.
+        std::fs::create_dir_all(root.join("Scripts/App.xcodeproj")).unwrap();
+        let (found, repo_root) = discover_walk_up(&root.join("Scripts"));
+        assert!(found.best().is_some());
+        assert!(repo_root.is_none());
+
+        std::fs::remove_dir_all(&root).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Discovery only ever walked up, so a project in a subdirectory was unreachable from the repository root without -C on every command. It now also scans two levels down from the working directory and then the repository root, skipping vendored and build trees, and errors with the candidates listed rather than guessing when several tie at one depth. A committed sweetpad.toml is now found by walking up rather than only beside its container, and can name its project outright with a workspace/project key, which settles those ties and covers layouts the scan should not reach.