### PR TITLE
Build the sweetpad CLI in CI so the e2e suite has a build server

### DIFF
--- a/.github/workflows/vscode.yaml
+++ b/.github/workflows/vscode.yaml
@@ -52,6 +52,15 @@ jobs:
         # it — the typecheck first.
         run: npm run build:native:debug
 
+      - name: Build the sweetpad CLI
+        # The build server runs through the CLI, so the e2e suite needs one on
+        # PATH to write a buildServer.json at all. Built from this checkout
+        # rather than installed from the tap: the pair under test should be the
+        # pair in this commit, not whichever version happens to be released.
+        run: |
+          cargo build -p sweetpad-cli --bin sweetpad
+          echo "$GITHUB_WORKSPACE/target/debug" >> "$GITHUB_PATH"
+
       - name: Types
         working-directory: sweetpad-vscode
         run: npm run check:types


### PR DESCRIPTION
The extension's build server runs through the CLI, so a runner without one can't write a buildServer.json at all and the config test waits for a file that never appears. Built from this checkout rather than the tap, so the pair under test is the pair in the commit.