### PR TITLE
Show build errors in the Problems panel when clang wraps them

### DIFF
--- a/sweetpad-vscode/src/build/diagnostics-parser.spec.ts
+++ b/sweetpad-vscode/src/build/diagnostics-parser.spec.ts
@@ -1,4 +1,4 @@
-import { parseDiagnosticLine } from "./diagnostics-parser";
+import { continuationMessage, isHeaderOnly, parseDiagnosticLine, type ParsedDiagnostic } from "./diagnostics-parser";
 
 describe("parseDiagnosticLine", () => {
   describe("xcbeautify error format", () => {
@@ -233,5 +233,52 @@ describe("parseDiagnosticLine", () => {
         expect(parseDiagnosticLine(xcodebuildLine)?.source).toBe("xcodebuild");
       });
     });
+  });
+});
+
+// clang writes to a TTY whenever no xcbeautify sits in the pipe, and wraps its
+// own diagnostics to the terminal width when it does. Past that width the
+// message lands on the following line, leaving a header that ends at "error:"
+// — the shape every build produced while this went unhandled.
+describe("clang diagnostics wrapped at the terminal width", () => {
+  const header = "/path/to/Foo.m:5:28: error: ";
+  const continuation = "      use of undeclared identifier 'undeclared_symbol_here'";
+
+  it("parses a header whose message wrapped away, and marks it incomplete", () => {
+    const result = parseDiagnosticLine(header, "xcodebuild");
+
+    expect(result).toMatchObject({ file: "/path/to/Foo.m", line: 5, column: 28, severity: "error", message: "" });
+    expect(isHeaderOnly(result as ParsedDiagnostic)).toBe(true);
+  });
+
+  it("still marks a diagnostic that kept its message as complete", () => {
+    const result = parseDiagnosticLine(`${header}use of undeclared identifier 'x'`, "xcodebuild");
+
+    expect(isHeaderOnly(result as ParsedDiagnostic)).toBe(false);
+  });
+
+  it("reads the wrapped remainder off the next line", () => {
+    expect(continuationMessage(continuation)).toBe("use of undeclared identifier 'undeclared_symbol_here'");
+  });
+
+  it("strips colour and a trailing carriage return from the remainder", () => {
+    expect(continuationMessage("   \u001b[1muse of undeclared identifier\u001b[0m\r")).toBe(
+      "use of undeclared identifier",
+    );
+  });
+
+  it("does not read the source snippet or caret rows as the message", () => {
+    // clang prints these directly beneath the diagnostic; taking either as the
+    // message would put source code in the Problems panel.
+    expect(continuationMessage("    1 | void broken(void) { return x; }")).toBeNull();
+    expect(continuationMessage("      |                            ^~~~")).toBeNull();
+  });
+
+  it("does not treat an unindented line as a continuation", () => {
+    expect(continuationMessage("1 error generated.")).toBeNull();
+  });
+
+  it("does not swallow the next diagnostic as a continuation", () => {
+    expect(continuationMessage("  /path/to/Bar.m:9:1: error: something else")).toBeNull();
   });
 });

--- a/sweetpad-vscode/src/build/diagnostics-parser.ts
+++ b/sweetpad-vscode/src/build/diagnostics-parser.ts
@@ -50,6 +50,34 @@ export type ParsedDiagnostic = {
   source: DiagnosticSource;
 };
 
+/**
+ * True when a parsed diagnostic carries a position but no message, which is
+ * what a clang diagnostic wrapped at the terminal width looks like on its
+ * first line. The message is on the line after it, so a caller reading a
+ * stream can complete this one; a caller holding a single line cannot, and
+ * should treat it as unusable rather than publish an empty squiggle.
+ */
+export function isHeaderOnly(diagnostic: ParsedDiagnostic): boolean {
+  return diagnostic.message.length === 0;
+}
+
+/**
+ * The message text `rawLine` supplies to a header-only diagnostic, or null if
+ * it supplies none. clang indents the continuation, and follows it with the
+ * source snippet (`    1 | void broken(...)`) and caret rows, so anything that
+ * looks like snippet furniture — or like a fresh diagnostic — ends the message.
+ */
+export function continuationMessage(rawLine: string): string | null {
+  const line = stripAnsi(rawLine).replace(/\r$/, "");
+  if (!/^\s+\S/.test(line)) return null;
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return null;
+  // `    1 | source text` and `      |      ^~~~` are the snippet and caret rows.
+  if (/^\d*\s*\|/.test(trimmed)) return null;
+  if (parseDiagnosticLine(line, "auto") !== null) return null;
+  return trimmed;
+}
+
 // Matches `\x1b[...m` SGR escape sequences (the "set graphics rendition"
 // family — colors, bold, reset, etc.). xcbeautify color-codes its prefixes
 // and messages; we strip them so the diagnostic regexes see plain text.
