### PR TITLE
Stop losing compiler arguments for headers, symlinks and CLI builds

### DIFF
--- a/sweetpad-cli/src/cli/commands/app.rs
+++ b/sweetpad-cli/src/cli/commands/app.rs
@@ -812,6 +812,7 @@ impl RunPlan {
             clean: false,
             hot: self.hot,
             hot_entitlements: self.hot_entitlements.as_deref(),
+            result_bundle: Some(xcodebuild::build_result_bundle(&self.resolved.container)),
             passthrough: &self.passthrough,
         }
     }
@@ -2647,7 +2648,11 @@ enum BuildOutcome {
 /// which keeps the session open to fix and rebuild.
 fn build(plan: &RunPlan, out: &Output, capture: Option<&std::path::Path>) -> BuildOutcome {
     use std::io::Write as _;
-    let (parts, cwd) = plan.build_plan().command();
+    let build_plan = plan.build_plan();
+    // This path spawns xcodebuild itself rather than going through
+    // `BuildPlan::run`, so it owns the slot cleanup too.
+    build_plan.prepare_result_bundle();
+    let (parts, cwd) = build_plan.command();
     let args: Vec<&str> = parts.iter().map(String::as_str).collect();
     let (mut child, reader) = match process::spawn_piped_group("xcodebuild", &args, cwd.as_deref())
     {

--- a/sweetpad-cli/src/cli/commands/build.rs
+++ b/sweetpad-cli/src/cli/commands/build.rs
@@ -258,6 +258,7 @@ fn start(
         clean,
         hot: false,
         hot_entitlements: None,
+        result_bundle: Some(xcodebuild::build_result_bundle(&resolved.container)),
         passthrough,
     };
 

--- a/sweetpad-cli/src/cli/xcodebuild.rs
+++ b/sweetpad-cli/src/cli/xcodebuild.rs
@@ -34,6 +34,13 @@ pub struct BuildPlan<'a> {
     /// `--hot-entitlements` file) that `CODE_SIGN_ENTITLEMENTS=…` points the
     /// signing at. Only emitted for a hot macOS build.
     pub hot_entitlements: Option<&'a Path>,
+    /// Where the run's `.xcresult` goes. Nothing here reads it: it is passed
+    /// because `xcodebuild` writes the build's `.xcactivitylog` only when
+    /// `-resultBundlePath` is given, and that log is the sole input
+    /// `xcode-build-server` has for a file's compiler arguments. A build without
+    /// it leaves the editor's index stale, so autocomplete degrades to "cannot
+    /// find <Foundation/Foundation.h>" while the build itself succeeds.
+    pub result_bundle: Option<PathBuf>,
     /// Extra arguments passed through to xcodebuild verbatim (everything after
     /// `--` on the command line) — the escape hatch for flags/settings the CLI
     /// doesn't model.
@@ -60,6 +67,10 @@ impl BuildPlan<'_> {
         if let Some(sdk) = self.sdk {
             args.push("-sdk".into());
             args.push(sdk.into());
+        }
+        if let Some(bundle) = &self.result_bundle {
+            args.push("-resultBundlePath".into());
+            args.push(bundle.display().to_string());
         }
         args.extend(container_args(self.container));
         if self.hot {
@@ -98,6 +109,20 @@ impl BuildPlan<'_> {
         (self.args(), working_dir(self.container))
     }
 
+    /// Clear the result-bundle slot: `xcodebuild` refuses to write into a path
+    /// that already exists, and the slot is reused across builds. Call this
+    /// immediately before spawning — never on the `--show-command` path, which
+    /// must not touch state.
+    pub fn prepare_result_bundle(&self) {
+        let Some(bundle) = &self.result_bundle else {
+            return;
+        };
+        let _ = std::fs::remove_dir_all(bundle);
+        if let Some(parent) = bundle.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+    }
+
     /// Run the build. Human mode beautifies xcodebuild's output via
     /// [`buildlog`]; `-v` passes it through raw; `--json` captures both child
     /// streams (nothing interleaves with the envelope) and folds the tail of
@@ -106,6 +131,7 @@ impl BuildPlan<'_> {
     /// Every mode but `-v` records the parsed diagnostics as the project's
     /// last-build artifact for `build diagnostics`.
     pub fn run(&self, out: &Output) -> Result<Option<buildlog::StreamStats>, CliError> {
+        self.prepare_result_bundle();
         let parts = self.args();
         let args: Vec<&str> = parts.iter().map(String::as_str).collect();
         let cwd = working_dir(self.container);
@@ -354,6 +380,13 @@ impl TestPlan<'_> {
 /// than `DefaultHasher`, whose algorithm is unspecified across Rust releases —
 /// a toolchain bump must not orphan every retained bundle and diagnostics
 /// artifact.
+/// The result-bundle slot a build writes into: one per project, in the state
+/// dir. See [`BuildPlan::result_bundle`] for why a build asks for one at all.
+#[must_use]
+pub fn build_result_bundle(container: &Container) -> PathBuf {
+    project_artifact(container, "-build.xcresult")
+}
+
 pub(crate) fn project_artifact(container: &Container, suffix: &str) -> std::path::PathBuf {
     let stem = container.path().file_stem().map_or_else(
         || "project".to_string(),
@@ -1365,6 +1398,7 @@ Test Suite 'All tests' passed at 2026-08-09 16:24:00.
             clean: true,
             hot: false,
             hot_entitlements: None,
+            result_bundle: None,
         };
         assert_eq!(
             plan.args(),
@@ -1396,6 +1430,7 @@ Test Suite 'All tests' passed at 2026-08-09 16:24:00.
             clean: false,
             hot: true,
             hot_entitlements: None,
+            result_bundle: None,
         };
         let args = plan.args();
         assert!(args.contains(&"OTHER_LDFLAGS=$(inherited) -Xlinker -interposable".to_string()));
@@ -1423,6 +1458,7 @@ Test Suite 'All tests' passed at 2026-08-09 16:24:00.
             clean: false,
             hot: true,
             hot_entitlements: None,
+            result_bundle: None,
         };
         let args = plan.args();
         assert!(args.contains(&"ENABLE_HARDENED_RUNTIME=NO".to_string()));
@@ -1438,6 +1474,7 @@ Test Suite 'All tests' passed at 2026-08-09 16:24:00.
             clean: false,
             hot: false,
             hot_entitlements: None,
+            result_bundle: None,
         };
         assert!(!cold.args().iter().any(|a| {
             a.starts_with("ENABLE_HARDENED_RUNTIME") || a.starts_with("ENABLE_APP_SANDBOX")
@@ -1458,6 +1495,7 @@ Test Suite 'All tests' passed at 2026-08-09 16:24:00.
             clean: false,
             hot: true,
             hot_entitlements: Some(stripped),
+            result_bundle: None,
         };
         let args = plan.args();
         let expected = "CODE_SIGN_ENTITLEMENTS=/cache/hot/Debug-nosandbox.entitlements";
@@ -1478,6 +1516,7 @@ Test Suite 'All tests' passed at 2026-08-09 16:24:00.
             clean: false,
             hot: true,
             hot_entitlements: Some(stripped),
+            result_bundle: None,
         };
         assert!(
             !sim.args()
@@ -1499,6 +1538,7 @@ Test Suite 'All tests' passed at 2026-08-09 16:24:00.
             clean: false,
             hot: false,
             hot_entitlements: None,
+            result_bundle: None,
         };
         assert_eq!(
             plan.args(),
@@ -1512,6 +1552,34 @@ Test Suite 'All tests' passed at 2026-08-09 16:24:00.
                 "/work/App.xcworkspace"
             ]
         );
+    }
+
+    #[test]
+    fn build_args_carry_the_result_bundle() {
+        // Not cosmetic: `xcodebuild` writes the build's `.xcactivitylog` only
+        // when asked for a result bundle, and that log is the only thing
+        // `xcode-build-server` can read compiler arguments out of. Drop the flag
+        // and every CLI build silently stops feeding the editor's index.
+        let c = Container::Project(PathBuf::from("/work/App.xcodeproj"));
+        let bundle = PathBuf::from("/state/App-build.xcresult");
+        let plan = BuildPlan {
+            container: &c,
+            scheme: "App",
+            configuration: "Debug",
+            destination: Some("platform=macOS"),
+            passthrough: &[],
+            sdk: None,
+            clean: false,
+            hot: false,
+            hot_entitlements: None,
+            result_bundle: Some(bundle.clone()),
+        };
+        let args = plan.args();
+        let at = args
+            .iter()
+            .position(|a| a == "-resultBundlePath")
+            .expect("build asks for a result bundle");
+        assert_eq!(args[at + 1], bundle.display().to_string());
     }
 
     #[test]

--- a/sweetpad-core/src/bsp/mod.rs
+++ b/sweetpad-core/src/bsp/mod.rs
@@ -27,7 +27,7 @@ use crate::build_context::BuildContext;
 use crate::build_settings::{self, BuildSettingsOptions};
 use crate::framing::{read_message, write_message};
 use control::{LogLevel, TelemetryServer};
-use sweetpad_lib::project;
+use sweetpad_lib::{compiler_args, project};
 
 /// Write a `buildServer.json` so `sourcekit-lsp` discovers and launches this
 /// server. Its `argv` is the current executable followed by
@@ -1084,12 +1084,13 @@ impl Server {
             .and_then(Value::as_str)
             .map(path_from_uri)
             .unwrap_or_default();
+        let standardized = project::standardize(&path);
         // Re-read the target list (not the startup snapshot) so files in a
         // target added after `buildTarget/didChange` resolve to an owner.
         let owning: Vec<Value> = self
             .current_targets()
             .iter()
-            .filter(|t| self.source_files(t).contains(&path))
+            .filter(|t| sources_contain(&self.source_files(t), &path, &standardized))
             .map(|t| target_id(t))
             .collect();
         json!({ "targets": owning })
@@ -1107,8 +1108,17 @@ impl Server {
             .unwrap_or("");
         let path = path_from_uri(uri);
 
+        // A header is not a build input — it belongs to no `PBXSourcesBuildPhase`,
+        // so no target's source list names it — and its extension tells clang
+        // nothing about the dialect inside. Answer it from a translation unit
+        // that would include it instead.
+        if is_header(&path) {
+            return self.header_options(&path);
+        }
+
         // The owning target: the request's `target`, else the first whose source
         // list contains the file.
+        let standardized = project::standardize(&path);
         let target = params
             .get("target")
             .and_then(|t| t.get("uri"))
@@ -1117,7 +1127,7 @@ impl Server {
             .or_else(|| {
                 self.current_targets()
                     .into_iter()
-                    .find(|t| self.source_files(t).contains(&path))
+                    .find(|t| sources_contain(&self.source_files(t), &path, &standardized))
             });
 
         let Some(target) = target else {
@@ -1134,6 +1144,90 @@ impl Server {
             "compilerArguments": args,
             "workingDirectory": self.project_dir().to_string_lossy(),
         })
+    }
+
+    /// The editor arguments for a header: its companion translation unit's
+    /// invocation, retargeted at the header. Everything a header needs to parse
+    /// — the sysroot, the include and framework search paths, the language
+    /// dialect — is a property of the sources that include it, never of the
+    /// header itself, so the companion's arguments are the answer. Returns null
+    /// when the project has no clang source to borrow from.
+    fn header_options(&self, header: &Path) -> Value {
+        let Some((target, companion)) = self.header_companion(header) else {
+            self.log(&format!(
+                "sourceKitOptions: no clang source to borrow arguments from for {}",
+                header.display()
+            ));
+            return Value::Null;
+        };
+        let (sdk, arch) = self.editor_platform(&target);
+        let opts = self.options_for(&target, &sdk, &arch);
+        let inv = match build_settings::resolve_file_arguments(&opts, &companion) {
+            Ok(inv) => inv,
+            Err(e) => {
+                self.log(&format!(
+                    "resolve failed: target={target} header={} companion={} err={e}",
+                    header.display(),
+                    companion.display()
+                ));
+                return Value::Null;
+            }
+        };
+        let mut args = editor_arguments(&inv.arguments);
+        // Left to itself clang reads a `.h` as a plain C header and rejects the
+        // ObjC or C++ it finds, so name the dialect the companion compiles as.
+        // A later `-x` wins over any the companion's own arguments carry.
+        args.push("-x".into());
+        args.push(header_dialect(&companion).into());
+        args.push(header.to_string_lossy().into_owned());
+        self.log(&format!(
+            "sourceKitOptions: target={target} header={} companion={} args={}",
+            header.display(),
+            companion.display(),
+            args.len(),
+        ));
+        json!({
+            "compilerArguments": args,
+            "workingDirectory": self.project_dir().to_string_lossy(),
+        })
+    }
+
+    /// The translation unit whose arguments stand in for `header`: the sibling
+    /// with the same stem (`Foo.h` → `Foo.m`), else any clang source in the same
+    /// directory, else the project's first clang source. Nearest first — the
+    /// closer the companion, the likelier it shares the header's search paths
+    /// and dialect. A `.swift` file is never a companion: it compiles through
+    /// swiftc, whose arguments say nothing about how to parse a header.
+    fn header_companion(&self, header: &Path) -> Option<(String, PathBuf)> {
+        // Source paths are built on a canonicalized project dir while the editor
+        // spells the header however the user opened it, so accept a source that
+        // sits beside either spelling.
+        let standardized = project::standardize(header);
+        let dirs: Vec<&Path> = [header.parent(), standardized.parent()]
+            .into_iter()
+            .flatten()
+            .collect();
+        let stem = header.file_stem();
+
+        let mut in_dir: Option<(String, PathBuf)> = None;
+        let mut anywhere: Option<(String, PathBuf)> = None;
+        for target in self.current_targets() {
+            for source in self.source_files(&target) {
+                if !is_clang_source(&source) {
+                    continue;
+                }
+                let beside = source.parent().is_some_and(|p| dirs.contains(&p));
+                if beside && source.file_stem() == stem {
+                    return Some((target, source));
+                }
+                if beside && in_dir.is_none() {
+                    in_dir = Some((target.clone(), source.clone()));
+                } else if anywhere.is_none() {
+                    anywhere = Some((target.clone(), source));
+                }
+            }
+        }
+        in_dir.or(anywhere)
     }
 
     /// The targets named in a `{ targets: [{uri}] }` param, or all targets.
@@ -1335,6 +1429,56 @@ fn file_uri(path: &Path) -> String {
 
 fn path_from_uri(uri: &str) -> PathBuf {
     PathBuf::from(percent_decode(uri.strip_prefix("file://").unwrap_or(uri)))
+}
+
+/// Header extensions an editor opens. None of them name a build input, so a
+/// file with one of these never appears in a target's source list.
+const HEADER_EXTS: &[&str] = &["h", "hh", "hpp", "hxx", "pch", "inl"];
+
+fn is_header(path: &Path) -> bool {
+    extension_of(path).is_some_and(|e| HEADER_EXTS.contains(&e.as_str()))
+}
+
+/// Whether `path` is a C-family source, judged by the same extension table that
+/// decides how the build compiles it.
+fn is_clang_source(path: &Path) -> bool {
+    !compiler_args::clang_languages(std::slice::from_ref(&path.to_string_lossy().into_owned()))
+        .is_empty()
+}
+
+/// The clang `-x` dialect a header should parse as, taken from the companion
+/// translation unit's language. Objective-C is the fallback because it accepts
+/// plain C too, so a header of unknown provenance still parses.
+fn header_dialect(companion: &Path) -> &'static str {
+    let langs = compiler_args::clang_languages(std::slice::from_ref(
+        &companion.to_string_lossy().into_owned(),
+    ));
+    match langs.iter().next().map(String::as_str) {
+        Some("sourcecode.cpp.objcpp") => "objective-c++-header",
+        Some("sourcecode.cpp.cpp") => "c++-header",
+        Some("sourcecode.c.c") => "c-header",
+        _ => "objective-c-header",
+    }
+}
+
+/// A path's extension, lowercased — extensions are matched case-insensitively
+/// because a case-insensitive filesystem lets a project spell `.h` as `.H`.
+fn extension_of(path: &Path) -> Option<String> {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase)
+}
+
+/// Whether `sources` names `path`. The editor spells a path however the user
+/// opened the file — through a symlinked checkout, or with `..` segments —
+/// while a target's source list is built on a canonicalized project dir, so an
+/// exact comparison misses files that are plainly there. Compare exactly first
+/// (the common case, no syscalls), then by standardized spelling.
+fn sources_contain(sources: &[PathBuf], path: &Path, standardized: &Path) -> bool {
+    sources.iter().any(|s| s == path)
+        || sources
+            .iter()
+            .any(|s| project::standardize(s) == standardized)
 }
 
 /// Append `s` to `out` percent-encoded: RFC 3986 unreserved bytes and `/` pass

--- a/sweetpad-core/tests/bsp_conformance.rs
+++ b/sweetpad-core/tests/bsp_conformance.rs
@@ -275,6 +275,79 @@ fn bsp_per_file_clang_dialect() {
     assert!(args.contains(&"-I"), "no header search path: {args:?}");
 }
 
+/// A header belongs to no build phase, so no target's source list names it.
+/// It still has to answer with the sysroot, search paths and dialect of the
+/// translation unit that includes it — otherwise the editor reports every
+/// `#import <Foundation/Foundation.h>` as a missing file.
+#[test]
+fn bsp_header_borrows_its_companions_arguments() {
+    let root = env!("SWEETPAD_LIB_DIR");
+    let dir = format!("{root}/fixtures/_synthetic-objc-headers/project");
+    let proj = format!("{dir}/ObjCHeaders.xcodeproj");
+    let h_uri = format!("file://{dir}/include/widget.h");
+    let messages = vec![
+        json!({"jsonrpc":"2.0","id":1,"method":"build/initialize","params":{}}),
+        json!({"jsonrpc":"2.0","method":"build/initialized"}),
+        json!({"jsonrpc":"2.0","id":5,"method":"textDocument/sourceKitOptions","params":{"textDocument":{"uri":h_uri}}}),
+        json!({"jsonrpc":"2.0","method":"build/exit"}),
+    ];
+    let frames = run_session(&messages, &proj);
+    let args: Vec<&str> = result_for(&frames, 5)
+        .and_then(|r| r.get("compilerArguments"))
+        .and_then(Value::as_array)
+        .expect("a header gets compilerArguments")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    // The dialect must be a *header* dialect, and it must be the last `-x` so
+    // it outranks the one the companion's own arguments carry.
+    let last_x = args
+        .iter()
+        .rposition(|a| *a == "-x")
+        .expect("a dialect is named");
+    assert_eq!(args[last_x + 1], "objective-c-header", "{args:?}");
+    assert!(args.contains(&"-isysroot"), "no sysroot: {args:?}");
+    assert!(args.contains(&"-I"), "no header search path: {args:?}");
+    // The header itself is the input, not the companion it borrowed from.
+    assert!(
+        args.last().is_some_and(|a| a.ends_with("include/widget.h")),
+        "header is not the input: {args:?}"
+    );
+}
+
+/// The editor spells a path however the user opened the file. A `..` segment
+/// names exactly the same source as the target's own canonical spelling, so it
+/// must resolve to the same arguments rather than falling off the source list.
+#[test]
+fn bsp_source_resolves_through_an_unnormalized_spelling() {
+    let root = env!("SWEETPAD_LIB_DIR");
+    let dir = format!("{root}/fixtures/_synthetic-objc-headers/project");
+    let proj = format!("{dir}/ObjCHeaders.xcodeproj");
+    let dotted = format!("file://{dir}/include/../widget.m");
+    let messages = vec![
+        json!({"jsonrpc":"2.0","id":1,"method":"build/initialize","params":{}}),
+        json!({"jsonrpc":"2.0","method":"build/initialized"}),
+        json!({"jsonrpc":"2.0","id":5,"method":"textDocument/sourceKitOptions","params":{"textDocument":{"uri":dotted}}}),
+        json!({"jsonrpc":"2.0","id":6,"method":"buildTarget/inverseSources","params":{"textDocument":{"uri":dotted}}}),
+        json!({"jsonrpc":"2.0","method":"build/exit"}),
+    ];
+    let frames = run_session(&messages, &proj);
+    let args: Vec<&str> = result_for(&frames, 5)
+        .and_then(|r| r.get("compilerArguments"))
+        .and_then(Value::as_array)
+        .expect("a '..' spelling still gets compilerArguments")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(args.contains(&"-isysroot"), "no sysroot: {args:?}");
+    // The same spelling must also name its owning target.
+    let targets = result_for(&frames, 6)
+        .and_then(|r| r.get("targets").cloned())
+        .and_then(|t| t.as_array().cloned())
+        .expect("inverseSources answered");
+    assert_eq!(targets.len(), 1, "no owning target: {targets:?}");
+}
+
 /// A target consuming a Swift Package product gets the package-products
 /// framework search path (`-F …/PackageFrameworks`), and its source maps to the
 /// target — both through the server, hermetically (no build required).

--- a/sweetpad-docs/docs/vscode/autocomplete.md
+++ b/sweetpad-docs/docs/vscode/autocomplete.md
@@ -45,7 +45,7 @@ After that, autocomplete should work. ✅
 
 ## Setup with the built-in build server (experimental)
 
-If your project is a plain `.xcodeproj`, you can skip installing `xcode-build-server` entirely:
+If your project is an `.xcodeproj` or an `.xcworkspace`, you can skip installing `xcode-build-server` entirely:
 
 1. Run `> SweetPad: Set up Swift code intelligence (BSP)` from the command palette. This switches
    `sweetpad.buildServer.provider` to `sweetpad` and writes a `buildServer.json` that launches the bundled server.
@@ -55,8 +55,13 @@ If your project is a plain `.xcodeproj`, you can skip installing `xcode-build-se
 A few things to know:
 
 - The server runs on Node.js, so `node` must be on your `PATH`.
-- `.xcworkspace` and Swift Package projects aren't handled by the built-in server yet — SweetPad falls back to the
-  `xcode-build-server` flow for those.
+- An `.xcworkspace` resolves each file against whichever member project declares its target, so a CocoaPods or
+  multi-project workspace works the same as a single `.xcodeproj`.
+- A Swift package takes a different route: SourceKit-LSP reads `Package.swift` and indexes it natively, so SweetPad
+  writes no `buildServer.json` at all. If one is already sitting in the package directory, delete it — its presence
+  overrides that native support.
+- Headers borrow the sysroot, search paths and language dialect of a neighbouring source file — the `.m` beside
+  `Foo.h`, or the nearest one in the same folder — so a `.h` resolves even though no target compiles it directly.
 - The `buildServer.json` it writes points at a file inside the installed extension. After an extension update that
   path can go stale — if autocomplete stops working, re-run `> SweetPad: Generate Build Server Config`.
 

--- a/sweetpad-vscode/package.json
+++ b/sweetpad-vscode/package.json
@@ -1230,7 +1230,7 @@
           "default": "xcode-build-server",
           "markdownEnumDescriptions": [
             "The standard, battle-tested `xcode-build-server` (parses build logs).",
-            "SweetPad's own BSP server, which derives compiler arguments from the project (no build required to parse). Experimental — currently applies only to plain `.xcodeproj` projects; `.xcworkspace`/SPM fall back to `xcode-build-server`."
+            "SweetPad's own BSP server, which derives compiler arguments from the project (no build required to parse). Experimental. Handles `.xcodeproj` and `.xcworkspace`; a Swift package instead uses SourceKit-LSP's native SwiftPM support, for which no build server is written."
           ],
           "description": "Which build server backs sourcekit-lsp (writes buildServer.json)."
         },


### PR DESCRIPTION
sourceKitOptions returned nothing for a `.h` (no build phase lists one) and for any path spelled through a symlink or a `..` segment; a header now answers from the source beside it, and file matching falls back to the standardized spelling. On Xcode 26 `xcodebuild` writes the build's `.xcactivitylog` only when `-resultBundlePath` is passed — the extension does, the CLI did not, and without that log xcode-build-server has no compiler arguments for any file. Also corrects the docs claim that `.xcworkspace` and Swift packages fall back to xcode-build-server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPVutGcKGcyTD2rJFjAyhS
