### PR TITLE
Run the build server through the sweetpad CLI instead of a bundled shim

### DIFF
--- a/sweetpad-docs/docs/vscode/autocomplete.md
+++ b/sweetpad-docs/docs/vscode/autocomplete.md
@@ -12,8 +12,8 @@ real autocomplete, jump-to-definition, hover docs, and Swift compiler diagnostic
 
 SourceKit-LSP needs a **build server** to tell it how each file is compiled. SweetPad supports two:
 
-- **SweetPad's built-in build server** (the default) — ships inside the extension and reads compiler arguments
-  straight from the project, so autocomplete works **without building first**. Handles `.xcodeproj` and
+- **SweetPad's own build server** (the default) — reads compiler arguments straight from the project, so
+  autocomplete works **without building first**. Runs through the `sweetpad` CLI. Handles `.xcodeproj` and
   `.xcworkspace`.
 - **xcode-build-server** — a battle-tested external tool that parses Xcode build logs. Install it separately, and
   build the project once before autocomplete comes alive.
@@ -28,12 +28,15 @@ is installed.
 
 ## Setup with the built-in build server (default)
 
-Nothing to install beyond the Swift extension:
-
 1. Install the [Swift](https://marketplace.visualstudio.com/items?itemName=swiftlang.swift-vscode) extension from the
-   Marketplace.
+   Marketplace, and the `sweetpad` CLI that runs the build server:
+
+   ```bash
+   brew install sweetpad-dev/tap/sweetpad
+   ```
+
 2. From the command palette, run `> SweetPad: Generate Build Server Config`. This writes a `buildServer.json` at the
-   workspace root that launches the bundled server. SweetPad writes it for you on the first build too.
+   workspace root that runs `sweetpad bsp serve`. SweetPad writes it for you on the first build too.
 3. Open a Swift file — SourceKit-LSP starts the server, which resolves build settings directly from the project.
 
 After that, autocomplete should work. ✅
@@ -50,7 +53,9 @@ another tool keeps that tool, so an existing setup is never swapped out undernea
 
 A few things to know:
 
-- The server runs on Node.js, so `node` must be on your `PATH`.
+- The server runs through the [`sweetpad` CLI](../cli/getting-started-cli.md), so it needs to be installed:
+  `brew install sweetpad-dev/tap/sweetpad`, or the Tools panel. SweetPad tells you once per workspace if it's
+  missing, and `> SweetPad: Diagnose BSP (Doctor)` reports it too.
 - An `.xcworkspace` resolves each file against whichever member project declares its target, so a CocoaPods or
   multi-project workspace works the same as a single `.xcodeproj`.
 - A Swift package takes a different route: SourceKit-LSP reads `Package.swift` and indexes it natively, so SweetPad
@@ -58,9 +63,9 @@ A few things to know:
   overrides that native support.
 - Headers borrow the sysroot, search paths and language dialect of a neighbouring source file — the `.m` beside
   `Foo.h`, or the nearest one in the same folder — so a `.h` resolves even though no target compiles it directly.
-- The `buildServer.json` it writes points at a file inside the installed extension, so an extension update leaves
-  that path behind. SweetPad rewrites it the next time the window loads, and `> SweetPad: Generate Build Server
-  Config` does the same on demand.
+- The `buildServer.json` it writes names the installed CLI, so it keeps resolving across extension updates. If the
+  CLI itself moves or is uninstalled, SweetPad rewrites the file the next time the window loads, and
+  `> SweetPad: Generate Build Server Config` does the same on demand.
 
 ## Setup with xcode-build-server
 
@@ -91,7 +96,7 @@ and regenerates `buildServer.json` in one step.
 ## When autocomplete doesn't work
 
 Run `> SweetPad: Diagnose BSP (Doctor)` from the command palette. It checks the whole chain for your active
-provider — `buildServer.json` is present and valid, the build-server tool (or Node.js) is available, a scheme is
+provider — `buildServer.json` is present and valid, the build-server tool is available, a scheme is
 selected, the Xcode developer directory resolves — and prints a ✓/✗ report with a fix hint for each failure in the
 **SweetPad: BSP** output channel.
 

--- a/sweetpad-vscode/native/src/lib.rs
+++ b/sweetpad-vscode/native/src/lib.rs
@@ -297,19 +297,6 @@ fn tool_to_napi(t: compiler_args::ToolInvocation) -> CompilerToolInvocation {
     }
 }
 
