### PR TITLE
Support multi-root VS Code workspaces in the extension

### DIFF
--- a/sweetpad-vscode/src/__mocks__/vscode.ts
+++ b/sweetpad-vscode/src/__mocks__/vscode.ts
@@ -19,6 +19,17 @@ export const workspace = {
   onDidChangeConfiguration: vi.fn(() => ({
     dispose: vi.fn(),
   })),
+  // Mirrors the real API: returns the workspace folder containing the given URI.
+  getWorkspaceFolder: vi.fn((uri: { fsPath: string }) => {
+    const folders = (workspace as { workspaceFolders?: { uri: { fsPath: string } }[] }).workspaceFolders;
+    return folders?.find(
+      (folder) => uri.fsPath === folder.uri.fsPath || uri.fsPath.startsWith(`${folder.uri.fsPath}/`),
+    );
+  }),
+};
+
+export const Uri = {
+  file: vi.fn((fsPath: string) => ({ fsPath })),
 };
 
 export const debug = {
@@ -32,4 +43,4 @@ export const DebugConfigurationProviderTriggerKind = {
 
 // Modules under test reach for vscode both as `import * as vscode` and as a default import;
 // the real extension host module satisfies both.
-export default { window, commands, workspace, debug, DebugConfigurationProviderTriggerKind };
+export default { window, commands, workspace, debug, DebugConfigurationProviderTriggerKind, Uri };

--- a/sweetpad-vscode/src/build/scheme-watcher.ts
+++ b/sweetpad-vscode/src/build/scheme-watcher.ts
@@ -3,10 +3,9 @@ import path from "node:path";
 import * as vscode from "vscode";
 
 import { getWorkspaceConfig } from "../common/config";
-import { isFileExists } from "../common/files";
 import { commonLogger } from "../common/logger";
 import type { BuildManager } from "./manager";
-import { getWorkspacePath, prepareDerivedDataPath } from "./utils";
+import { getWorkspacePath, isFileExistsInAnyWorkspaceFolder, prepareDerivedDataPath } from "./utils";
 
 export class SchemeWatcher implements vscode.Disposable {
   private watchers: vscode.FileSystemWatcher[] = [];
@@ -85,8 +84,7 @@ export class SchemeWatcher implements vscode.Disposable {
     this.watchers.push(schemeWatcher);
 
     // Watch for project.yml files (XcodeGen)
-    const workspacePath = getWorkspacePath();
-    const isProjectYmlExists = await isFileExists(path.join(workspacePath, "project.yml"));
+    const isProjectYmlExists = await isFileExistsInAnyWorkspaceFolder("project.yml");
     if (isProjectYmlExists) {
       const projectYmlWatcher = vscode.workspace.createFileSystemWatcher(
         "**/project.yml",
@@ -101,8 +99,8 @@ export class SchemeWatcher implements vscode.Disposable {
     }
 
     // Watch for Tuist files (Project.swift, Workspace.swift)
-    const isTuistProjectExists = await isFileExists(path.join(workspacePath, "Project.swift"));
-    const isTuistWorkspaceExists = await isFileExists(path.join(workspacePath, "Workspace.swift"));
+    const isTuistProjectExists = await isFileExistsInAnyWorkspaceFolder("Project.swift");
+    const isTuistWorkspaceExists = await isFileExistsInAnyWorkspaceFolder("Workspace.swift");
 
     if (isTuistProjectExists || isTuistWorkspaceExists) {
       const tuistWatcher = vscode.workspace.createFileSystemWatcher(

--- a/sweetpad-vscode/src/build/utils.spec.ts
+++ b/sweetpad-vscode/src/build/utils.spec.ts
@@ -1,10 +1,18 @@
+import { existsSync } from "node:fs";
+
 import type { Mock } from "vitest";
 import * as vscode from "vscode";
 
 import { generateBuildServerConfig, getSweetpadBspServerPath } from "../common/cli/scripts";
 import { isFileExists, readJsonFile } from "../common/files";
 import type { WorkspaceStateService } from "../common/workspace-state";
-import { generateBuildServerConfigOnBuild, launchActionToSettings } from "./utils";
+import {
+  generateBuildServerConfigOnBuild,
+  getCurrentXcodeWorkspacePath,
+  getWorkspacePath,
+  launchActionToSettings,
+  setActiveWorkspaceFolder,
+} from "./utils";
 
 // `./utils` imports the native `@sweetpad/native` addon at module level; stub it so
 // this spec runs without the compiled addon (none of the tested paths touch it).
@@ -19,6 +27,12 @@ vi.mock("../common/files", () => ({
   isFileExists: vi.fn(),
   readJsonFile: vi.fn(),
 }));
+
+// `./utils` reads `existsSync` to resolve relative configured paths across workspace folders.
+vi.mock("node:fs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs")>();
+  return { ...original, existsSync: vi.fn(original.existsSync) };
+});
 
 type ArgInput = { argument: string; isEnabled?: boolean };
 type EnvInput = { key: string; value?: string; isEnabled?: boolean };
@@ -180,5 +194,84 @@ describe("generateBuildServerConfigOnBuild (sweetpad provider)", () => {
     mockReadJsonFile.mockRejectedValue(new Error("ENOENT"));
     await run();
     expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("multi-root workspace path resolution", () => {
+  const mockGetConfiguration = vscode.workspace.getConfiguration as Mock;
+  const mockExistsSync = existsSync as Mock;
+
+  function setFolders(paths: string[]) {
+    (vscode.workspace as { workspaceFolders?: unknown }).workspaceFolders = paths.map((p) => ({
+      uri: { fsPath: p },
+    }));
+  }
+
+  function mockConfig(values: Record<string, unknown>) {
+    mockGetConfiguration.mockReturnValue({
+      get: vi.fn((key: string) => values[key]),
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfig({});
+    mockExistsSync.mockReturnValue(false);
+  });
+
+  it("defaults to the first workspace folder before any project is selected", () => {
+    setFolders(["/root-a", "/root-b"]);
+    expect(getWorkspacePath()).toBe("/root-a");
+  });
+
+  it("follows the folder containing the selected xcworkspace", () => {
+    setFolders(["/root-c", "/root-d"]);
+    setActiveWorkspaceFolder("/root-d/App/App.xcworkspace");
+    expect(getWorkspacePath()).toBe("/root-d");
+  });
+
+  it("keeps the current folder when the xcworkspace is outside every workspace folder", () => {
+    setFolders(["/root-e", "/root-f"]);
+    setActiveWorkspaceFolder("/root-f/App.xcworkspace");
+    // e.g. a git worktree next to the repo
+    setActiveWorkspaceFolder("/elsewhere/App.xcworkspace");
+    expect(getWorkspacePath()).toBe("/root-f");
+  });
+
+  it("falls back to the first folder when the active folder leaves the workspace", () => {
+    setFolders(["/root-g", "/root-h"]);
+    setActiveWorkspaceFolder("/root-h/App.xcworkspace");
+    setFolders(["/root-i"]);
+    expect(getWorkspacePath()).toBe("/root-i");
+  });
+
+  it("activates the folder of a cached xcworkspace from workspace state", () => {
+    setFolders(["/root-j", "/root-k"]);
+    const state = {
+      get: vi.fn(() => "/root-k/App.xcworkspace"),
+      update: vi.fn(),
+    } as unknown as WorkspaceStateService;
+
+    expect(getCurrentXcodeWorkspacePath(state)).toBe("/root-k/App.xcworkspace");
+    expect(getWorkspacePath()).toBe("/root-k");
+  });
+
+  it("resolves a relative configured path against the folder where it exists", () => {
+    setFolders(["/root-l", "/root-m"]);
+    mockConfig({ "build.xcodeWorkspacePath": "App.xcworkspace" });
+    mockExistsSync.mockImplementation((p: string) => p === "/root-m/App.xcworkspace");
+    const state = { get: vi.fn(), update: vi.fn() } as unknown as WorkspaceStateService;
+
+    expect(getCurrentXcodeWorkspacePath(state)).toBe("/root-m/App.xcworkspace");
+    expect(getWorkspacePath()).toBe("/root-m");
+  });
+
+  it("activates the folder of an absolute configured path", () => {
+    setFolders(["/root-n", "/root-o"]);
+    mockConfig({ "build.xcodeWorkspacePath": "/root-o/App.xcworkspace" });
+    const state = { get: vi.fn(), update: vi.fn() } as unknown as WorkspaceStateService;
+
+    expect(getCurrentXcodeWorkspacePath(state)).toBe("/root-o/App.xcworkspace");
+    expect(getWorkspacePath()).toBe("/root-o");
   });
 });

--- a/sweetpad-vscode/src/build/utils.ts
+++ b/sweetpad-vscode/src/build/utils.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import path from "node:path";
 
 import * as sweetpadLib from "@sweetpad/native";
@@ -231,14 +232,64 @@ export async function askSchemeForBuild(
 }
 
 /**
- * It's absolute path to current opened workspace
+ * Absolute paths of all VS Code workspace folders (a multi-root workspace has several).
+ */
+export function getWorkspaceFolderPaths(): string[] {
+  return vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath) ?? [];
+}
+
+/**
+ * The VS Code workspace folder that contains the given path, if any.
+ */
+export function getWorkspaceFolderForPath(fsPath: string): string | undefined {
+  return vscode.workspace.getWorkspaceFolder(vscode.Uri.file(fsPath))?.uri.fsPath;
+}
+
+// SweetPad operates on one Xcode project at a time. In a multi-root VS Code workspace the
+// project may live in any folder, so remember which folder contains the currently selected
+// xcworkspace and resolve every "workspace root" lookup against it instead of always
+// defaulting to the first folder.
+let activeWorkspaceFolder: string | undefined;
+
+/**
+ * Remember the VS Code workspace folder that contains the given xcworkspace so
+ * `getWorkspacePath()` resolves against it. No-op when the path is outside every folder
+ * (e.g. a git worktree next to the repo).
+ */
+export function setActiveWorkspaceFolder(xcworkspacePath: string): void {
+  const folder = getWorkspaceFolderForPath(xcworkspacePath);
+  if (folder && folder !== activeWorkspaceFolder) {
+    activeWorkspaceFolder = folder;
+    commonLogger.log("Active workspace folder changed", {
+      folder: folder,
+      xcworkspace: xcworkspacePath,
+    });
+  }
+}
+
+/**
+ * It's absolute path to the workspace folder SweetPad currently operates on: the folder
+ * containing the selected xcworkspace, or the first workspace folder before any selection.
  */
 export function getWorkspacePath(): string {
-  const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
-  if (!workspaceFolder) {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
     throw new ExtensionError("No workspace folder found");
   }
-  return workspaceFolder;
+  if (activeWorkspaceFolder && folders.some((folder) => folder.uri.fsPath === activeWorkspaceFolder)) {
+    return activeWorkspaceFolder;
+  }
+  return folders[0].uri.fsPath;
+}
+
+/**
+ * Check if a file exists in the root of any VS Code workspace folder.
+ */
+export async function isFileExistsInAnyWorkspaceFolder(fileName: string): Promise<boolean> {
+  const results = await Promise.all(
+    getWorkspaceFolderPaths().map((folder) => isFileExists(path.join(folder, fileName))),
+  );
+  return results.some(Boolean);
 }
 
 /**
@@ -294,14 +345,22 @@ export function getCurrentXcodeWorkspacePath(workspaceState: WorkspaceStateServi
   const configPath = getWorkspaceConfig("build.xcodeWorkspacePath");
   if (configPath) {
     workspaceState.update("build.xcodeWorkspacePath", undefined);
+    let resolvedPath: string;
     if (path.isAbsolute(configPath)) {
-      return configPath;
+      resolvedPath = configPath;
+    } else {
+      // In a multi-root workspace a relative path may belong to any folder — pick the
+      // first one where it actually exists, falling back to the current root.
+      const candidates = getWorkspaceFolderPaths().map((folder) => path.join(folder, configPath));
+      resolvedPath = candidates.find((candidate) => existsSync(candidate)) ?? path.join(getWorkspacePath(), configPath);
     }
-    return path.join(getWorkspacePath(), configPath);
+    setActiveWorkspaceFolder(resolvedPath);
+    return resolvedPath;
   }
 
   const cachedPath = workspaceState.get("build.xcodeWorkspacePath");
   if (cachedPath) {
+    setActiveWorkspaceFolder(cachedPath);
     return cachedPath;
   }
 
@@ -534,27 +593,35 @@ export async function generateBuildServerConfigOnBuild(options: {
 }
 
 /**
- * Detect xcode workspace in the given directory
+ * Detect xcode workspaces in all VS Code workspace folders
  */
 export async function detectXcodeWorkspacesPaths(): Promise<string[]> {
-  const workspace = getWorkspacePath();
+  const folders = getWorkspaceFolderPaths();
+  if (folders.length === 0) {
+    throw new ExtensionError("No workspace folder found");
+  }
 
-  // Get all files that end with .xcworkspace or Package.swift (4 depth)
-  const paths = await findFilesRecursive({
-    directory: workspace,
-    depth: 4,
-    matcher: (file) => {
-      return file.name.endsWith(".xcworkspace") || file.name === "Package.swift";
-    },
-  });
-  return paths;
+  // Get all files that end with .xcworkspace or Package.swift (4 depth) in every folder
+  const results = await Promise.all(
+    folders.map((folder) =>
+      findFilesRecursive({
+        directory: folder,
+        depth: 4,
+        matcher: (file) => {
+          return file.name.endsWith(".xcworkspace") || file.name === "Package.swift";
+        },
+      }),
+    ),
+  );
+  return results.flat();
 }
 
 /**
- * Find xcode workspace in the given directory and ask user to select it
+ * Find xcode workspaces across all VS Code workspace folders and ask user to select one
  */
 export async function selectXcodeWorkspace(options: { autoselect: boolean }): Promise<string> {
-  const workspacePath = getWorkspacePath();
+  const folders = getWorkspaceFolderPaths();
+  const isMultiRoot = folders.length > 1;
 
   // Get all files that end with .xcworkspace (4 depth) and Package.swift files
   const paths = await detectXcodeWorkspacesPaths();
@@ -563,7 +630,7 @@ export async function selectXcodeWorkspace(options: { autoselect: boolean }): Pr
   if (paths.length === 0) {
     throw new ExtensionError("No xcode workspaces or SPM packages found", {
       context: {
-        cwd: workspacePath,
+        cwd: folders.join(", "),
       },
     });
   }
@@ -573,15 +640,21 @@ export async function selectXcodeWorkspace(options: { autoselect: boolean }): Pr
     const selectedPath = paths[0];
     const projectType = detectWorkspaceType(selectedPath);
     commonLogger.log("Project was detected", {
-      workspace: workspacePath,
+      workspace: getWorkspaceFolderForPath(selectedPath) ?? folders[0],
       path: selectedPath,
       projectType: projectType,
     });
+    setActiveWorkspaceFolder(selectedPath);
     return selectedPath;
   }
 
-  const podfilePath = path.join(workspacePath, "Podfile");
-  const isCocoaProject = await isFileExists(podfilePath);
+  // Which folders are CocoaPods projects (Podfile in their root)?
+  const cocoaPodsRoots = new Set<string>();
+  for (const folder of folders) {
+    if (await isFileExists(path.join(folder, "Podfile"))) {
+      cocoaPodsRoots.add(folder);
+    }
+  }
 
   // More then one, ask user to select
   const selected = await showQuickPick({
@@ -594,12 +667,13 @@ export async function selectXcodeWorkspace(options: { autoselect: boolean }): Pr
         return aDepth - bDepth;
       })
       .map((xwPath) => {
-        // show only relative path, to make it more readable
-        const relativePath = path.relative(workspacePath, xwPath);
+        // show only path relative to its own workspace folder, to make it more readable
+        const rootDir = getWorkspaceFolderForPath(xwPath) ?? folders[0];
+        const relativePath = path.relative(rootDir, xwPath);
         const parentDir = path.dirname(relativePath);
 
         const isInRootDir = parentDir === ".";
-        const isCocoaPods = isInRootDir && isCocoaProject;
+        const isCocoaPods = isInRootDir && cocoaPodsRoots.has(rootDir);
         const isSPMPackage = detectWorkspaceType(xwPath) === "spm";
 
         let detail: string | undefined;
@@ -614,6 +688,8 @@ export async function selectXcodeWorkspace(options: { autoselect: boolean }): Pr
 
         return {
           label: relativePath,
+          // In multi-root workspaces show which folder the project belongs to
+          description: isMultiRoot ? path.basename(rootDir) : undefined,
           detail: detail,
           context: {
             path: xwPath,
@@ -621,6 +697,7 @@ export async function selectXcodeWorkspace(options: { autoselect: boolean }): Pr
         };
       }),
   });
+  setActiveWorkspaceFolder(selected.context.path);
   return selected.context.path;
 }
 

--- a/sweetpad-vscode/src/common/files.ts
+++ b/sweetpad-vscode/src/common/files.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 
 import type * as vscode from "vscode";
 
-import { getWorkspacePath, prepareStoragePath } from "../build/utils";
+import { getWorkspaceFolderForPath, getWorkspacePath, prepareStoragePath } from "../build/utils";
 
 /**
  * Find files or directories in a given directory
@@ -105,7 +105,9 @@ export async function readJsonFile<T = unknown>(filePath: string): Promise<T> {
 }
 
 export function getWorkspaceRelativePath(filePath: string): string {
-  const workspacePath = getWorkspacePath();
+  // In multi-root workspaces the file may live in any folder — compute the path
+  // relative to the folder that actually contains it.
+  const workspacePath = getWorkspaceFolderForPath(filePath) ?? getWorkspacePath();
   return path.relative(workspacePath, filePath);
 }
 

--- a/sweetpad-vscode/src/extension.ts
+++ b/sweetpad-vscode/src/extension.ts
@@ -35,7 +35,7 @@ import { XcodeBuildTaskProvider } from "./build/provider.js";
 import { SchemeWatcher } from "./build/scheme-watcher.js";
 import { DefaultSchemeStatusBar } from "./build/status-bar.js";
 import { BuildTreeProvider } from "./build/tree.js";
-import { getWorkspacePath, notifyCustomXcodebuildReadOnlyScope } from "./build/utils.js";
+import { getCurrentXcodeWorkspacePath, getWorkspacePath, notifyCustomXcodebuildReadOnlyScope } from "./build/utils.js";
 import { CliServerService } from "./cli-server/service.js";
 import { type AppDeps, registerCommand, registerTreeDataProvider } from "./common/commands.js";
 import { errorReporting } from "./common/error-reporting.js";
@@ -133,13 +133,17 @@ export async function activate(context: vscode.ExtensionContext) {
   const devFeaturesEnabled = context.extensionMode === vscode.ExtensionMode.Development;
   await vscode.commands.executeCommand("setContext", "sweetpad.devFeatures", devFeaturesEnabled);
 
-  const workspacePath = getWorkspacePath();
-
   warmShellEnv();
 
   // Services 🔧
   // Leaf services with no manager dependencies. Constructed first so managers can take them as deps.
   const workspaceState = new WorkspaceStateService(context);
+
+  // Prime the active workspace folder from the previously selected xcworkspace, so that in
+  // multi-root workspaces everything below resolves against the right folder from the start.
+  getCurrentXcodeWorkspacePath(workspaceState);
+  const workspacePath = getWorkspacePath();
+
   const execution = new ExecutionScopeService();
 
   // Managers 💼

--- a/sweetpad-vscode/src/testing/manager.ts
+++ b/sweetpad-vscode/src/testing/manager.ts
@@ -172,8 +172,11 @@ export class TestingManager {
   // don't keep the items in memory if they are not used anymore
   readonly testItems = new WeakMap<vscode.TestItem, TestItemContext>();
 
-  // Root folder of the workspace (VSCode, not Xcode)
-  readonly workspacePath: string;
+  // Root folder of the workspace (VSCode, not Xcode). Resolved lazily so it follows
+  // the active project in multi-root workspaces.
+  get workspacePath(): string {
+    return getWorkspacePath();
+  }
 
   constructor(options: {
     workspaceState: WorkspaceStateService;
@@ -187,7 +190,6 @@ export class TestingManager {
     this.execution = options.execution;
     this.buildManager = options.buildManager;
     this.destinations = options.destinations;
-    this.workspacePath = getWorkspacePath();
     this.controller = vscode.tests.createTestController("sweetpad", "SweetPad");
   }
 

--- a/sweetpad-vscode/src/tuist/watcher.ts
+++ b/sweetpad-vscode/src/tuist/watcher.ts
@@ -1,10 +1,7 @@
-import path from "node:path";
-
 import * as vscode from "vscode";
 
-import { getWorkspacePath, prepareDerivedDataPath } from "../build/utils";
+import { getWorkspacePath, isFileExistsInAnyWorkspaceFolder, prepareDerivedDataPath } from "../build/utils";
 import { getWorkspaceConfig } from "../common/config";
-import { isFileExists } from "../common/files";
 import { commonLogger } from "../common/logger";
 
 export class TuistGenWatcher implements vscode.Disposable {
@@ -23,11 +20,10 @@ export class TuistGenWatcher implements vscode.Disposable {
       return;
     }
 
-    // We don't even need to start the watcher if there is no tuist files in the workspace
-    const workspacePath = getWorkspacePath();
+    // We don't even need to start the watcher if there is no tuist files in any workspace folder
     const isTuistFileExists =
-      (await isFileExists(path.join(workspacePath, "Project.swift"))) ||
-      (await isFileExists(path.join(workspacePath, "Workspace.swift")));
+      (await isFileExistsInAnyWorkspaceFolder("Project.swift")) ||
+      (await isFileExistsInAnyWorkspaceFolder("Workspace.swift"));
     if (!isTuistFileExists) {
       commonLogger.log("Project.swift or Workspace.swift not found, skipping tuist watcher", {
         workspacePath: getWorkspacePath(),

--- a/sweetpad-vscode/src/xcodegen/watcher.ts
+++ b/sweetpad-vscode/src/xcodegen/watcher.ts
@@ -1,10 +1,7 @@
-import path from "node:path";
-
 import * as vscode from "vscode";
 
-import { getWorkspacePath } from "../build/utils";
+import { getWorkspacePath, isFileExistsInAnyWorkspaceFolder } from "../build/utils";
 import { getWorkspaceConfig } from "../common/config";
-import { isFileExists } from "../common/files";
 import { commonLogger } from "../common/logger";
 
 export class XcodeGenWatcher implements vscode.Disposable {
@@ -22,9 +19,8 @@ export class XcodeGenWatcher implements vscode.Disposable {
       return;
     }
 
-    // Is project.yml exists?
-    const workspacePath = getWorkspacePath();
-    const isProjectExists = await isFileExists(path.join(workspacePath, "project.yml"));
+    // Is project.yml exists in any workspace folder?
+    const isProjectExists = await isFileExistsInAnyWorkspaceFolder("project.yml");
     if (!isProjectExists) {
       commonLogger.log("project.yml not found, skipping xcodegen watcher", {
         workspacePath: getWorkspacePath(),


### PR DESCRIPTION
# Support multi-root VS Code workspaces

## Problem

SweetPad works great with a single-folder workspace, but in a multi-root VS Code workspace (e.g. two iOS projects added via *File → Add Folder to Workspace…*) it is impossible to switch to a project in any folder other than the first one:

- The project scan (`detectXcodeWorkspacesPaths`) only searched `workspaceFolders[0]`, so `.xcworkspace` / `Package.swift` files in other folders never appeared in the **Select Xcode Workspace** picker.
- `getWorkspacePath()` hardcoded `workspaceFolders[0]`, so everything derived from it — the `cwd` for `xcodebuild`, the `buildServer.json` location, relative resolution of `sweetpad.build.xcodeWorkspacePath`, derived-data paths — always pointed at the first folder, even if the user managed to configure a project from another one.

Fixes the "can't switch xcworkspace/scheme with 2 iOS projects in one workspace" scenario.

## What changed

### Project discovery and selection (`build/utils.ts`)

- `detectXcodeWorkspacesPaths()` now scans **all** workspace folders (same depth-4 scan as before, per folder).
- The **Select Xcode Workspace or SPM package** picker shows each candidate relative to its own folder and, when the workspace has more than one root, badges it with the folder name. CocoaPods (`Podfile`) detection is per-folder as well.

### Active-folder tracking (`build/utils.ts`)

- New `setActiveWorkspaceFolder(xcworkspacePath)` remembers which VS Code folder contains the currently selected Xcode workspace. It is invoked at every point a project becomes current: picker selection, autoselect, cached workspace-state path, and configured `sweetpad.build.xcodeWorkspacePath`.
- `getWorkspacePath()` returns that folder, falling back to the first folder before any selection or when the folder is removed from the workspace. All ~30 existing call sites (xcodebuild `cwd`, `buildServer.json` read/write, git-worktree detection, shell env, etc.) pick the correct root automatically — no changes needed at those sites.

### Path resolution

- A **relative** `sweetpad.build.xcodeWorkspacePath` is resolved against the first workspace folder where the path actually exists, instead of blindly against folder #1.
- `getWorkspaceRelativePath()` (used when pinning a selection to settings) computes the path relative to the file's own containing folder.

### Supporting changes

- `extension.ts` primes the active folder from the previously selected project during activation, so services constructed at startup (CLI server, etc.) resolve against the right root after a window reload.
- The XcodeGen / Tuist / scheme watchers check for their trigger files (`project.yml`, `Project.swift`, `Workspace.swift`) in **any** workspace folder before deciding to start.
- `TestingManager.workspacePath` became a live getter so it cannot go stale after switching projects.

## Behavior notes

- SweetPad still operates on **one active project at a time** (one scheme status bar, one build tree). This PR adds the ability to *switch* between projects across folders, not to build several projects simultaneously.
- Single-folder workspaces are unaffected: with one folder, every new code path degrades to the previous behavior.
- If a relative `build.xcodeWorkspacePath` exists in several folders, the first matching folder wins. Selections stored in workspace state use absolute paths and are unambiguous.

## Testing

- 7 new unit tests covering the multi-root resolution logic (default folder, following the selection, paths outside all folders such as git worktrees, folder removal, cached / relative / absolute path activation); `Uri.file` and `getWorkspaceFolder` added to the vscode test mock.
- `npm run check:all` (format, lint, typecheck) and `npm run test` pass — 408/408.
- Manually verified with a two-project multi-root workspace: both projects appear in the picker with folder badges, switching swaps the scheme list, builds run with the right `-workspace` and `cwd`, `buildServer.json` is written to the selected project's folder, and the selection survives a window reload.
