### PR TITLE
Write sweetpad as the build server name the CLI generates

### DIFF
--- a/sweetpad-core/src/bsp/mod.rs
+++ b/sweetpad-core/src/bsp/mod.rs
@@ -63,7 +63,7 @@ pub fn write_config(args: &[String], serve_subcommand: &[&str]) -> Result<(), St
         }
     }
     let config = json!({
-        "name": "sweetpad-lib",
+        "name": "sweetpad",
         "version": env!("CARGO_PKG_VERSION"),
         "bspVersion": "2.2.0",
         "languages": LANGUAGE_IDS,
@@ -692,7 +692,7 @@ impl Server {
                 json!(dd.join("Index.noindex/IndexDatabase").to_string_lossy());
         }
         json!({
-            "displayName": "sweetpad-lib",
+            "displayName": "sweetpad",
             "version": env!("CARGO_PKG_VERSION"),
             "bspVersion": "2.2.0",
             "capabilities": { "languageIds": LANGUAGE_IDS },

--- a/sweetpad-vscode/src/bsp/commands.spec.ts
+++ b/sweetpad-vscode/src/bsp/commands.spec.ts
@@ -7,6 +7,13 @@ import type { Mock } from "vitest";
 import { getWorkspacePath } from "../build/utils";
 import { getWorkspaceConfig, isWorkspaceConfigSetByUser } from "../common/config";
 import { getBuildServerProvider, isPreservingForeignBuildServer, isSweetpadBuildServerActive } from "./commands";
+import { getBspConfigFile } from "./paths";
+
+/** argv for the config the extension maintains: project comes from bsp.json. */
+const managedArgv = () => ["/opt/homebrew/bin/sweetpad", "bsp", "serve", "--config", getBspConfigFile(workspace)];
+
+/** argv `sweetpad bsp init` writes: project fixed on the command line. */
+const standaloneArgv = () => ["/opt/homebrew/bin/sweetpad", "bsp", "serve", "--project", "/w/App.xcodeproj"];
 
 vi.mock("../common/config", () => ({
   getWorkspaceConfig: vi.fn(),
@@ -84,11 +91,9 @@ describe("getBuildServerProvider", () => {
       expect(getBuildServerProvider()).toBe("sweetpad");
     });
 
-    it("claims a workspace the CLI set up, which runs the same server", () => {
+    it("claims a workspace an older CLI set up under the previous name", () => {
       noChoiceMade();
-      writeBuildServerConfig(
-        JSON.stringify({ name: "sweetpad-lib", argv: ["/opt/homebrew/bin/sweetpad", "bsp", "serve"] }),
-      );
+      writeBuildServerConfig(JSON.stringify({ name: "sweetpad-lib", argv: standaloneArgv() }));
 
       // `sweetpad bsp init` writes this. Reading it as somebody else's setup
       // would route the workspace to xcode-build-server and start asking it to
@@ -159,7 +164,7 @@ describe("isPreservingForeignBuildServer", () => {
 describe("isSweetpadBuildServerActive", () => {
   it("is active when the provider is ours and so is the config", async () => {
     chose("sweetpad");
-    writeBuildServerConfig(JSON.stringify({ name: "sweetpad", argv: ["/path/to/server"] }));
+    writeBuildServerConfig(JSON.stringify({ name: "sweetpad", argv: managedArgv() }));
 
     await expect(isSweetpadBuildServerActive(workspace)).resolves.toBe(true);
   });
@@ -181,8 +186,18 @@ describe("isSweetpadBuildServerActive", () => {
 
   it("is inactive when the provider is not ours", async () => {
     chose("xcode-build-server");
-    writeBuildServerConfig(JSON.stringify({ name: "sweetpad" }));
+    writeBuildServerConfig(JSON.stringify({ name: "sweetpad", argv: managedArgv() }));
 
+    await expect(isSweetpadBuildServerActive(workspace)).resolves.toBe(false);
+  });
+
+  it("is inactive for a standalone config that shares our name", async () => {
+    chose("sweetpad");
+    writeBuildServerConfig(JSON.stringify({ name: "sweetpad", argv: standaloneArgv() }));
+
+    // `sweetpad bsp init` writes the same name now, so only argv separates the
+    // two. That server reads neither our bsp.json nor our socket, and calling
+    // it active would have us write and report against something we don't run.
     await expect(isSweetpadBuildServerActive(workspace)).resolves.toBe(false);
   });
 });

--- a/sweetpad-vscode/src/bsp/commands.ts
+++ b/sweetpad-vscode/src/bsp/commands.ts
@@ -14,6 +14,7 @@ import type { AppDeps } from "../common/commands";
 import { getWorkspaceConfig, isWorkspaceConfigSetByUser, updateWorkspaceConfig } from "../common/config";
 import { isFileExists, readJsonFile } from "../common/files";
 import { assertUnreachable } from "../common/types";
+import { getBspConfigFile } from "./paths";
 
 type DoctorCheck = {
   ok: boolean;
@@ -24,16 +25,41 @@ type DoctorCheck = {
 
 const SWIFT_RESTART_COMMAND = "swift.restartLSPServer";
 
-/** The `name` in a buildServer.json this extension writes. */
-export const EXTENSION_BUILD_SERVER_NAME = "sweetpad";
+/** The `name` SweetPad writes into a buildServer.json, from either side. */
+export const BUILD_SERVER_NAME = "sweetpad";
 
-/** The `name` in a buildServer.json `sweetpad bsp init` writes. */
-export const CLI_BUILD_SERVER_NAME = "sweetpad-lib";
+// Older `sweetpad bsp init` runs wrote the crate the BSP server was first built
+// in. Nothing rewrites a config in place, so those files are still out there and
+// still ours.
+const LEGACY_BUILD_SERVER_NAME = "sweetpad-lib";
 
-// Both name the same server, reached through `sweetpad bsp serve`: this
-// extension writes the first when it manages the config itself, `sweetpad bsp
-// init` writes the second. Neither is a foreign setup to be preserved.
-const SWEETPAD_BUILD_SERVER_NAMES = new Set<string>([EXTENSION_BUILD_SERVER_NAME, CLI_BUILD_SERVER_NAME]);
+const SWEETPAD_BUILD_SERVER_NAMES = new Set<string>([BUILD_SERVER_NAME, LEGACY_BUILD_SERVER_NAME]);
+
+type BuildServerConfig = { name?: unknown; argv?: unknown };
+
+/** Whether SweetPad wrote this config at all, from either side. */
+export function isSweetpadBuildServerConfig(config: BuildServerConfig | undefined): boolean {
+  return typeof config?.name === "string" && SWEETPAD_BUILD_SERVER_NAMES.has(config.name);
+}
+
+/**
+ * Whether this config is the one the extension maintains, as opposed to one
+ * `sweetpad bsp init` wrote.
+ *
+ * Told apart by `argv`, not by `name`: both name the same server and both launch
+ * the same CLI, and what actually separates them is where the project comes
+ * from — ours from the `bsp.json` the extension rewrites as the scheme changes,
+ * the CLI's from a `--project`/`--workspace` fixed when it was initialised.
+ */
+export function isExtensionManagedBuildServerConfig(
+  config: BuildServerConfig | undefined,
+  workspacePath: string,
+): boolean {
+  if (!isSweetpadBuildServerConfig(config)) return false;
+  if (!Array.isArray(config?.argv)) return false;
+  const flag = config.argv.indexOf("--config");
+  return flag !== -1 && config.argv[flag + 1] === getBspConfigFile(workspacePath);
+}
 
 /**
  * Which build server backs sourcekit-lsp.
@@ -70,8 +96,7 @@ export function getBuildServerProvider(): "sweetpad" | "xcode-build-server" {
 function hasForeignBuildServerConfig(): boolean {
   try {
     const raw = readFileSync(path.join(getWorkspacePath(), "buildServer.json"), "utf8");
-    const name = (JSON.parse(raw) as { name?: unknown }).name;
-    return typeof name !== "string" || !SWEETPAD_BUILD_SERVER_NAMES.has(name);
+    return !isSweetpadBuildServerConfig(JSON.parse(raw) as BuildServerConfig);
   } catch {
     // No workspace, no file, unreadable, or not JSON — no evidence of a setup
     // worth keeping. A config too broken to read is one the default repairs
@@ -96,14 +121,13 @@ export async function isSweetpadBuildServerActive(workspacePath: string): Promis
   // Treating any file as proof would have us write `bsp.json` for, and report
   // ourselves active against, a server we aren't running.
   //
-  // Stricter than `SWEETPAD_BUILD_SERVER_NAMES` on purpose: this gates the
-  // `bsp.json` the extension writes and the socket it dials, and the CLI's
-  // server is told its project on the command line instead of reading either.
-  // It is our server, but it isn't the one this extension is driving.
-  const config = await readJsonFile<{ name?: unknown }>(path.join(workspacePath, "buildServer.json")).catch(
+  // Narrower than "SweetPad wrote it" on purpose: this gates the `bsp.json` the
+  // extension writes and the socket it dials, and a standalone `bsp init` config
+  // reads neither. That is our server, but it isn't the one we are driving.
+  const config = await readJsonFile<BuildServerConfig>(path.join(workspacePath, "buildServer.json")).catch(
     () => undefined,
   );
-  return config?.name === EXTENSION_BUILD_SERVER_NAME;
+  return isExtensionManagedBuildServerConfig(config, workspacePath);
 }
 
 export async function bspSetupCommand(): Promise<void> {
@@ -266,9 +290,9 @@ async function collectCliDrivenChecks(config: Record<string, unknown>): Promise<
 }
 
 async function collectSweetpadChecks(deps: AppDeps): Promise<DoctorCheck[]> {
-  const cliConfig = await readBuildServerJson();
-  if (cliConfig?.name === CLI_BUILD_SERVER_NAME) {
-    return collectCliDrivenChecks(cliConfig);
+  const config = await readBuildServerJson();
+  if (isSweetpadBuildServerConfig(config) && !isExtensionManagedBuildServerConfig(config, getWorkspacePath())) {
+    return collectCliDrivenChecks(config as Record<string, unknown>);
   }
 
   const checks: DoctorCheck[] = [];

--- a/sweetpad-vscode/src/build/utils.spec.ts
+++ b/sweetpad-vscode/src/build/utils.spec.ts
@@ -1,6 +1,7 @@
 import type { Mock } from "vitest";
 import * as vscode from "vscode";
 
+import { getBspConfigFile } from "../bsp/paths";
 import {
   generateBuildServerConfig,
   generateSweetpadBuildServerConfig,
@@ -161,27 +162,53 @@ describe("generateBuildServerConfigOnBuild (sweetpad provider)", () => {
   it("skips regeneration when the config already names the installed CLI", async () => {
     mockReadJsonFile.mockResolvedValue({
       name: "sweetpad",
-      argv: ["/opt/homebrew/bin/sweetpad", "bsp", "serve", "--config", "/state/bsp.json"],
+      argv: ["/opt/homebrew/bin/sweetpad", "bsp", "serve", "--config", getBspConfigFile("/workspace")],
     });
     await run();
     expect(mockGenerate).not.toHaveBeenCalled();
   });
 
+  it("leaves a standalone config alone even though it shares our name", async () => {
+    mockReadJsonFile.mockResolvedValue({
+      name: "sweetpad",
+      argv: ["/opt/homebrew/bin/sweetpad", "bsp", "serve", "--project", "/workspace/App.xcodeproj"],
+    });
+    mockIsFileExists.mockResolvedValue(true);
+
+    await run();
+
+    // `sweetpad bsp init` writes our name too, so only the absence of
+    // `--config` marks this as a setup the workspace made rather than one we
+    // maintain. Reading it as ours would overwrite it on the next build.
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
   it("migrates a config an older extension wrote to run its own launcher", async () => {
-    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/old-ext/out/bsp-server.js", "--config", "/x"] });
+    mockReadJsonFile.mockResolvedValue({
+      name: "sweetpad",
+      argv: ["/old-ext/out/bsp-server.js", "--config", getBspConfigFile("/workspace")],
+    });
     await run();
     expect(mockGenerate).toHaveBeenCalledTimes(1);
   });
 
   it("regenerates when the CLI has moved since the config was written", async () => {
-    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/usr/local/bin/sweetpad", "bsp", "serve"] });
+    mockReadJsonFile.mockResolvedValue({
+      name: "sweetpad",
+      argv: ["/usr/local/bin/sweetpad", "bsp", "serve", "--config", getBspConfigFile("/workspace")],
+    });
+    mockIsFileExists.mockResolvedValue(true);
     await run();
     expect(mockGenerate).toHaveBeenCalledTimes(1);
   });
 
   it("writes nothing and says so once when the CLI is not installed", async () => {
     mockCliPath.mockResolvedValue(undefined);
-    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/old-ext/out/bsp-server.js"] });
+    mockReadJsonFile.mockResolvedValue({
+      name: "sweetpad",
+      argv: ["/old-ext/out/bsp-server.js", "--config", getBspConfigFile("/workspace")],
+    });
+    mockIsFileExists.mockResolvedValue(false);
 
     await run();
 
@@ -248,7 +275,10 @@ describe("repairStaleBuildServerConfig", () => {
   });
 
   it("rewrites a config of ours whose launcher an update deleted", async () => {
-    mockReadJsonFile.mockResolvedValue({ name: "sweetpad", argv: ["/old-ext/out/bsp-server.js"] });
+    mockReadJsonFile.mockResolvedValue({
+      name: "sweetpad",
+      argv: ["/old-ext/out/bsp-server.js", "--config", getBspConfigFile("/workspace")],
+    });
     mockIsFileExists.mockResolvedValue(false);
 
     await repairStaleBuildServerConfig();

--- a/sweetpad-vscode/src/build/utils.ts
+++ b/sweetpad-vscode/src/build/utils.ts
@@ -4,7 +4,11 @@ import * as sweetpadLib from "@sweetpad/native";
 import { execa } from "execa";
 import * as vscode from "vscode";
 
-import { CLI_BUILD_SERVER_NAME, EXTENSION_BUILD_SERVER_NAME, getBuildServerProvider } from "../bsp/commands";
+import {
+  getBuildServerProvider,
+  isExtensionManagedBuildServerConfig,
+  isSweetpadBuildServerConfig,
+} from "../bsp/commands";
 import { askConfigurationBase } from "../common/askers";
 import {
   type XBSConfig,
@@ -500,7 +504,7 @@ export async function repairStaleBuildServerConfig(): Promise<void> {
   }
 
   const launcher = config?.argv?.[0];
-  if (config?.name !== EXTENSION_BUILD_SERVER_NAME || launcher === undefined) {
+  if (!isExtensionManagedBuildServerConfig(config, getWorkspacePath()) || launcher === undefined) {
     return;
   }
   if (await isFileExists(launcher)) {
@@ -553,12 +557,14 @@ export async function generateBuildServerConfigOnBuild(options: {
     }
     const launcher = config?.argv?.[0];
 
-    // A config from `sweetpad bsp init` names the CLI binary and reaches the
-    // same server through it. Leave it while it resolves: that launcher is the
-    // one the workspace set up, and swapping ours in is not this function's
-    // call. A launcher that has gone missing is broken rather than chosen, so
-    // that one falls through and is replaced.
-    if (config?.name === CLI_BUILD_SERVER_NAME && launcher !== undefined && (await isFileExists(launcher))) {
+    // A standalone `sweetpad bsp init` config reaches the same server, with the
+    // project fixed on the command line instead of read from our `bsp.json`.
+    // Leave it while its launcher resolves: that setup is the one the workspace
+    // made, and swapping ours in is not this function's call. A launcher that
+    // has gone missing is broken rather than chosen, so it falls through.
+    const isOurs = isSweetpadBuildServerConfig(config);
+    const isManagedHere = isExtensionManagedBuildServerConfig(config, getWorkspacePath());
+    if (isOurs && !isManagedHere && launcher !== undefined && (await isFileExists(launcher))) {
       return;
     }
 
@@ -570,7 +576,7 @@ export async function generateBuildServerConfigOnBuild(options: {
       return;
     }
 
-    const isConfigValid = config?.name === EXTENSION_BUILD_SERVER_NAME && launcher !== undefined && launcher === cli;
+    const isConfigValid = isManagedHere && launcher === cli;
     if (!isConfigValid) {
       await refreshBuildServer({ xcworkspace: options.xcworkspace, scheme: options.scheme });
     }


### PR DESCRIPTION
`sweetpad bsp init` wrote `sweetpad-lib`, the crate the BSP server was first built in and a name nothing outside the repo would recognise. Both sides write `sweetpad` now, so the extension tells the config it maintains from a standalone one by whether argv names its `bsp.json`, rather than by the name — which is the real difference between them anyway, since both launch the same CLI. Configs already on disk still say `sweetpad-lib` and are still recognised as ours.

Closes #318