-/// Run the Build Server Protocol server (see [`sweetpad_core::bsp`]) over this process's
-/// stdio, blocking until EOF / `build/exit`. `args` are the `bsp` flags, e.g.
-/// `["--project", "App.xcodeproj", "--xcode", "/Applications/Xcode.app",
-/// "--derived-data-path", "…"]`.
-///
-/// This lets sourcekit-lsp launch the server through VS Code's bundled Node +
-/// the shipped addon (a `buildServer.json` `argv` of `[node, entry.js, …]`),
-/// rather than a separate published binary.
-#[napi]
-pub fn bsp(args: Vec<String>) -> napi::Result<()> {
-    sweetpad_core::bsp::run(&args).map_err(to_napi_err)
-}
-
 /// A target referenced by a scheme (a build entry or a testable). Mirrors a
 /// `BuildableReference` in the `.xcscheme` XML.
 #[napi(object)]

--- a/sweetpad-vscode/package.json
+++ b/sweetpad-vscode/package.json
@@ -1239,7 +1239,7 @@
           ],
           "default": "sweetpad",
           "markdownEnumDescriptions": [
-            "SweetPad's own BSP server, bundled with the extension. Reads compiler arguments straight from the project. Handles `.xcodeproj` and `.xcworkspace`; a Swift package instead uses SourceKit-LSP's native SwiftPM support, for which no build server is written. Needs `node` on your `PATH`.",
+            "SweetPad's own BSP server, bundled with the extension. Reads compiler arguments straight from the project. Handles `.xcodeproj` and `.xcworkspace`; a Swift package instead uses SourceKit-LSP's native SwiftPM support, for which no build server is written. Runs through the `sweetpad` CLI (`brew install sweetpad-dev/tap/sweetpad`).",
             "The external `xcode-build-server`, which parses Xcode's build logs. Install it separately, and build the project once before autocomplete comes alive."
           ],
           "markdownDescription": "Which build server backs sourcekit-lsp (writes `buildServer.json`). Left unset, SweetPad's own server is used — except in a workspace whose `buildServer.json` another tool wrote, which keeps that server until you set this explicitly or run `SweetPad: Set up Swift code intelligence (BSP)`."

--- a/sweetpad-vscode/rolldown.config.mjs
+++ b/sweetpad-vscode/rolldown.config.mjs
@@ -43,17 +43,6 @@ const sweetpadNativePlugin = {
   },
 };
 
-// The BSP server entry only needs the `@sweetpad/native` import rewritten to the
-// copied addon — the extension entry's `writeBundle` already populates `out/lib`.
-const sweetpadNativeResolvePlugin = {
-  name: "sweetpad-native-resolve",
-  resolveId(source) {
-    if (source === "@sweetpad/native") {
-      return { id: "./lib/index.js", external: true };
-    }
-  },
-};
-
 const extensionPlugins = [sweetpadNativePlugin];
 
 if (isProduction) {
@@ -90,31 +79,5 @@ export default defineConfig([
       },
     },
     plugins: extensionPlugins,
-  },
-  {
-    // The BSP server sourcekit-lsp execs (via `argv` in buildServer.json).
-    // Bundled with a `#!/usr/bin/env node` shebang so it runs under the user's
-    // system Node, which loads the copied addon (`out/lib`) and runs the
-    // sweetpad-core BSP loop over stdio. No running extension required. Unlike
-    // the native `sweetpad` CLI, the BSP server stays a JS wrapper around the
-    // addon: the addon ships unsigned, and macOS only loads it inside an
-    // already-signed host process like `node`.
-    input: "./src/cli/bsp-server.ts",
-    output: {
-      file: "out/bsp-server.js",
-      format: "cjs",
-      sourcemap: isProduction ? "hidden" : true,
-      minify: isProduction,
-      banner: "#!/usr/bin/env node",
-    },
-    platform: "node",
-    transform: {
-      target: "es2022",
-      define: {
-        GLOBAL_SENTRY_DSN: JSON.stringify(null),
-        GLOBAL_RELEASE_VERSION: JSON.stringify(pkg.version),
-      },
-    },
-    plugins: [sweetpadNativeResolvePlugin],
   },
 ]);

