### PR TITLE
Default to SweetPad's built-in build server for autocomplete

### DIFF
--- a/sweetpad-docs/docs/intro.md
+++ b/sweetpad-docs/docs/intro.md
@@ -42,8 +42,8 @@ The VSCode extension gives you:
   Swift Testing.
 - ✍️ **[Format on save](./vscode/format.md)** with `swift-format` (Xcode's bundled copy by default) or any other Swift
   formatter you prefer.
-- 💡 **[Autocomplete](./vscode/autocomplete.md)** via SourceKit-LSP — backed by `xcode-build-server` or SweetPad's
-  built-in build server — including inline compiler diagnostics in the Problems panel.
+- 💡 **[Autocomplete](./vscode/autocomplete.md)** via SourceKit-LSP — backed by SweetPad's built-in build server —
+  including inline compiler diagnostics in the Problems panel.
 - 🌳 **[Git worktrees](./vscode/worktree.md)** — switch the active workspace between parallel checkouts of the same project
   in one command.
 

--- a/sweetpad-docs/docs/vscode/autocomplete.md
+++ b/sweetpad-docs/docs/vscode/autocomplete.md
@@ -12,11 +12,11 @@ real autocomplete, jump-to-definition, hover docs, and Swift compiler diagnostic
 
 SourceKit-LSP needs a **build server** to tell it how each file is compiled. SweetPad supports two:
 
-- **xcode-build-server** (the default) — a battle-tested external tool that parses Xcode build logs. Works with
-  workspaces, projects, and SPM, but needs a successful build before autocomplete comes alive.
-- **SweetPad's built-in build server** (experimental) — ships inside the extension and reads compiler arguments
-  straight from the project, so autocomplete works **without building first**. Currently limited to plain
-  `.xcodeproj` projects.
+- **SweetPad's built-in build server** (the default) — ships inside the extension and reads compiler arguments
+  straight from the project, so autocomplete works **without building first**. Handles `.xcodeproj` and
+  `.xcworkspace`.
+- **xcode-build-server** — a battle-tested external tool that parses Xcode build logs. Install it separately, and
+  build the project once before autocomplete comes alive.
 
 :::info
 
@@ -26,7 +26,51 @@ is installed.
 
 :::
 
-## Setup with xcode-build-server (default)
+## Setup with the built-in build server (default)
+
+Nothing to install beyond the Swift extension:
+
+1. Install the [Swift](https://marketplace.visualstudio.com/items?itemName=swiftlang.swift-vscode) extension from the
+   Marketplace.
+2. From the command palette, run `> SweetPad: Generate Build Server Config`. This writes a `buildServer.json` at the
+   workspace root that launches the bundled server. SweetPad writes it for you on the first build too.
+3. Open a Swift file — SourceKit-LSP starts the server, which resolves build settings directly from the project.
+
+After that, autocomplete should work. ✅
+
+:::note
+
+Already using `xcode-build-server`? Nothing changes for you. A workspace that has a `buildServer.json` written by
+another tool keeps that tool, so an existing setup is never swapped out underneath you — that includes a
+`buildServer.json` you maintain by hand. To move such a workspace to the built-in server, run
+`> SweetPad: Set up Swift code intelligence (BSP)`, or delete the file and build once.
+`> SweetPad: Diagnose BSP (Doctor)` reports which server is in use and why.
+
+:::
+
+A few things to know:
+
+- The server runs on Node.js, so `node` must be on your `PATH`.
+- An `.xcworkspace` resolves each file against whichever member project declares its target, so a CocoaPods or
+  multi-project workspace works the same as a single `.xcodeproj`.
+- A Swift package takes a different route: SourceKit-LSP reads `Package.swift` and indexes it natively, so SweetPad
+  writes no `buildServer.json` at all. If one is already sitting in the package directory, delete it — its presence
+  overrides that native support.
+- Headers borrow the sysroot, search paths and language dialect of a neighbouring source file — the `.m` beside
+  `Foo.h`, or the nearest one in the same folder — so a `.h` resolves even though no target compiles it directly.
+- The `buildServer.json` it writes points at a file inside the installed extension, so an extension update leaves
+  that path behind. SweetPad rewrites it the next time the window loads, and `> SweetPad: Generate Build Server
+  Config` does the same on demand.
+
+## Setup with xcode-build-server
+
+To use the external tool instead, point the provider at it:
+
+```json title=".vscode/settings.json"
+{
+  "sweetpad.buildServer.provider": "xcode-build-server"
+}
+```
 
 1. Install the [Swift](https://marketplace.visualstudio.com/items?itemName=swiftlang.swift-vscode) extension from the
    Marketplace and [xcode-build-server](https://github.com/SolaWing/xcode-build-server) from Homebrew:
@@ -41,37 +85,8 @@ is installed.
 3. Build the project once (▶️ in the Build view). Without a successful build there are no build logs for
    `xcode-build-server` to parse, so autocomplete looks "stuck".
 
-After that, autocomplete should work. ✅
-
-## Setup with the built-in build server (experimental)
-
-If your project is an `.xcodeproj` or an `.xcworkspace`, you can skip installing `xcode-build-server` entirely:
-
-1. Run `> SweetPad: Set up Swift code intelligence (BSP)` from the command palette. This switches
-   `sweetpad.buildServer.provider` to `sweetpad` and writes a `buildServer.json` that launches the bundled server.
-2. Open a Swift file — SourceKit-LSP starts the server, which resolves build settings directly from the project.
-   No prior build needed.
-
-A few things to know:
-
-- The server runs on Node.js, so `node` must be on your `PATH`.
-- An `.xcworkspace` resolves each file against whichever member project declares its target, so a CocoaPods or
-  multi-project workspace works the same as a single `.xcodeproj`.
-- A Swift package takes a different route: SourceKit-LSP reads `Package.swift` and indexes it natively, so SweetPad
-  writes no `buildServer.json` at all. If one is already sitting in the package directory, delete it — its presence
-  overrides that native support.
-- Headers borrow the sysroot, search paths and language dialect of a neighbouring source file — the `.m` beside
-  `Foo.h`, or the nearest one in the same folder — so a `.h` resolves even though no target compiles it directly.
-- The `buildServer.json` it writes points at a file inside the installed extension. After an extension update that
-  path can go stale — if autocomplete stops working, re-run `> SweetPad: Generate Build Server Config`.
-
-To switch back, set the provider in your settings:
-
-```json title=".vscode/settings.json"
-{
-  "sweetpad.buildServer.provider": "xcode-build-server"
-}
-```
+To go back to the built-in server, run `> SweetPad: Set up Swift code intelligence (BSP)` — it resets the provider
+and regenerates `buildServer.json` in one step.
 
 ## When autocomplete doesn't work
 
@@ -115,6 +130,9 @@ may want to silence SweetPad's pass to avoid duplicate squiggles:
 
 - `> SweetPad: Disable LSP Diagnostics` — turns the live diagnostic stream off for this workspace.
 - `> SweetPad: Enable LSP Diagnostics` — turns it back on.
+
+Both drive `xcode-build-server`'s logging, so they apply only to that provider. With the built-in server, turn up
+`sweetpad.buildServer.logLevel` and run `> SweetPad: Show BSP logs` instead.
 
 ## Use a custom xcode-build-server
 

--- a/sweetpad-docs/docs/vscode/settings.md
+++ b/sweetpad-docs/docs/vscode/settings.md
@@ -61,7 +61,7 @@ Covered in depth in [Autocomplete](./autocomplete.md).
 
 | Setting                                        | Default              | What it does                                                                              |
 | ----------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------ |
-| `sweetpad.buildServer.provider`                 | `xcode-build-server` | Which build server backs SourceKit-LSP: `xcode-build-server` (parses build logs) or `sweetpad` (built-in, experimental, no build needed). |
+| `sweetpad.buildServer.provider`                 | `sweetpad`           | Which build server backs SourceKit-LSP: `sweetpad` (built-in) or `xcode-build-server` (external, parses build logs). A workspace that already has a `buildServer.json` from another tool keeps it until you set this explicitly. |
 | `sweetpad.buildServer.logLevel`                 | `info`               | Verbosity of the built-in server's live log stream (`off`, `error`, `info`, `debug`). The log file always captures everything. |
 | `sweetpad.buildServer.logPath`                  | —                    | Custom location for the built-in server's log file. Relative paths and `${workspaceFolder}` resolve against the workspace. |
 | `sweetpad.build.autoGenerateBuildServerConfig`  | `true`               | Regenerate `buildServer.json` on build and scheme change. Turn off if you maintain your own file. |

--- a/sweetpad-docs/docs/vscode/tools.md
+++ b/sweetpad-docs/docs/vscode/tools.md
@@ -21,7 +21,8 @@ The tools listed in the panel:
 - [**SwiftLint**](https://github.com/realm/SwiftLint) — Swift linter.
 - [**xcbeautify**](https://github.com/cpisciotta/xcbeautify) — formats `xcodebuild` output into something readable.
 - [**xcode-build-server**](https://github.com/SolaWing/xcode-build-server) — exposes Xcode's build outputs to
-  SourceKit-LSP, which powers [autocomplete](./autocomplete.md), jump-to-definition, and hover docs.
+  SourceKit-LSP. An alternative to SweetPad's built-in build server, which backs
+  [autocomplete](./autocomplete.md) out of the box.
 - [**ios-deploy**](https://github.com/ios-control/ios-deploy) — installs and launches apps on physical iOS devices.
 - [**tuist**](https://docs.tuist.io/) — declarative Xcode project generation. SweetPad has deeper integration here; see
   [Tuist](./tuist.md).

--- a/sweetpad-vscode/README.md
+++ b/sweetpad-vscode/README.md
@@ -25,8 +25,8 @@ tools such as **swift-format**, **swiftlint**, **xcodebuild**, **xcrun**, **xcod
 
 ## Feature
 
-- ✅ **[Autocomplete](https://sweetpad.hyzyla.dev/docs/autocomplete)** — setup autocomplete using
-  [xcode-build-server](https://github.com/SolaWing/xcode-build-server)
+- ✅ **[Autocomplete](https://sweetpad.hyzyla.dev/docs/autocomplete)** — autocomplete, jump-to-definition and hover
+  docs via SourceKit-LSP, backed by SweetPad's built-in build server
   
 - 🛠️ **[Build & Run](https://sweetpad.hyzyla.dev/docs/build)** — build and run application using
   [xcodebuild](https://developer.apple.com/library/archive/technotes/tn2339/_index.html)

--- a/sweetpad-vscode/package.json
+++ b/sweetpad-vscode/package.json
@@ -1234,15 +1234,15 @@
         "sweetpad.buildServer.provider": {
           "type": "string",
           "enum": [
-            "xcode-build-server",
-            "sweetpad"
+            "sweetpad",
+            "xcode-build-server"
           ],
-          "default": "xcode-build-server",
+          "default": "sweetpad",
           "markdownEnumDescriptions": [
-            "The standard, battle-tested `xcode-build-server` (parses build logs).",
-            "SweetPad's own BSP server, which derives compiler arguments from the project (no build required to parse). Experimental. Handles `.xcodeproj` and `.xcworkspace`; a Swift package instead uses SourceKit-LSP's native SwiftPM support, for which no build server is written."
+            "SweetPad's own BSP server, bundled with the extension. Reads compiler arguments straight from the project. Handles `.xcodeproj` and `.xcworkspace`; a Swift package instead uses SourceKit-LSP's native SwiftPM support, for which no build server is written. Needs `node` on your `PATH`.",
+            "The external `xcode-build-server`, which parses Xcode's build logs. Install it separately, and build the project once before autocomplete comes alive."
           ],
-          "description": "Which build server backs sourcekit-lsp (writes buildServer.json)."
+          "markdownDescription": "Which build server backs sourcekit-lsp (writes `buildServer.json`). Left unset, SweetPad's own server is used — except in a workspace whose `buildServer.json` another tool wrote, which keeps that server until you set this explicitly or run `SweetPad: Set up Swift code intelligence (BSP)`."
         },
         "sweetpad.buildServer.logPath": {
           "type": "string",

--- a/sweetpad-vscode/src/__mocks__/vscode.ts
+++ b/sweetpad-vscode/src/__mocks__/vscode.ts
@@ -15,6 +15,7 @@ export const commands = {
 export const workspace = {
   getConfiguration: vi.fn(() => ({
     get: vi.fn(),
+    inspect: vi.fn(),
   })),
   onDidChangeConfiguration: vi.fn(() => ({
     dispose: vi.fn(),

--- a/sweetpad-vscode/src/bsp/commands.spec.ts
+++ b/sweetpad-vscode/src/bsp/commands.spec.ts
@@ -1,0 +1,188 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type { Mock } from "vitest";
+
+import { getWorkspacePath } from "../build/utils";
+import { getWorkspaceConfig, isWorkspaceConfigSetByUser } from "../common/config";
+import { getBuildServerProvider, isPreservingForeignBuildServer, isSweetpadBuildServerActive } from "./commands";
+
+vi.mock("../common/config", () => ({
+  getWorkspaceConfig: vi.fn(),
+  isWorkspaceConfigSetByUser: vi.fn(),
+  updateWorkspaceConfig: vi.fn(),
+}));
+vi.mock("../build/utils", () => ({ getWorkspacePath: vi.fn() }));
+
+const mockConfig = getWorkspaceConfig as Mock;
+const mockSetByUser = isWorkspaceConfigSetByUser as Mock;
+const mockWorkspacePath = getWorkspacePath as Mock;
+
+/**
+ * Nobody has chosen a provider. VS Code still hands back the default this
+ * extension contributes, which is exactly why the code can't read the absence
+ * of a choice off the value.
+ */
+function noChoiceMade(): void {
+  mockSetByUser.mockReturnValue(false);
+  mockConfig.mockReturnValue("sweetpad");
+}
+
+function chose(provider: "sweetpad" | "xcode-build-server"): void {
+  mockSetByUser.mockReturnValue(true);
+  mockConfig.mockReturnValue(provider);
+}
+
+let workspace: string;
+
+/** Put a `buildServer.json` in the workspace, verbatim. */
+function writeBuildServerConfig(contents: string): void {
+  writeFileSync(path.join(workspace, "buildServer.json"), contents, "utf8");
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  workspace = mkdtempSync(path.join(os.tmpdir(), "sweetpad-bsp-"));
+  mockWorkspacePath.mockReturnValue(workspace);
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+describe("getBuildServerProvider", () => {
+  describe("with no provider configured", () => {
+    it("uses the provider declared as the default in package.json", () => {
+      noChoiceMade();
+
+      const manifest = JSON.parse(readFileSync(path.resolve(__dirname, "../../package.json"), "utf8"));
+      const declared = manifest.contributes.configuration.properties["sweetpad.buildServer.provider"].default;
+
+      // The code fallback and the contributed default are two separate
+      // spellings of one decision, and only the manifest reaches the settings
+      // UI. Left to drift they disagree about what a workspace that never
+      // touched the setting gets.
+      expect(getBuildServerProvider()).toBe(declared);
+      expect(declared).toBe("sweetpad");
+    });
+
+    it("keeps a workspace on the server that already owns buildServer.json", () => {
+      noChoiceMade();
+      writeBuildServerConfig(JSON.stringify({ name: "xcode build server", scheme: "App" }));
+
+      // Nobody set this setting while xcode-build-server was the default, so
+      // the file is the only record that a working setup exists here. Taking
+      // it over would swap a build server out from under the project.
+      expect(getBuildServerProvider()).toBe("xcode-build-server");
+    });
+
+    it("claims a workspace whose config is one SweetPad wrote", () => {
+      noChoiceMade();
+      writeBuildServerConfig(JSON.stringify({ name: "sweetpad", argv: ["/path/to/server"] }));
+
+      expect(getBuildServerProvider()).toBe("sweetpad");
+    });
+
+    it("claims a workspace the CLI set up, which runs the same server", () => {
+      noChoiceMade();
+      writeBuildServerConfig(
+        JSON.stringify({ name: "sweetpad-lib", argv: ["/opt/homebrew/bin/sweetpad", "bsp", "serve"] }),
+      );
+
+      // `sweetpad bsp init` writes this. Reading it as somebody else's setup
+      // would route the workspace to xcode-build-server and start asking it to
+      // install a tool it has no use for.
+      expect(getBuildServerProvider()).toBe("sweetpad");
+      expect(isPreservingForeignBuildServer()).toBe(false);
+    });
+
+    it("treats a config too broken to read as nothing to defer to", () => {
+      noChoiceMade();
+      writeBuildServerConfig("{ not json");
+
+      expect(getBuildServerProvider()).toBe("sweetpad");
+    });
+
+    it("survives having no workspace at all", () => {
+      noChoiceMade();
+      mockWorkspacePath.mockImplementation(() => {
+        throw new Error("no workspace open");
+      });
+
+      expect(getBuildServerProvider()).toBe("sweetpad");
+    });
+  });
+
+  describe("with a provider configured", () => {
+    it("honours an explicit choice", () => {
+      chose("xcode-build-server");
+
+      expect(getBuildServerProvider()).toBe("xcode-build-server");
+    });
+
+    it("lets an explicit choice override the file on disk", () => {
+      chose("sweetpad");
+      writeBuildServerConfig(JSON.stringify({ name: "xcode build server" }));
+
+      // Asking for our server is how a workspace opts in, so the leftover file
+      // must not veto it — the next build rewrites it.
+      expect(getBuildServerProvider()).toBe("sweetpad");
+    });
+  });
+});
+
+describe("isPreservingForeignBuildServer", () => {
+  it("is true when another server's config is the only reason we're on it", () => {
+    noChoiceMade();
+    writeBuildServerConfig(JSON.stringify({ name: "xcode build server" }));
+
+    expect(isPreservingForeignBuildServer()).toBe(true);
+  });
+
+  it("is false once the workspace has asked for xcode-build-server itself", () => {
+    chose("xcode-build-server");
+    writeBuildServerConfig(JSON.stringify({ name: "xcode build server" }));
+
+    // Same provider, but nothing was preserved on the workspace's behalf, so
+    // there is nothing to tell it about.
+    expect(isPreservingForeignBuildServer()).toBe(false);
+  });
+
+  it("is false when there is no foreign config to preserve", () => {
+    noChoiceMade();
+
+    expect(isPreservingForeignBuildServer()).toBe(false);
+  });
+});
+
+describe("isSweetpadBuildServerActive", () => {
+  it("is active when the provider is ours and so is the config", async () => {
+    chose("sweetpad");
+    writeBuildServerConfig(JSON.stringify({ name: "sweetpad", argv: ["/path/to/server"] }));
+
+    await expect(isSweetpadBuildServerActive(workspace)).resolves.toBe(true);
+  });
+
+  it("is inactive when another server's config is what sourcekit-lsp will launch", async () => {
+    chose("sweetpad");
+    writeBuildServerConfig(JSON.stringify({ name: "xcode build server", scheme: "App" }));
+
+    // The setting says ours, the file says otherwise, and the file is what
+    // sourcekit-lsp acts on.
+    await expect(isSweetpadBuildServerActive(workspace)).resolves.toBe(false);
+  });
+
+  it("is inactive when there is no config at all", async () => {
+    chose("sweetpad");
+
+    await expect(isSweetpadBuildServerActive(workspace)).resolves.toBe(false);
+  });
+
+  it("is inactive when the provider is not ours", async () => {
+    chose("xcode-build-server");
+    writeBuildServerConfig(JSON.stringify({ name: "sweetpad" }));
+
+    await expect(isSweetpadBuildServerActive(workspace)).resolves.toBe(false);
+  });
+});

--- a/sweetpad-vscode/src/bsp/commands.ts
+++ b/sweetpad-vscode/src/bsp/commands.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from "node:fs";
+import { promises as fs, readFileSync } from "node:fs";
 import * as path from "node:path";
 
 import * as vscode from "vscode";
@@ -6,8 +6,8 @@ import * as vscode from "vscode";
 import { getWorkspacePath } from "../build/utils";
 import { getDeveloperDir, getIsNodeInstalled, getIsXBSInstalled } from "../common/cli/scripts";
 import { type AppDeps, NODE_DOWNLOAD_URL } from "../common/commands";
-import { getWorkspaceConfig, updateWorkspaceConfig } from "../common/config";
-import { isFileExists } from "../common/files";
+import { getWorkspaceConfig, isWorkspaceConfigSetByUser, updateWorkspaceConfig } from "../common/config";
+import { isFileExists, readJsonFile } from "../common/files";
 import { assertUnreachable } from "../common/types";
 
 type DoctorCheck = {
@@ -19,13 +19,86 @@ type DoctorCheck = {
 
 const SWIFT_RESTART_COMMAND = "swift.restartLSPServer";
 
+/** The `name` in a buildServer.json this extension writes. */
+export const EXTENSION_BUILD_SERVER_NAME = "sweetpad";
+
+/** The `name` in a buildServer.json `sweetpad bsp init` writes. */
+export const CLI_BUILD_SERVER_NAME = "sweetpad-lib";
+
+// Both launch the same server — the CLI through `sweetpad bsp serve`, the
+// extension through the bundled `bsp-server.js` — so neither is a foreign setup
+// to be preserved.
+const SWEETPAD_BUILD_SERVER_NAMES = new Set<string>([EXTENSION_BUILD_SERVER_NAME, CLI_BUILD_SERVER_NAME]);
+
+/**
+ * Which build server backs sourcekit-lsp.
+ *
+ * An explicit setting always wins. Without one, a workspace whose
+ * `buildServer.json` SweetPad didn't write keeps whatever owns that file: the
+ * built-in server is the default for projects that have yet to choose one, but
+ * applying it to a working `xcode-build-server` or hand-maintained setup would
+ * replace that setup on the next build without anyone asking. Deleting the
+ * file, or running `SweetPad: Set up Swift code intelligence (BSP)`, is what
+ * moves such a workspace across.
+ */
 export function getBuildServerProvider(): "sweetpad" | "xcode-build-server" {
-  return getWorkspaceConfig("buildServer.provider") ?? "xcode-build-server";
+  // Asked via `isWorkspaceConfigSetByUser` rather than by testing the value for
+  // undefined: package.json contributes a default, so `getWorkspaceConfig`
+  // returns one whether or not anybody chose it, and the evidence below would
+  // never be reached.
+  if (isWorkspaceConfigSetByUser("buildServer.provider")) {
+    const configured = getWorkspaceConfig("buildServer.provider");
+    if (configured !== undefined) return configured;
+  }
+  return hasForeignBuildServerConfig() ? "xcode-build-server" : "sweetpad";
+}
+
+/**
+ * Whether `buildServer.json` exists and names a server other than ours.
+ *
+ * Read synchronously and uncached. Every caller arrives here through a user
+ * action — a build, a scheme change, a command — rather than a per-file path,
+ * and the file is a few hundred bytes; a cache would save nothing measurable
+ * and would need invalidating from every place the file can change, including
+ * edits made outside VS Code.
+ */
+function hasForeignBuildServerConfig(): boolean {
+  try {
+    const raw = readFileSync(path.join(getWorkspacePath(), "buildServer.json"), "utf8");
+    const name = (JSON.parse(raw) as { name?: unknown }).name;
+    return typeof name !== "string" || !SWEETPAD_BUILD_SERVER_NAMES.has(name);
+  } catch {
+    // No workspace, no file, unreadable, or not JSON — no evidence of a setup
+    // worth keeping. A config too broken to read is one the default repairs
+    // rather than one it should defer to.
+    return false;
+  }
+}
+
+/**
+ * Whether this workspace runs `xcode-build-server` only because a
+ * `buildServer.json` for it is already sitting here, rather than because anyone
+ * asked for it.
+ */
+export function isPreservingForeignBuildServer(): boolean {
+  return !isWorkspaceConfigSetByUser("buildServer.provider") && hasForeignBuildServerConfig();
 }
 
 export async function isSweetpadBuildServerActive(workspacePath: string): Promise<boolean> {
   if (getBuildServerProvider() !== "sweetpad") return false;
-  return isFileExists(path.join(workspacePath, "buildServer.json"));
+  // sourcekit-lsp launches whatever `buildServer.json` names, so the setting
+  // alone doesn't put our server in the loop — the file has to be ours too.
+  // Treating any file as proof would have us write `bsp.json` for, and report
+  // ourselves active against, a server we aren't running.
+  //
+  // Stricter than `SWEETPAD_BUILD_SERVER_NAMES` on purpose: this gates the
+  // `bsp.json` the extension writes and the socket it dials, and the CLI's
+  // server is told its project on the command line instead of reading either.
+  // It is our server, but it isn't the one this extension is driving.
+  const config = await readJsonFile<{ name?: unknown }>(path.join(workspacePath, "buildServer.json")).catch(
+    () => undefined,
+  );
+  return config?.name === EXTENSION_BUILD_SERVER_NAME;
 }
 
 export async function bspSetupCommand(): Promise<void> {
@@ -118,7 +191,16 @@ async function collectBspChecks(deps: AppDeps): Promise<DoctorCheck[]> {
 async function collectXBSChecks(): Promise<DoctorCheck[]> {
   const checks: DoctorCheck[] = [];
 
-  checks.push({ ok: true, label: "Build server provider", detail: "xcode-build-server" });
+  // Said here rather than in a notification: a workspace kept on
+  // xcode-build-server has working code intelligence and no reason to be
+  // interrupted, while one that doesn't is being read from this very report.
+  checks.push({
+    ok: true,
+    label: "Build server provider",
+    detail: isPreservingForeignBuildServer()
+      ? "xcode-build-server — kept because a buildServer.json for it is already here. SweetPad's own server is bundled with the extension; 'SweetPad: Set up Swift code intelligence (BSP)' switches over."
+      : "xcode-build-server",
+  });
 
   const installed = await getIsXBSInstalled();
   checks.push({
@@ -147,7 +229,43 @@ async function collectXBSChecks(): Promise<DoctorCheck[]> {
   return checks;
 }
 
+/**
+ * A workspace whose `buildServer.json` came from `sweetpad bsp init`. The server
+ * is ours, but the CLI binary starts it and is handed the project on the command
+ * line, so the extension's socket, its `bsp.json` and its selected scheme never
+ * come into it — reporting on those would call a healthy setup broken.
+ */
+async function collectCliDrivenChecks(config: Record<string, unknown>): Promise<DoctorCheck[]> {
+  const argv = config.argv;
+  const launcher = Array.isArray(argv) && typeof argv[0] === "string" ? argv[0] : undefined;
+
+  return [
+    {
+      ok: true,
+      label: "Build server provider",
+      detail: "sweetpad, launched by the sweetpad CLI — this buildServer.json came from 'sweetpad bsp init'",
+    },
+    await buildServerJsonCheck(),
+    {
+      ok: launcher !== undefined && (await isFileExists(launcher)),
+      label: "sweetpad CLI present",
+      detail: launcher,
+      hint: "Reinstall it with 'brew install sweetpad-dev/tap/sweetpad', or run 'SweetPad: Set up Swift code intelligence (BSP)' to use the server bundled with this extension instead.",
+    },
+    {
+      ok: (await vscode.commands.getCommands(true)).includes(SWIFT_RESTART_COMMAND),
+      label: "Swift extension (sourcekit-lsp) available",
+      hint: "Install the Swift extension so sourcekit-lsp picks up buildServer.json.",
+    },
+  ];
+}
+
 async function collectSweetpadChecks(deps: AppDeps): Promise<DoctorCheck[]> {
+  const cliConfig = await readBuildServerJson();
+  if (cliConfig?.name === CLI_BUILD_SERVER_NAME) {
+    return collectCliDrivenChecks(cliConfig);
+  }
+
   const checks: DoctorCheck[] = [];
   const snap = deps.bspService.snapshot();
 

--- a/sweetpad-vscode/src/build/commands.ts
+++ b/sweetpad-vscode/src/build/commands.ts
@@ -13,7 +13,7 @@ import {
 } from "../common/cli/scripts";
 import { type AppDeps, warnNodeRuntimeMissing } from "../common/commands";
 import { getWorkspaceConfig, updateWorkspaceConfig } from "../common/config";
-import { ExecBaseError } from "../common/errors";
+import { ExecBaseError, ExtensionError } from "../common/errors";
 import { exec } from "../common/exec";
 import { getWorkspaceRelativePath, isFileExists, removeDirectory } from "../common/files";
 import { showInputBox, showQuickPick } from "../common/quick-pick";
@@ -182,6 +182,27 @@ export async function generateBuildServerConfigCommand(deps: AppDeps, item?: Bui
 }
 
 /**
+ * Both LSP-logging commands drive xcode-build-server's own `XBS_LOGPATH`, which
+ * SweetPad's build server has no use for — it streams through the "SweetPad:
+ * BSP" channel at `sweetpad.buildServer.logLevel` instead. Offering its users an
+ * install prompt for a tool that would not help them is worse than naming the
+ * command that shows the logs they actually want.
+ */
+function assertXBSLoggingApplies(): void {
+  if (getBuildServerProvider() !== "sweetpad") {
+    return;
+  }
+  throw new ExtensionError("These commands configure xcode-build-server, and SweetPad's own build server is active", {
+    actions: [
+      {
+        label: "Show BSP logs",
+        callback: () => void vscode.commands.executeCommand("sweetpad.bsp.showLogs"),
+      },
+    ],
+  });
+}
+
+/**
  * Enable verbose LSP / build-server logging: set env vars on xcode-build-server
  * (XBS_LOGPATH) and sourcekit-lsp (SOURCEKIT_LOGGING=3), regenerate
  * buildServer.json with the env injection so the long-running build server
@@ -189,6 +210,8 @@ export async function generateBuildServerConfigCommand(deps: AppDeps, item?: Bui
  * "SweetPad: xcode-build-server logs" output channel.
  */
 export async function enableLspDiagnosticsCommand(deps: AppDeps, item?: BuildTreeItem) {
+  assertXBSLoggingApplies();
+
   const isServerInstalled = await getIsXBSInstalled();
   if (!isServerInstalled) {
     throw XBSMissingError();
@@ -224,6 +247,8 @@ export async function enableLspDiagnosticsCommand(deps: AppDeps, item?: BuildTre
  * XBS_LOGPATH, restart the Swift LSP, and stop the log stream.
  */
 export async function disableLspDiagnosticsCommand(deps: AppDeps, item?: BuildTreeItem) {
+  assertXBSLoggingApplies();
+
   const isServerInstalled = await getIsXBSInstalled();
   if (!isServerInstalled) {
     throw XBSMissingError();

--- a/sweetpad-vscode/src/build/manager.ts
+++ b/sweetpad-vscode/src/build/manager.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 
 import * as vscode from "vscode";
 
+import { getBuildServerProvider } from "../bsp/commands";
 import {
   type XcodeScheme,
   getBuildSettingsToLaunch,
@@ -275,6 +276,15 @@ export class BuildManager {
     }
 
     if (!isAutoGenerateBuildServerConfigEnabled()) {
+      return;
+    }
+
+    // xcode-build-server bakes the scheme into buildServer.json, so a scheme
+    // change invalidates it. SweetPad's own config names no scheme — the scheme
+    // lives in `bsp.json`, which `BspService` rewrites from the same event — so
+    // there is nothing to regenerate here, and asking for a tool that provider
+    // never uses would be a prompt to install xcode-build-server for nothing.
+    if (getBuildServerProvider() === "sweetpad") {
       return;
     }
 

--- a/sweetpad-vscode/src/build/utils.spec.ts
+++ b/sweetpad-vscode/src/build/utils.spec.ts
@@ -1,10 +1,14 @@
 import type { Mock } from "vitest";
 import * as vscode from "vscode";
 
-import { generateBuildServerConfig, getSweetpadBspServerPath } from "../common/cli/scripts";
+import {
+  generateBuildServerConfig,
+  generateSweetpadBuildServerConfig,
+  getSweetpadBspServerPath,
+} from "../common/cli/scripts";
 import { isFileExists, readJsonFile } from "../common/files";
 import type { WorkspaceStateService } from "../common/workspace-state";
-import { generateBuildServerConfigOnBuild, launchActionToSettings } from "./utils";
+import { generateBuildServerConfigOnBuild, launchActionToSettings, repairStaleBuildServerConfig } from "./utils";
 
 // `./utils` imports the native `@sweetpad/native` addon at module level; stub it so
 // this spec runs without the compiled addon (none of the tested paths touch it).
@@ -12,6 +16,7 @@ vi.mock("@sweetpad/native", () => ({}));
 
 vi.mock("../common/cli/scripts", () => ({
   generateBuildServerConfig: vi.fn(),
+  generateSweetpadBuildServerConfig: vi.fn(),
   getSweetpadBspServerPath: vi.fn(),
 }));
 
@@ -133,6 +138,13 @@ describe("generateBuildServerConfigOnBuild (sweetpad provider)", () => {
             "build.autoRestartSwiftLSP": false,
           })[key as never],
       ),
+      // These cases are about a workspace that asked for our server, so the
+      // provider reads as chosen rather than inherited from the manifest —
+      // otherwise the resolver would go looking for a config on disk to defer
+      // to, which is a different test.
+      inspect: vi.fn((key: string) =>
+        key === "buildServer.provider" ? { defaultValue: "sweetpad", workspaceValue: "sweetpad" } : undefined,
+      ),
     });
     mockBspServerPath.mockReturnValue("/ext/out/bsp-server.js");
   });
@@ -166,6 +178,28 @@ describe("generateBuildServerConfigOnBuild (sweetpad provider)", () => {
     expect(mockGenerate).toHaveBeenCalledTimes(1);
   });
 
+  it("leaves a config the sweetpad CLI wrote alone", async () => {
+    mockReadJsonFile.mockResolvedValue({ name: "sweetpad-lib", argv: ["/opt/homebrew/bin/sweetpad", "bsp", "serve"] });
+    mockIsFileExists.mockResolvedValue(true);
+
+    await run();
+
+    // `sweetpad bsp init` reaches the same server through the CLI binary. That
+    // launcher is the one the workspace set up, so swapping ours in would move
+    // the project onto something it never asked for.
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it("replaces a CLI config whose binary has gone", async () => {
+    mockReadJsonFile.mockResolvedValue({ name: "sweetpad-lib", argv: ["/opt/homebrew/bin/sweetpad", "bsp", "serve"] });
+    mockIsFileExists.mockResolvedValue(false);
+
+    await run();
+
+    // Nothing can start from here, so this is a repair rather than a takeover.
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
   it("regenerates when switching in from another provider's config", async () => {
     mockReadJsonFile.mockResolvedValue({
       name: "xcode build server",
@@ -180,5 +214,61 @@ describe("generateBuildServerConfigOnBuild (sweetpad provider)", () => {
     mockReadJsonFile.mockRejectedValue(new Error("ENOENT"));
     await run();
     expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("repairStaleBuildServerConfig", () => {
+  const mockGetConfiguration = vscode.workspace.getConfiguration as Mock;
+  const mockRepair = generateSweetpadBuildServerConfig as Mock;
+  const mockReadJsonFile = readJsonFile as Mock;
+  const mockIsFileExists = isFileExists as Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode.workspace as { workspaceFolders?: unknown }).workspaceFolders = [{ uri: { fsPath: "/workspace" } }];
+    mockGetConfiguration.mockReturnValue({
+      get: vi.fn((key: string) => ({ "buildServer.provider": "sweetpad" })[key as never]),
+      inspect: vi.fn((key: string) =>
+        key === "buildServer.provider" ? { defaultValue: "sweetpad", workspaceValue: "sweetpad" } : undefined,
+      ),
+    });
+  });
+
+  it("rewrites a config of ours whose launcher an update deleted", async () => {
+    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/old-ext/out/bsp-server.js"] });
+    mockIsFileExists.mockResolvedValue(false);
+
+    await repairStaleBuildServerConfig();
+
+    expect(mockRepair).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a launcher that still resolves alone", async () => {
+    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/somewhere/custom/bsp-server.js"] });
+    mockIsFileExists.mockResolvedValue(true);
+
+    // A path that exists is one somebody meant to point at, even where it isn't
+    // the launcher this version ships. Only dangling ones are repaired.
+    await repairStaleBuildServerConfig();
+
+    expect(mockRepair).not.toHaveBeenCalled();
+  });
+
+  it("does not touch another server's config", async () => {
+    mockReadJsonFile.mockResolvedValue({ name: "xcode build server", argv: ["/gone/xcode-build-server"] });
+    mockIsFileExists.mockResolvedValue(false);
+
+    await repairStaleBuildServerConfig();
+
+    expect(mockRepair).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing when there is no config to repair", async () => {
+    mockReadJsonFile.mockRejectedValue(new Error("ENOENT"));
+
+    // Creating one from nothing belongs to the build, which knows the project.
+    await repairStaleBuildServerConfig();
+
+    expect(mockRepair).not.toHaveBeenCalled();
   });
 });

--- a/sweetpad-vscode/src/build/utils.ts
+++ b/sweetpad-vscode/src/build/utils.ts
@@ -4,12 +4,13 @@ import * as sweetpadLib from "@sweetpad/native";
 import { execa } from "execa";
 import * as vscode from "vscode";
 
-import { getBuildServerProvider } from "../bsp/commands";
+import { CLI_BUILD_SERVER_NAME, EXTENSION_BUILD_SERVER_NAME, getBuildServerProvider } from "../bsp/commands";
 import { askConfigurationBase } from "../common/askers";
 import {
   type XBSConfig,
   findSchemeFile,
   generateBuildServerConfig,
+  generateSweetpadBuildServerConfig,
   getBuildSettingsToAskDestination,
   getIsXBSInstalled,
   getSchemes,
@@ -451,6 +452,47 @@ export async function refreshBuildServer(options: {
 }
 
 /**
+ * Repair a `buildServer.json` of ours whose launcher has gone missing.
+ *
+ * `argv[0]` names a file inside the *versioned* extension directory, so every
+ * extension update leaves that path dangling: sourcekit-lsp can't start the
+ * server, and autocomplete stops with nothing said about why. Building repairs
+ * it, but nothing makes a user build before they expect to type — so this runs
+ * at activation, the first moment after an update that any of our code looks at
+ * the file.
+ *
+ * Narrower on purpose than the check on the build path, which requires the
+ * launcher to be the current one: here only a launcher missing from disk is
+ * rewritten. One that resolves is somebody aiming us at a server deliberately,
+ * and it keeps working.
+ */
+export async function repairStaleBuildServerConfig(): Promise<void> {
+  if (getBuildServerProvider() !== "sweetpad") {
+    return;
+  }
+
+  let config: { name?: string; argv?: string[] } | undefined;
+  try {
+    config = await readJsonFile<{ name?: string; argv?: string[] }>(path.join(getWorkspacePath(), "buildServer.json"));
+  } catch {
+    // No workspace, or no readable config. Writing one from nothing is the
+    // build's job; a repair only fixes what is already here.
+    return;
+  }
+
+  const launcher = config?.argv?.[0];
+  if (config?.name !== EXTENSION_BUILD_SERVER_NAME || launcher === undefined) {
+    return;
+  }
+  if (await isFileExists(launcher)) {
+    return;
+  }
+
+  await generateSweetpadBuildServerConfig();
+  await restartSwiftLSP();
+}
+
+/**
  * Check if buildServer.json needs to be regenerated and regenerate it if needed
  */
 export async function generateBuildServerConfigOnBuild(options: {
@@ -485,8 +527,18 @@ export async function generateBuildServerConfigOnBuild(options: {
       // missing / invalid → (re)generate below
     }
     const launcher = config?.argv?.[0];
+
+    // A config from `sweetpad bsp init` names the CLI binary and reaches the
+    // same server through it. Leave it while it resolves: that launcher is the
+    // one the workspace set up, and swapping ours in is not this function's
+    // call. A launcher that has gone missing is broken rather than chosen, so
+    // that one falls through and is replaced.
+    if (config?.name === CLI_BUILD_SERVER_NAME && launcher !== undefined && (await isFileExists(launcher))) {
+      return;
+    }
+
     const isConfigValid =
-      config?.name === "sweetpad" &&
+      config?.name === EXTENSION_BUILD_SERVER_NAME &&
       launcher !== undefined &&
       launcher === getSweetpadBspServerPath() &&
       (await isFileExists(launcher));

--- a/sweetpad-vscode/src/common/cli/scripts.ts
+++ b/sweetpad-vscode/src/common/cli/scripts.ts
@@ -731,7 +731,7 @@ export async function generateBuildServerConfig(options: { xcworkspace: string; 
  * Project, Xcode, scheme, configuration, the log path and the telemetry socket
  * are all read from that `bsp.json`, which the extension writes.
  */
-async function generateSweetpadBuildServerConfig(): Promise<void> {
+export async function generateSweetpadBuildServerConfig(): Promise<void> {
   const cwd = getWorkspacePath();
   const bspServer = getSweetpadBspServerPath();
   await ensureExecutable(bspServer);

--- a/sweetpad-vscode/src/common/config.spec.ts
+++ b/sweetpad-vscode/src/common/config.spec.ts
@@ -1,0 +1,40 @@
+import type { Mock } from "vitest";
+import * as vscode from "vscode";
+
+import { isWorkspaceConfigSetByUser } from "./config";
+
+const mockGetConfiguration = vscode.workspace.getConfiguration as unknown as Mock;
+
+/** Stand in for what `WorkspaceConfiguration.inspect` reports for a setting. */
+function inspectReports(scopes: Record<string, unknown> | undefined): void {
+  mockGetConfiguration.mockReturnValue({ get: vi.fn(), inspect: vi.fn(() => scopes) });
+}
+
+describe("isWorkspaceConfigSetByUser", () => {
+  it("is false when the only value is the one package.json contributes", () => {
+    inspectReports({ key: "sweetpad.buildServer.provider", defaultValue: "sweetpad" });
+
+    expect(isWorkspaceConfigSetByUser("buildServer.provider")).toBe(false);
+  });
+
+  it.each([["globalValue"], ["workspaceValue"], ["workspaceFolderValue"]])("is true for a %s", (scope) => {
+    inspectReports({ defaultValue: "sweetpad", [scope]: "xcode-build-server" });
+
+    expect(isWorkspaceConfigSetByUser("buildServer.provider")).toBe(true);
+  });
+
+  it("is true when the chosen value happens to equal the default", () => {
+    inspectReports({ defaultValue: "sweetpad", workspaceValue: "sweetpad" });
+
+    // Choosing the same value the manifest suggests is still choosing, and the
+    // two answers lead somewhere different: a workspace that picked `sweetpad`
+    // wants our server even where one already exists for something else.
+    expect(isWorkspaceConfigSetByUser("buildServer.provider")).toBe(true);
+  });
+
+  it("is false when the setting is unknown to VS Code", () => {
+    inspectReports(undefined);
+
+    expect(isWorkspaceConfigSetByUser("buildServer.provider")).toBe(false);
+  });
+});

--- a/sweetpad-vscode/src/common/config.ts
+++ b/sweetpad-vscode/src/common/config.ts
@@ -74,6 +74,25 @@ export function isWorkspaceConfigIsDefined<K extends ConfigKey>(key: K): boolean
   return getWorkspaceConfig(key) !== undefined;
 }
 
+/**
+ * Whether a value for `key` comes from the user rather than from the `default`
+ * this extension contributes in package.json.
+ *
+ * `getWorkspaceConfig` can't answer that: `config.get` folds the contributed
+ * default in with the user's own settings and hands back a value either way, so
+ * a caller that has to tell "asked for this" apart from "never asked" is left
+ * inspecting the scopes a choice could have been written to. Language-scoped
+ * overrides are ignored — none of these settings are per-language.
+ */
+export function isWorkspaceConfigSetByUser<K extends ConfigKey>(key: K): boolean {
+  const inspected = vscode.workspace.getConfiguration("sweetpad").inspect<Config[K]>(key);
+  return (
+    inspected?.workspaceFolderValue !== undefined ||
+    inspected?.workspaceValue !== undefined ||
+    inspected?.globalValue !== undefined
+  );
+}
+
 export async function updateWorkspaceConfig<K extends ConfigKey>(key: K, value: Config[K]): Promise<void> {
   const config = vscode.workspace.getConfiguration("sweetpad");
   return await config.update(key, value, vscode.ConfigurationTarget.Workspace);

--- a/sweetpad-vscode/src/extension.ts
+++ b/sweetpad-vscode/src/extension.ts
@@ -35,7 +35,7 @@ import { XcodeBuildTaskProvider } from "./build/provider.js";
 import { SchemeWatcher } from "./build/scheme-watcher.js";
 import { DefaultSchemeStatusBar } from "./build/status-bar.js";
 import { BuildTreeProvider } from "./build/tree.js";
-import { getWorkspacePath, notifyCustomXcodebuildReadOnlyScope } from "./build/utils.js";
+import { getWorkspacePath, notifyCustomXcodebuildReadOnlyScope, repairStaleBuildServerConfig } from "./build/utils.js";
 import { CliServerService } from "./cli-server/service.js";
 import { type AppDeps, registerCommand, registerTreeDataProvider } from "./common/commands.js";
 import { errorReporting } from "./common/error-reporting.js";
@@ -257,6 +257,9 @@ export async function activate(context: vscode.ExtensionContext) {
   void xcodegenWatcher.start();
   void serverService.start();
   void bspService.start();
+  // An extension update leaves buildServer.json pointing into the directory the
+  // previous version lived in. Nothing else notices until the next build.
+  void repairStaleBuildServerConfig();
 
   // Main dependency bag for commands 🌍
   const deps: AppDeps = {


### PR DESCRIPTION
Autocomplete now works without installing xcode-build-server or building first. A workspace whose buildServer.json another tool wrote keeps that tool, since nobody set the provider explicitly while it was the default, and one set up by `sweetpad bsp init` keeps the CLI launcher it named. Activation repairs a config left pointing into the previous extension version's directory, which otherwise breaks code intelligence until the next build.