### PR TITLE
Report the sweetpad CLI's version in the BSP doctor

### DIFF
--- a/sweetpad-vscode/src/bsp/commands.ts
+++ b/sweetpad-vscode/src/bsp/commands.ts
@@ -5,15 +5,18 @@ import * as vscode from "vscode";
 
 import { getWorkspacePath } from "../build/utils";
 import {
+  MINIMUM_SWEETPAD_CLI_VERSION,
   SWEETPAD_CLI_MISSING_MESSAGE,
   getDeveloperDir,
   getIsXBSInstalled,
   getSweetpadCliPath,
+  getSweetpadCliVersion,
 } from "../common/cli/scripts";
 import type { AppDeps } from "../common/commands";
 import { getWorkspaceConfig, isWorkspaceConfigSetByUser, updateWorkspaceConfig } from "../common/config";
 import { isFileExists, readJsonFile } from "../common/files";
 import { assertUnreachable } from "../common/types";
+import { isVersionAtLeast } from "../common/version";
 import { getBspConfigFile } from "./paths";
 
 type DoctorCheck = {
@@ -175,6 +178,23 @@ export async function bspDoctorCommand(deps: AppDeps): Promise<void> {
   deps.bspService.writeReport(lines);
 }
 
+/**
+ * Report the CLI's version against the floor the extension needs.
+ *
+ * Reported even when it passes: the pair in play is the first thing worth
+ * knowing when code intelligence misbehaves, and the two versions come from
+ * different release channels so neither implies the other.
+ */
+async function cliVersionCheck(): Promise<DoctorCheck> {
+  const version = await getSweetpadCliVersion();
+  return {
+    ok: version !== undefined && isVersionAtLeast(version, MINIMUM_SWEETPAD_CLI_VERSION),
+    label: "sweetpad CLI version",
+    detail: version ?? "could not be read",
+    hint: `The extension needs ${MINIMUM_SWEETPAD_CLI_VERSION} or newer — upgrade with 'brew upgrade sweetpad-dev/tap/sweetpad'.`,
+  };
+}
+
 async function readBuildServerJson(): Promise<Record<string, unknown> | undefined> {
   try {
     const raw = await fs.readFile(path.join(getWorkspacePath(), "buildServer.json"), "utf8");
@@ -279,8 +299,9 @@ async function collectCliDrivenChecks(config: Record<string, unknown>): Promise<
       ok: launcher !== undefined && (await isFileExists(launcher)),
       label: "sweetpad CLI present",
       detail: launcher,
-      hint: "Reinstall it with 'brew install sweetpad-dev/tap/sweetpad', or run 'SweetPad: Set up Swift code intelligence (BSP)' to use the server bundled with this extension instead.",
+      hint: "Reinstall it with 'brew install sweetpad-dev/tap/sweetpad', or run 'SweetPad: Set up Swift code intelligence (BSP)' to have the extension manage this instead.",
     },
+    await cliVersionCheck(),
     {
       ok: (await vscode.commands.getCommands(true)).includes(SWIFT_RESTART_COMMAND),
       label: "Swift extension (sourcekit-lsp) available",
@@ -309,6 +330,9 @@ async function collectSweetpadChecks(deps: AppDeps): Promise<DoctorCheck[]> {
     detail: cli ?? "not found",
     hint: SWEETPAD_CLI_MISSING_MESSAGE,
   });
+  if (cli !== undefined) {
+    checks.push(await cliVersionCheck());
+  }
 
   checks.push({
     ok: snap.bspConnected,

--- a/sweetpad-vscode/src/common/cli/scripts.ts
+++ b/sweetpad-vscode/src/common/cli/scripts.ts
@@ -713,6 +713,28 @@ export const SWEETPAD_CLI_MISSING_MESSAGE =
   "SweetPad's build server runs through the sweetpad CLI, which isn't on your PATH. Install it with 'brew install sweetpad-dev/tap/sweetpad', or run 'SweetPad: Install tool'.";
 
 /**
+ * Oldest CLI the extension will drive without complaint.
+ *
+ * The two ship on separate cadences — the extension through the Marketplace,
+ * the CLI through Homebrew — so any pair can meet. This is the floor for the
+ * `bsp.json` the extension writes and the CLI reads; raise it in the same
+ * change that starts writing something an older CLI can't act on.
+ */
+export const MINIMUM_SWEETPAD_CLI_VERSION = "0.1.2";
+
+/**
+ * What `sweetpad --version` prints, or undefined when it can't be asked.
+ */
+export async function getSweetpadCliVersion(): Promise<string | undefined> {
+  try {
+    const output = (await exec({ command: "sweetpad", args: ["--version"] })).trim();
+    return output.length > 0 ? output : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Absolute path to the `sweetpad` CLI, or undefined when it isn't installed.
  *
  * Resolved to a full path rather than left as a bare name: sourcekit-lsp spawns

--- a/sweetpad-vscode/src/common/version.spec.ts
+++ b/sweetpad-vscode/src/common/version.spec.ts
@@ -1,0 +1,43 @@
+import { isVersionAtLeast, parseVersion } from "./version";
+
+describe("parseVersion", () => {
+  it("reads a bare version", () => {
+    expect(parseVersion("0.1.5")).toEqual([0, 1, 5]);
+  });
+
+  it("reads the version out of a whole --version line", () => {
+    expect(parseVersion("sweetpad 0.1.5")).toEqual([0, 1, 5]);
+  });
+
+  it("reads a dev build as the version it was built from", () => {
+    // `build.rs` stamps anything off-tag as `<version>-dev+<sha>`; the sha can
+    // start with digits, so the first match is what has to win.
+    expect(parseVersion("sweetpad 0.1.5-dev+4e8e57fa")).toEqual([0, 1, 5]);
+  });
+
+  it("returns nothing for input carrying no version", () => {
+    expect(parseVersion("sweetpad")).toBeUndefined();
+  });
+});
+
+describe("isVersionAtLeast", () => {
+  it.each([
+    ["0.1.5", "0.1.5", true],
+    ["0.1.6", "0.1.5", true],
+    ["0.2.0", "0.1.9", true],
+    ["1.0.0", "0.9.9", true],
+    ["0.1.4", "0.1.5", false],
+    ["0.0.9", "0.1.0", false],
+  ])("%s vs minimum %s -> %s", (actual, minimum, expected) => {
+    expect(isVersionAtLeast(actual, minimum)).toBe(expected);
+  });
+
+  it("compares numerically rather than as text", () => {
+    // "0.1.10" sorts before "0.1.9" as a string, and after it as a version.
+    expect(isVersionAtLeast("0.1.10", "0.1.9")).toBe(true);
+  });
+
+  it("treats unreadable input as not new enough", () => {
+    expect(isVersionAtLeast("unknown", "0.1.5")).toBe(false);
+  });
+});

--- a/sweetpad-vscode/src/common/version.ts
+++ b/sweetpad-vscode/src/common/version.ts
@@ -1,0 +1,28 @@
+// Dotted version handling for the tools SweetPad shells out to. Deliberately
+// not a semver library: the only question asked is "is this new enough", and a
+// dependency for one comparison would cost more than it saves.
+
+const VERSION_REGEX = /(\d+)\.(\d+)\.(\d+)/;
+
+/**
+ * The first `major.minor.patch` in `text`, or undefined when there is none.
+ *
+ * Takes the first match so a whole `--version` line works as input, and so a
+ * build that stamps itself `0.1.5-dev+<sha>` reads as 0.1.5 — a local or
+ * pre-release build of a version speaks the same protocol as the release.
+ */
+export function parseVersion(text: string): [number, number, number] | undefined {
+  const match = VERSION_REGEX.exec(text);
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : undefined;
+}
+
+/** Whether `actual` is `minimum` or newer. Unparseable input is not. */
+export function isVersionAtLeast(actual: string, minimum: string): boolean {
+  const a = parseVersion(actual);
+  const b = parseVersion(minimum);
+  if (a === undefined || b === undefined) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] > b[i];
+  }
+  return true;
+}


### PR DESCRIPTION
The extension and the CLI ship on separate cadences, so any pair of versions can meet, and nothing said which one was in play. The doctor now reports the CLI's version on both the extension-managed and standalone paths, and flags it against the oldest release the extension will drive.