--- a/sweetpad-vscode/src/bsp/commands.ts
+++ b/sweetpad-vscode/src/bsp/commands.ts
@@ -4,8 +4,13 @@ import * as path from "node:path";
 import * as vscode from "vscode";
 
 import { getWorkspacePath } from "../build/utils";
-import { getDeveloperDir, getIsNodeInstalled, getIsXBSInstalled } from "../common/cli/scripts";
-import { type AppDeps, NODE_DOWNLOAD_URL } from "../common/commands";
+import {
+  SWEETPAD_CLI_MISSING_MESSAGE,
+  getDeveloperDir,
+  getIsXBSInstalled,
+  getSweetpadCliPath,
+} from "../common/cli/scripts";
+import type { AppDeps } from "../common/commands";
 import { getWorkspaceConfig, isWorkspaceConfigSetByUser, updateWorkspaceConfig } from "../common/config";
 import { isFileExists, readJsonFile } from "../common/files";
 import { assertUnreachable } from "../common/types";
@@ -25,9 +30,9 @@ export const EXTENSION_BUILD_SERVER_NAME = "sweetpad";
 /** The `name` in a buildServer.json `sweetpad bsp init` writes. */
 export const CLI_BUILD_SERVER_NAME = "sweetpad-lib";
 
-// Both launch the same server — the CLI through `sweetpad bsp serve`, the
-// extension through the bundled `bsp-server.js` — so neither is a foreign setup
-// to be preserved.
+// Both name the same server, reached through `sweetpad bsp serve`: this
+// extension writes the first when it manages the config itself, `sweetpad bsp
+// init` writes the second. Neither is a foreign setup to be preserved.
 const SWEETPAD_BUILD_SERVER_NAMES = new Set<string>([EXTENSION_BUILD_SERVER_NAME, CLI_BUILD_SERVER_NAME]);
 
 /**
@@ -273,12 +278,12 @@ async function collectSweetpadChecks(deps: AppDeps): Promise<DoctorCheck[]> {
 
   checks.push(await buildServerJsonCheck());
 
-  const nodeOk = await getIsNodeInstalled();
+  const cli = await getSweetpadCliPath();
   checks.push({
-    ok: nodeOk,
-    label: "Node.js runtime on PATH",
-    detail: nodeOk ? undefined : "node not found",
-    hint: `The BSP server launches via "#!/usr/bin/env node"; install Node.js (${NODE_DOWNLOAD_URL}) so it's on your PATH.`,
+    ok: cli !== undefined,
+    label: "sweetpad CLI on PATH",
+    detail: cli ?? "not found",
+    hint: SWEETPAD_CLI_MISSING_MESSAGE,
   });
 
   checks.push({

--- a/sweetpad-vscode/src/build/commands.ts
+++ b/sweetpad-vscode/src/build/commands.ts
@@ -4,14 +4,8 @@ import * as vscode from "vscode";
 
 import { getBuildServerProvider } from "../bsp/commands";
 import { showConfigurationPicker, showYesNoQuestion } from "../common/askers";
-import {
-  type XcodeScheme,
-  getBuildConfigurations,
-  getIsNodeInstalled,
-  getIsXBSInstalled,
-  getSchemes,
-} from "../common/cli/scripts";
-import { type AppDeps, warnNodeRuntimeMissing } from "../common/commands";
+import { type XcodeScheme, getBuildConfigurations, getIsXBSInstalled, getSchemes } from "../common/cli/scripts";
+import type { AppDeps } from "../common/commands";
 import { getWorkspaceConfig, updateWorkspaceConfig } from "../common/config";
 import { ExecBaseError, ExtensionError } from "../common/errors";
 import { exec } from "../common/exec";
@@ -136,18 +130,11 @@ export async function removeBundleDirCommand(deps: AppDeps) {
 export async function generateBuildServerConfigCommand(deps: AppDeps, item?: BuildTreeItem) {
   deps.progressStatusBar.updateText("Starting buildServer.json generation");
 
-  // SweetPad's own provider ships with the extension; only xcode-build-server
-  // needs the external tool installed.
+  // The sweetpad provider's own launcher is checked where the config is
+  // written; only xcode-build-server is gated here.
   const usingXBS = getBuildServerProvider() === "xcode-build-server";
   if (usingXBS && !(await getIsXBSInstalled())) {
     throw XBSMissingError();
-  }
-
-  // SweetPad's own BSP server launches via `#!/usr/bin/env node`. Warn (without
-  // blocking) when Node is missing: the config still writes, so it's ready once
-  // Node is on PATH, but the server can't start until then.
-  if (!usingXBS && !(await getIsNodeInstalled())) {
-    void warnNodeRuntimeMissing("The SweetPad BSP server");
   }
 
   deps.progressStatusBar.updateText("Searching for workspace");

--- a/sweetpad-vscode/src/build/utils.spec.ts
+++ b/sweetpad-vscode/src/build/utils.spec.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 import {
   generateBuildServerConfig,
   generateSweetpadBuildServerConfig,
-  getSweetpadBspServerPath,
+  getSweetpadCliPath,
 } from "../common/cli/scripts";
 import { isFileExists, readJsonFile } from "../common/files";
 import type { WorkspaceStateService } from "../common/workspace-state";
@@ -17,7 +17,8 @@ vi.mock("@sweetpad/native", () => ({}));
 vi.mock("../common/cli/scripts", () => ({
   generateBuildServerConfig: vi.fn(),
   generateSweetpadBuildServerConfig: vi.fn(),
-  getSweetpadBspServerPath: vi.fn(),
+  getSweetpadCliPath: vi.fn(),
+  SWEETPAD_CLI_MISSING_MESSAGE: "cli missing",
 }));
 
 vi.mock("../common/files", () => ({
@@ -121,7 +122,7 @@ describe("launchActionToSettings", () => {
 describe("generateBuildServerConfigOnBuild (sweetpad provider)", () => {
   const mockGetConfiguration = vscode.workspace.getConfiguration as Mock;
   const mockGenerate = generateBuildServerConfig as Mock;
-  const mockBspServerPath = getSweetpadBspServerPath as Mock;
+  const mockCliPath = getSweetpadCliPath as Mock;
   const mockReadJsonFile = readJsonFile as Mock;
   const mockIsFileExists = isFileExists as Mock;
 
@@ -146,36 +147,48 @@ describe("generateBuildServerConfigOnBuild (sweetpad provider)", () => {
         key === "buildServer.provider" ? { defaultValue: "sweetpad", workspaceValue: "sweetpad" } : undefined,
       ),
     });
-    mockBspServerPath.mockReturnValue("/ext/out/bsp-server.js");
+    mockCliPath.mockResolvedValue("/opt/homebrew/bin/sweetpad");
   });
 
   function run() {
     return generateBuildServerConfigOnBuild({
       scheme: "App",
       xcworkspace: "/workspace/App.xcworkspace",
-      workspaceState: {} as unknown as WorkspaceStateService,
+      workspaceState: { get: vi.fn(), update: vi.fn() } as unknown as WorkspaceStateService,
     });
   }
 
-  it("skips regeneration when the config is ours and the launcher path is current", async () => {
-    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/ext/out/bsp-server.js"] });
-    mockIsFileExists.mockResolvedValue(true);
+  it("skips regeneration when the config already names the installed CLI", async () => {
+    mockReadJsonFile.mockResolvedValue({
+      name: "sweetpad",
+      argv: ["/opt/homebrew/bin/sweetpad", "bsp", "serve", "--config", "/state/bsp.json"],
+    });
     await run();
     expect(mockGenerate).not.toHaveBeenCalled();
   });
 
-  it("regenerates when argv[0] points into a stale (old extension version) dir", async () => {
-    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/old-ext/out/bsp-server.js"] });
-    mockIsFileExists.mockResolvedValue(true);
+  it("migrates a config an older extension wrote to run its own launcher", async () => {
+    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/old-ext/out/bsp-server.js", "--config", "/x"] });
     await run();
     expect(mockGenerate).toHaveBeenCalledTimes(1);
   });
 
-  it("regenerates when argv[0] no longer exists on disk", async () => {
-    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/ext/out/bsp-server.js"] });
-    mockIsFileExists.mockResolvedValue(false);
+  it("regenerates when the CLI has moved since the config was written", async () => {
+    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/usr/local/bin/sweetpad", "bsp", "serve"] });
     await run();
     expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes nothing and says so once when the CLI is not installed", async () => {
+    mockCliPath.mockResolvedValue(undefined);
+    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/old-ext/out/bsp-server.js"] });
+
+    await run();
+
+    // Pointing buildServer.json at a launcher that isn't there would leave
+    // sourcekit-lsp failing to spawn it with nothing said about why.
+    expect(mockGenerate).not.toHaveBeenCalled();
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledTimes(1);
   });
 
   it("leaves a config the sweetpad CLI wrote alone", async () => {
@@ -244,7 +257,7 @@ describe("repairStaleBuildServerConfig", () => {
   });
 
   it("leaves a launcher that still resolves alone", async () => {
-    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/somewhere/custom/bsp-server.js"] });
+    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/usr/local/bin/sweetpad", "bsp", "serve"] });
     mockIsFileExists.mockResolvedValue(true);
 
     // A path that exists is one somebody meant to point at, even where it isn't

--- a/sweetpad-vscode/src/build/utils.ts
+++ b/sweetpad-vscode/src/build/utils.ts
@@ -14,7 +14,8 @@ import {
   getBuildSettingsToAskDestination,
   getIsXBSInstalled,
   getSchemes,
-  getSweetpadBspServerPath,
+  SWEETPAD_CLI_MISSING_MESSAGE,
+  getSweetpadCliPath,
   getXcodeBuildCommand,
   isXcodeBuildCommandCustomized,
   readXBSConfig,
@@ -367,6 +368,24 @@ export function isAutoGenerateBuildServerConfigEnabled(): boolean {
 const XCODE_BUILD_SERVER_TOOL_ID = "xcode-build-server";
 const XBS_INSTALL_ACTION = "Install";
 const XBS_DOCS_ACTION = "Open docs";
+const SWEETPAD_CLI_TOOL_ID = "sweetpad-cli";
+
+/**
+ * Say once, per workspace, that the build server has no launcher to run.
+ * Warned rather than thrown: a build shouldn't fail over code intelligence, and
+ * everything else about it still works.
+ */
+export async function notifySweetpadCliMissing(workspaceState: WorkspaceStateService): Promise<void> {
+  if (workspaceState.get("build.sweetpadCliMissingNotified")) {
+    return;
+  }
+  workspaceState.update("build.sweetpadCliMissingNotified", true);
+
+  const choice = await vscode.window.showWarningMessage(SWEETPAD_CLI_MISSING_MESSAGE, XBS_INSTALL_ACTION);
+  if (choice === XBS_INSTALL_ACTION) {
+    await vscode.commands.executeCommand("sweetpad.tools.install", SWEETPAD_CLI_TOOL_ID);
+  }
+}
 
 function openXBSDocs(): void {
   void vscode.env.openExternal(vscode.Uri.parse(getToolById(XCODE_BUILD_SERVER_TOOL_ID).documentation));
@@ -488,6 +507,12 @@ export async function repairStaleBuildServerConfig(): Promise<void> {
     return;
   }
 
+  // Nothing to rewrite it to. Silent here rather than warning: the build path
+  // says this once already, and activation is not where somebody is asking.
+  if ((await getSweetpadCliPath()) === undefined) {
+    return;
+  }
+
   await generateSweetpadBuildServerConfig();
   await restartSwiftLSP();
 }