@@ -101,8 +129,19 @@ const XCBEAUTIFY_WARNING_REGEX = /^(?:⚠️|\[!\])\s*(\/[^:]+):(\d+):(\d+):\s*(
 //                            "Foo.swift:10:5: note: see declaration of 'bar'") are
 //                            deliberately skipped. They could be attached as
 //                            relatedInformation on the preceding diagnostic later.
-//   :\s+(.*)$                separator, then group 5 — the rest of the message
-const XCODEBUILD_REGEX = /^(\/[^:]+):(\d+):(\d+):\s+(error|warning):\s+(.*)$/;
+//   :\s*(.*)$                separator, then group 5 — the rest of the message.
+//                            `\s*` and a possibly-empty group 5 because clang
+//                            wraps its own output to the terminal width when
+//                            stdout is a TTY, which is exactly what it is when
+//                            no xcbeautify sits in the pipe. Past the width the
+//                            message moves to the next line and the header ends
+//                            at `error:` with nothing after it. `isHeaderOnly`
+//                            marks that case for the caller to complete.
+const XCODEBUILD_REGEX = /^(\/[^:]+):(\d+):(\d+):\s+(error|warning):\s*(.*)$/;
+
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_STRIP_REGEX, "");
+}
 
 export function parseDiagnosticLine(rawLine: string, mode: ParseMode = "auto"): ParsedDiagnostic | null {
   // `\r` would block the `$` anchor; strip CR + any stray ANSI (the v3 task

--- a/sweetpad-vscode/src/build/diagnostics.spec.ts
+++ b/sweetpad-vscode/src/build/diagnostics.spec.ts
@@ -1,0 +1,94 @@
+import type * as vscode from "vscode";
+
+import { DiagnosticAccumulator } from "./diagnostics";
+
+// `recordLine` reads build output and never touches the editor surface — the
+// collection is only used by `flush`, which these tests don't call.
+const accumulator = (mode: "xcodebuild" | "xcbeautify" = "xcodebuild") =>
+  new DiagnosticAccumulator({} as vscode.DiagnosticCollection, mode);
+
+describe("DiagnosticAccumulator.recordLine", () => {
+  describe("a clang message wrapped to the terminal width", () => {
+    // Real xcodebuild output at 80 columns. clang fits the message into the
+    // width left after the file path, so a long enough workspace path pushes
+    // all of it onto the following line.
+    const header = "/tmp/w/p/widget.m:5:28: error: ";
+    const continuation = "      use of undeclared identifier 'undeclared_symbol_here'";
+    const snippet = "    5 | void broken(void) { return undeclared_symbol_here; }";
+    const caret = "      |                            ^~~~~~~~~~~~~~~~~~~~~~";
+
+    it("holds the header back rather than publishing an empty squiggle", () => {
+      expect(accumulator().recordLine(header)).toBeNull();
+    });
+
+    it("publishes it once the next line supplies the message", () => {
+      const acc = accumulator();
+      acc.recordLine(header);
+
+      expect(acc.recordLine(continuation)).toMatchObject({
+        file: "/tmp/w/p/widget.m",
+        line: 5,
+        column: 28,
+        severity: "error",
+        message: "use of undeclared identifier 'undeclared_symbol_here'",
+      });
+    });
+
+    it("keeps the source snippet and caret rows out of the message", () => {
+      const acc = accumulator();
+      acc.recordLine(header);
+      acc.recordLine(continuation);
+
+      expect(acc.recordLine(snippet)).toBeNull();
+      expect(acc.recordLine(caret)).toBeNull();
+    });
+
+    it("drops a header the following line never completes", () => {
+      const acc = accumulator();
+      acc.recordLine(header);
+
+      // The snippet row is the next line when clang has nothing to wrap, so a
+      // header followed by one is abandoned rather than given the source text.
+      expect(acc.recordLine(snippet)).toBeNull();
+    });
+  });
+
+  describe("a diagnostic that arrived whole", () => {
+    // swiftc doesn't wrap, and echoes the offending line beneath the
+    // diagnostic with no `N |` gutter — the shape a broader continuation rule
+    // would swallow into the message. Nothing is held back here, so it can't.
+    const swiftError = "/tmp/w/App.swift:26:22: error: cannot convert value of type 'String' to specified type 'Int'";
+    const sourceEcho = '    let value: Int = "a string literal long enough that the compiler has plenty to say"';
+
+    it("publishes immediately instead of waiting for a continuation", () => {
+      expect(accumulator().recordLine(swiftError)).toMatchObject({
+        file: "/tmp/w/App.swift",
+        message: "cannot convert value of type 'String' to specified type 'Int'",
+      });
+    });
+
+    it("does not absorb the echoed source line", () => {
+      const acc = accumulator();
+      acc.recordLine(swiftError);
+
+      expect(acc.recordLine(sourceEcho)).toBeNull();
+    });
+  });
+
+  it("starts a fresh diagnostic when one header follows another", () => {
+    const acc = accumulator();
+    acc.recordLine("/tmp/w/a.m:1:1: error: ");
+
+    expect(acc.recordLine("/tmp/w/b.m:2:2: error: something else")).toMatchObject({
+      file: "/tmp/w/b.m",
+      message: "something else",
+    });
+  });
+
+  it("keeps the first of two diagnostics at the same position", () => {
+    const acc = accumulator();
+
+    expect(acc.recordLine("/tmp/w/a.m:1:1: error: first")).not.toBeNull();
+    expect(acc.recordLine("/tmp/w/a.m:1:1: error: First")).toBeNull();
+  });
+});

--- a/sweetpad-vscode/src/build/diagnostics.ts
+++ b/sweetpad-vscode/src/build/diagnostics.ts
@@ -1,7 +1,13 @@
 import * as vscode from "vscode";
 
 import { commonLogger } from "../common/logger";
-import { type ParseMode, parseDiagnosticLine, type ParsedDiagnostic } from "./diagnostics-parser";
+import {
+  continuationMessage,
+  isHeaderOnly,
+  type ParseMode,
+  parseDiagnosticLine,
+  type ParsedDiagnostic,
+} from "./diagnostics-parser";
 export type { ParsedDiagnostic } from "./diagnostics-parser";
 
 /**
@@ -78,6 +84,8 @@ export class DiagnosticsManager implements vscode.Disposable {
 export class DiagnosticAccumulator {
   private readonly perFile = new Map<string, ParsedDiagnostic[]>();
   private flushed = false;
+  /** A diagnostic whose message clang wrapped onto the following line. */
+  private pendingHeader: ParsedDiagnostic | undefined;
 
   constructor(
     private readonly collection: vscode.DiagnosticCollection,
@@ -102,9 +110,40 @@ export class DiagnosticAccumulator {
    * otherwise. Callers that just want side-effects can ignore the return.
    */
   recordLine(rawLine: string): ParsedDiagnostic | null {
+    const pending = this.pendingHeader;
+    this.pendingHeader = undefined;
+
     const diag = parseDiagnosticLine(rawLine, this.mode);
+
+    // A header held from the previous line is completed by this one, so long as
+    // this one is the wrapped remainder rather than the start of something new.
+    if (pending && !diag) {
+      const message = continuationMessage(rawLine);
+      if (message !== null) {
+        return this.add({ ...pending, message: message });
+      }
+    }
+
     if (!diag) return null;
 
+    // Position but no message: clang wrapped it, and the message is on the next
+    // line. Hold it rather than publish a squiggle with no text.
+    //
+    // A header that kept some of its message is published as it stands, even
+    // though clang may have wrapped the rest away. Joining that case too would
+    // mean treating any indented line as a continuation, and swiftc — which
+    // doesn't wrap — echoes the offending source line directly beneath the
+    // diagnostic with no `N |` gutter to tell it apart, so the echo would land
+    // in the message of every Swift error. A clipped tail costs less.
+    if (isHeaderOnly(diag)) {
+      this.pendingHeader = diag;
+      return null;
+    }
+
+    return this.add(diag);
+  }
+
+  private add(diag: ParsedDiagnostic): ParsedDiagnostic | null {
     const bucket = this.perFile.get(diag.file);
     if (!bucket) {
       this.perFile.set(diag.file, [diag]);


### PR DESCRIPTION
Without xcbeautify in the pipe xcodebuild writes straight to the task terminal's pty, and clang word-wraps its message into the width left after the file path — so a long enough workspace path pushes the whole message onto the next line and leaves a header ending at `error:`, which the single-line pattern never matched. Those errors reached no one. The parser now completes a message-less header from the continuation line, ignoring the snippet and caret rows beneath it; only that case is joined, since swiftc doesn't wrap and echoes the source line with no gutter, which a broader rule would swallow into the message.