@@ -537,11 +562,15 @@ export async function generateBuildServerConfigOnBuild(options: {
       return;
     }
 
-    const isConfigValid =
-      config?.name === EXTENSION_BUILD_SERVER_NAME &&
-      launcher !== undefined &&
-      launcher === getSweetpadBspServerPath() &&
-      (await isFileExists(launcher));
+    const cli = await getSweetpadCliPath();
+    if (cli === undefined) {
+      // Nothing to point a config at. Say so once rather than rewriting
+      // buildServer.json to a launcher that isn't there.
+      await notifySweetpadCliMissing(options.workspaceState);
+      return;
+    }
+
+    const isConfigValid = config?.name === EXTENSION_BUILD_SERVER_NAME && launcher !== undefined && launcher === cli;
     if (!isConfigValid) {
       await refreshBuildServer({ xcworkspace: options.xcworkspace, scheme: options.scheme });
     }

--- a/sweetpad-vscode/src/cli/bsp-server.ts
+++ b/sweetpad-vscode/src/cli/bsp-server.ts
@@ -1,9 +1,0 @@
-// The Build Server Protocol server sourcekit-lsp launches (via `argv` in
-// buildServer.json). Bundled to `out/bsp-server.js` with a `#!/usr/bin/env node`
-// shebang — like the CLI — so sourcekit-lsp execs it directly through system
-// Node, which loads the native addon and runs the BSP loop over stdio. The
-// extension passes `--config <bsp.json>` in argv; absent that, the server
-// discovers the config from its cwd via the host-wide project index.
-import { bsp } from "@sweetpad/native";
-
-bsp(process.argv.slice(2));

--- a/sweetpad-vscode/src/common/cli/scripts.ts
+++ b/sweetpad-vscode/src/common/cli/scripts.ts
@@ -565,22 +565,6 @@ export async function getIsXBSInstalled() {
   }
 }
 
-/**
- * Is a Node.js runtime on the user's PATH? The bundled BSP server
- * (`bsp-server.js`) launches via a `#!/usr/bin/env node` shebang, so it needs
- * a real `node` on PATH — VS Code's own bundled Node isn't exposed there.
- * Resolved against the login-shell PATH (via `exec`), the same one the
- * shebang sees.
- */
-export async function getIsNodeInstalled(): Promise<boolean> {
-  try {
-    await exec({ command: "which", args: ["node"] });
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
-
 export async function getSchemes(options: { xcworkspace: string | undefined }): Promise<XcodeScheme[]> {
   commonLogger.log("Getting schemes", { xcworkspace: options?.xcworkspace ?? "undefined" });
 
@@ -722,19 +706,46 @@ export async function generateBuildServerConfig(options: { xcworkspace: string; 
 }
 
 /**
- * Generate a minimal `buildServer.json` for SweetPad's own BSP server. `argv` is
- * the bundled `bsp-server.js` (which carries a `#!/usr/bin/env node` shebang,
- * like the CLI, so sourcekit-lsp execs it directly through the user's Node)
- * followed by `--config <bsp.json>` naming the per-project config in the host
- * state dir. Editor-agnostic — works the same in VS Code, Cursor, nvim, Zed.
+ * Shown wherever the build server can't be set up because the CLI is absent.
+ * One string so the wording is the same in an error, a warning and the doctor.
+ */
+export const SWEETPAD_CLI_MISSING_MESSAGE =
+  "SweetPad's build server runs through the sweetpad CLI, which isn't on your PATH. Install it with 'brew install sweetpad-dev/tap/sweetpad', or run 'SweetPad: Install tool'.";
+
+/**
+ * Absolute path to the `sweetpad` CLI, or undefined when it isn't installed.
+ *
+ * Resolved to a full path rather than left as a bare name: sourcekit-lsp spawns
+ * `argv[0]` itself and doesn't necessarily carry the login shell's `PATH`.
+ */
+export async function getSweetpadCliPath(): Promise<string | undefined> {
+  try {
+    const resolved = (await exec({ command: "which", args: ["sweetpad"] })).trim();
+    return resolved.length > 0 ? resolved : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Generate a minimal `buildServer.json` for SweetPad's own BSP server. `argv`
+ * runs `sweetpad bsp serve` with `--config <bsp.json>`, naming the per-project
+ * config in the host state dir. Editor-agnostic — works the same in VS Code,
+ * Cursor, nvim, Zed.
  *
  * Project, Xcode, scheme, configuration, the log path and the telemetry socket
  * are all read from that `bsp.json`, which the extension writes.
+ *
+ * The launcher is the installed CLI rather than anything inside this
+ * extension's own directory, so it keeps resolving after an extension update
+ * instead of pointing into a version that has been deleted.
  */
 export async function generateSweetpadBuildServerConfig(): Promise<void> {
   const cwd = getWorkspacePath();
-  const bspServer = getSweetpadBspServerPath();
-  await ensureExecutable(bspServer);
+  const cli = await getSweetpadCliPath();
+  if (cli === undefined) {
+    throw new ExtensionError(SWEETPAD_CLI_MISSING_MESSAGE);
+  }
 
   // sourcekit-lsp requires all five fields (`name`, `version`, `bspVersion`,
   // `languages`, `argv`) or the decode throws and the server is silently skipped.
@@ -743,7 +754,7 @@ export async function generateSweetpadBuildServerConfig(): Promise<void> {
     version: GLOBAL_RELEASE_VERSION ?? "0.1.0",
     bspVersion: "2.2.0",
     languages: ["swift", "objective-c", "objective-cpp", "c", "cpp"],
-    argv: [bspServer, "--config", getBspConfigFile(cwd)],
+    argv: [cli, "bsp", "serve", "--config", getBspConfigFile(cwd)],
   };
   await fs.writeFile(path.join(cwd, "buildServer.json"), `${JSON.stringify(config, null, 2)}\n`, "utf8");
 }
@@ -771,17 +782,6 @@ async function handleSwiftPackageNativeLsp(packageManifest: string): Promise<voi
   }
 }
 
-/**
- * Absolute path to the bundled BSP launcher — it ships next to the extension
- * bundle (this module's dir). Note this lives inside the *versioned* extension
- * install dir (`…/extensions/sweetpad.sweetpad-<ver>/out`), so the path changes
- * on every extension update and any `buildServer.json` written before the
- * update points at a deleted file.
- */
-export function getSweetpadBspServerPath(): string {
-  return path.join(__dirname, "bsp-server.js");
-}
-
 async function generateXBSBuildServerConfig(options: { xcworkspace: string; scheme: string }): Promise<void> {
   const workspaceType = detectWorkspaceType(options.xcworkspace);
   const command = getXBSCommand();
@@ -805,20 +805,6 @@ async function generateXBSBuildServerConfig(options: { xcworkspace: string; sche
 
   const env = getWorkspaceConfig("xcodebuildserver.serverEnv") ?? {};
   await injectEnvIntoBuildServerConfig(path.join(cwd, "buildServer.json"), env);
-}
-
-/**
- * Make the bundled BSP launcher executable. Its `#!/usr/bin/env node` shebang
- * lets sourcekit-lsp exec the `.js` directly, but only if the file keeps its
- * executable bit — a VSIX zip can drop it. Best-effort chmod; a Node script needs
- * no de-quarantine or code-signing (only a bare Mach-O hits amfi on launch).
- */
-async function ensureExecutable(bspServer: string): Promise<void> {
-  try {
-    await fs.chmod(bspServer, 0o755);
-  } catch (e) {
-    commonLogger.debug("Failed to chmod the BSP launcher", { error: e, bspServer });
-  }
 }
 
 /**

--- a/sweetpad-vscode/src/common/commands.ts
+++ b/sweetpad-vscode/src/common/commands.ts
@@ -153,25 +153,6 @@ export async function showCommandErrorMessage(
 }
 
 /** Node.js download/install instructions (shown when no `node` is on PATH). */
-export const NODE_DOWNLOAD_URL = "https://nodejs.org/en/download";
-
-/**
- * Warn that no Node.js runtime is on PATH, with a button to the install docs.
- * The BSP server (`bsp-server.js`) launches via `#!/usr/bin/env node`, so
- * without `node` on PATH it can't run. Non-blocking: the caller still
- * completes its work (the warning is informational).
- */
-export async function warnNodeRuntimeMissing(subject: string): Promise<void> {
-  const install = "Install Node.js";
-  const choice = await vscode.window.showWarningMessage(
-    `SweetPad: ${subject} needs a Node.js runtime on your PATH, but "node" wasn't found. Install Node.js to use it.`,
-    install,
-  );
-  if (choice === install) {
-    void vscode.env.openExternal(vscode.Uri.parse(NODE_DOWNLOAD_URL));
-  }
-}
-
 /**
  * Wipe all sweetpad.* workspace state and reset coordinated manager state.
  */

--- a/sweetpad-vscode/src/common/workspace-state.ts
+++ b/sweetpad-vscode/src/common/workspace-state.ts
@@ -61,6 +61,7 @@ export type WorkspaceTypes = {
   "build.xbsAutogenreateInfoShown": boolean;
   "build.missingPinnedSchemeWarned": string;
   "build.xbsMissingNotified": boolean;
+  "build.sweetpadCliMissingNotified": boolean;
   "build.customXcodebuildNoticeShown": boolean;
   "build.lspDiagnosticsEnabled": boolean;
   "build.lspDiagnosticsPostReloadAction": "enabled" | "disabled";

--- a/sweetpad-vscode/src/tools/constants.ts
+++ b/sweetpad-vscode/src/tools/constants.ts
@@ -27,6 +27,20 @@ export const TOOLS: Tool[] = [
     documentation: "https://brew.sh/",
   },
   {
+    id: "sweetpad-cli",
+    label: "SweetPad CLI",
+    check: {
+      command: "sweetpad",
+      args: ["--version"],
+    },
+    install: {
+      type: "shell",
+      command: "brew",
+      args: ["install", "sweetpad-dev/tap/sweetpad"],
+    },
+    documentation: "https://sweetpad.hyzyla.dev/docs/getting-started-cli",
+  },
+  {
     id: "swift-format",
     label: "swift-format",
     check: {


### PR DESCRIPTION
`buildServer.json` now runs `sweetpad bsp serve --config <bsp.json>` — the same server the extension shipped, reached through the installed CLI rather than a Node shim inside the versioned extension directory. That drops the node-on-PATH requirement, drops the .node addon from the code-intelligence path, and stops the launcher going stale on every extension update. The CLI joins the Tools panel so it installs in one click, the BSP doctor reports it, and a workspace whose config an older extension wrote is migrated on the next build.