### PR TITLE
feat(destination): add generic build-only destinations ("Any … Device")

### DIFF
--- a/sweetpad-docs/docs/vscode/build.md
+++ b/sweetpad-docs/docs/vscode/build.md
@@ -204,10 +204,12 @@ doesn't always match the `type` spelling:
 | `tvOSDevice`        | `tvosdevice-<udid>`        |
 | `visionOSDevice`    | `visionosdevice-<udid>`    |
 | `macOS`             | `macos-<computer name>`    |
+| `generic`           | `generic-<platform>`       |
 
-Note the two that break the pattern: `visionOSSimulator` drops the `os`, and `macOS` uses your computer's name
-instead of a UDID, which is why pasting the bare value and letting `type` supply the prefix is the safer habit. An
-id SweetPad doesn't recognise isn't reported as an error; it just falls through to the picker on every build.
+Three break the pattern: `visionOSSimulator` drops the `os`, `macOS` uses your computer's name instead of a UDID,
+and `generic` names a platform, since there is no device to name. That is why pasting the bare value and letting
+`type` supply the prefix is the safer habit. An id SweetPad doesn't recognise isn't reported as an error; it just
+falls through to the picker on every build.
 
 Unset = SweetPad asks the first time and remembers the choice in its cache. Settings always win over that cache, so
 `> SweetPad: Reset Extension Cache` clears the cache but leaves a pinned setting deciding the answer.
@@ -221,6 +223,42 @@ which means a committed `.vscode/settings.json` shows up as a local edit on each
 the scheme and leave the destination to each developer.
 
 :::
+
+### Build for a whole platform
+
+Xcode's device-less "Any iOS Device" and "Any iOS Simulator Device", plus the Mac, watchOS, tvOS and visionOS
+equivalents, live under **Generic (build-only)** in the Destinations view. They pin no simulator or device, so
+`xcodebuild` gets `-destination generic/platform=iOS` and you can build or archive for a platform with nothing
+attached and nothing booted.
+
+Nothing runs on them, so SweetPad leaves them out of the run, debug and testing pickers. If one is already pinned in
+your settings, Run and Test stop with a message telling you to pick a simulator or device, instead of failing inside
+`xcodebuild`.
+
+With `"type": "generic"` the bare platform works in any capitalisation, so `iOS Simulator`, `ios-simulator` and
+`generic-ios-simulator` all name the same destination:
+
+| Destination                   | `id`                         |
+| ----------------------------- | ---------------------------- |
+| Any iOS Device                | `generic-ios`                |
+| Any iOS Simulator Device      | `generic-ios-simulator`      |
+| Any Mac                       | `generic-macos`              |
+| Any watchOS Device            | `generic-watchos`            |
+| Any watchOS Simulator Device  | `generic-watchos-simulator`  |
+| Any tvOS Device               | `generic-tvos`               |
+| Any tvOS Simulator Device     | `generic-tvos-simulator`     |
+| Any visionOS Device           | `generic-visionos`           |
+| Any visionOS Simulator Device | `generic-visionos-simulator` |
+
+A task names one the same way, either by that id or by the `-destination` string itself:
+
+```json title=".vscode/tasks.json"
+{
+  "type": "sweetpad",
+  "action": "build",
+  "destination": "generic/platform=iOS"
+}
+```
 
 ## Set DerivedData path
 

--- a/sweetpad-docs/docs/vscode/destinations.md
+++ b/sweetpad-docs/docs/vscode/destinations.md
@@ -5,7 +5,8 @@ sidebar_position: 9
 # Destinations
 
 In SweetPad, a **destination** is anywhere you can run your app: a specific simulator or a connected device. Under
-the hood SweetPad uses `xcrun simctl` and `xcrun devicectl` to manage them.
+the hood SweetPad uses `xcrun simctl` and `xcrun devicectl` to manage them. A few destinations stand for a whole
+platform instead of one device, and those only build.
 
 The **Destinations** view in the sidebar consolidates everything in one place **[1]**, grouped by platform:
 
@@ -13,6 +14,9 @@ The **Destinations** view in the sidebar consolidates everything in one place **
 - **iOS / watchOS / tvOS / visionOS Simulators**: every installed simulator, one section per OS.
 - **macOS**: your local Mac as a destination for Mac apps.
 - **iOS / watchOS / tvOS / visionOS Devices**: physical devices paired with this Mac.
+- **Generic (build-only)**: Xcode's "Any iOS Device", "Any Mac" and the rest. They pin no device, so you can build
+  or archive for a platform without one. Nothing runs on them. See
+  [Build for a whole platform](./build.md#build-for-a-whole-platform).
 
 A status bar item at the bottom of the VSCode window shows the active destination and lets you switch it with one
 click **[2]**.

--- a/sweetpad-vscode/CHANGELOG.md
+++ b/sweetpad-vscode/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 New features, improvements and bug fixes for SweetPad are documented in this file.
 
-## [0.2.14] - 2026-08-24
-
-- Add generic build-only destinations ("Any iOS Device", "Any iOS Simulator Device", and the macOS/watchOS/tvOS/visionOS equivalents) to the destination picker and tree, so you can build or archive for a platform without picking a specific simulator or device ([#71](https://github.com/sweetpad-dev/sweetpad/issues/71))
-
 ## [0.2.13] - 2026-08-24
 
+- Add Xcode's "Any iOS Device" and the other build-only destinations ([#71](https://github.com/sweetpad-dev/sweetpad/issues/71), thanks [@NSExceptional](https://github.com/NSExceptional))
 - Fix autocomplete failing on a first BSP setup because `buildServer.json` was written before the config file it names ([#326](https://github.com/sweetpad-dev/sweetpad/issues/326))
 
 ## [0.2.12] - 2026-08-24

--- a/sweetpad-vscode/CHANGELOG.md
+++ b/sweetpad-vscode/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 New features, improvements and bug fixes for SweetPad are documented in this file.
 
+## [0.2.14] - 2026-08-24
+
+- Add generic build-only destinations ("Any iOS Device", "Any iOS Simulator Device", and the macOS/watchOS/tvOS/visionOS equivalents) to the destination picker and tree, so you can build or archive for a platform without picking a specific simulator or device ([#71](https://github.com/sweetpad-dev/sweetpad/issues/71))
+
 ## [0.2.13] - 2026-08-24
 
 - Fix autocomplete failing on a first BSP setup because `buildServer.json` was written before the config file it names ([#326](https://github.com/sweetpad-dev/sweetpad/issues/326))

--- a/sweetpad-vscode/package.json
+++ b/sweetpad-vscode/package.json
@@ -1049,7 +1049,8 @@
                 "iOSDevice",
                 "watchOSDevice",
                 "tvOSDevice",
-                "visionOSDevice"
+                "visionOSDevice",
+                "generic"
               ],
               "description": "What kind of thing the id names. Also how SweetPad expands a plain UDID into a full id."
             }

--- a/sweetpad-vscode/src/build/generic-destination.spec.ts
+++ b/sweetpad-vscode/src/build/generic-destination.spec.ts
@@ -1,4 +1,15 @@
-import { GENERIC_DESTINATIONS, GenericDestination } from "../destination/types";
+import {
+  GENERIC_DESTINATIONS,
+  GenericDestination,
+  macOSDestination,
+  normalizeDestinationId,
+} from "../destination/types";
+import {
+  assertDestinationSupportsAction,
+  assertRunnableDestination,
+  filterDestinationsForAction,
+  findDestinationForTaskInput,
+} from "../destination/utils";
 import { getXcodeBuildDestinationString } from "./utils";
 
 describe("generic build-only destinations", () => {
@@ -23,7 +34,7 @@ describe("generic build-only destinations", () => {
       platformArg: "iOS Simulator",
     });
     expect(anyIOSSim.id).toBe("generic-ios-simulator");
-    expect(anyIOSSim.type).toBe("Generic");
+    expect(anyIOSSim.type).toBe("generic");
   });
 
   it("every catalog entry round-trips its id through the -destination string", () => {
@@ -35,5 +46,70 @@ describe("generic build-only destinations", () => {
     const names = GENERIC_DESTINATIONS.map((d) => d.name);
     expect(names).toContain("Any iOS Device");
     expect(names).toContain("Any iOS Simulator Device");
+  });
+});
+
+describe("build-only destinations and what an action can use", () => {
+  const anyIOS = new GenericDestination({ name: "Any iOS Device", platform: "iphoneos", platformArg: "iOS" });
+  const myMac = new macOSDestination({ name: "My Mac", arch: "arm64" });
+
+  it.each(["build", "clean"] as const)("offers them to %s, which needs no device", (action) => {
+    expect(filterDestinationsForAction([myMac, anyIOS], action)).toEqual([myMac, anyIOS]);
+  });
+
+  it.each(["run", "launch", "test"] as const)("keeps them out of the %s picker", (action) => {
+    expect(filterDestinationsForAction([myMac, anyIOS], action)).toEqual([myMac]);
+  });
+
+  it("refuses one that reaches a run, launch or test path anyway", () => {
+    // A pinned or task-named destination skips the picker, so the filter alone isn't enough.
+    expect(() => assertRunnableDestination(anyIOS, "test")).toThrow(
+      '"Any iOS Device" is a build-only destination. Pick a simulator or device to test.',
+    );
+    expect(() => assertRunnableDestination(myMac, "test")).not.toThrow();
+  });
+
+  it.each(["build", "clean"] as const)("lets one through on %s", (action) => {
+    expect(() => assertDestinationSupportsAction(anyIOS, action)).not.toThrow();
+  });
+});
+
+describe("resolving a hand-written generic id", () => {
+  it.each(["iOS Simulator", "ios-simulator", "IOS SIMULATOR", "generic-ios-simulator"])(
+    "folds %s onto the catalog id",
+    (written) => {
+      expect(normalizeDestinationId(written, "generic")).toBe("generic-ios-simulator");
+    },
+  );
+});
+
+describe("resolving the destination a task named", () => {
+  const anyIOS = new GenericDestination({ name: "Any iOS Device", platform: "iphoneos", platformArg: "iOS" });
+  const anyMac = new GenericDestination({ name: "Any Mac", platform: "macosx", platformArg: "macOS" });
+  const myMac = new macOSDestination({ name: "My Mac", arch: "arm64" });
+  // My Mac is scanned before the generics, so it gets first refusal on every string.
+  const destinations = [myMac, anyIOS, anyMac];
+
+  it.each(["generic/platform=macOS", "generic/platform=macos", " generic/platform=macOS "])(
+    "reads %s as Any Mac, not this Mac",
+    (destination) => {
+      expect(findDestinationForTaskInput(destinations, { destination })).toBe(anyMac);
+    },
+  );
+
+  it("still reads a plain macOS destination as this Mac", () => {
+    expect(findDestinationForTaskInput(destinations, { destination: "platform=macOS,arch=arm64" })).toBe(myMac);
+  });
+
+  it("reads a device-less string for any other platform too", () => {
+    expect(findDestinationForTaskInput(destinations, { destination: "generic/platform=iOS" })).toBe(anyIOS);
+  });
+
+  it("still accepts a generic destination named by its id", () => {
+    expect(findDestinationForTaskInput(destinations, { destinationId: "generic-ios" })).toBe(anyIOS);
+  });
+
+  it("matches nothing when the platform isn't one we offer", () => {
+    expect(findDestinationForTaskInput(destinations, { destination: "generic/platform=DriverKit" })).toBeUndefined();
   });
 });

--- a/sweetpad-vscode/src/build/generic-destination.spec.ts
+++ b/sweetpad-vscode/src/build/generic-destination.spec.ts
@@ -1,0 +1,39 @@
+import { GENERIC_DESTINATIONS, GenericDestination } from "../destination/types";
+import { getXcodeBuildDestinationString } from "./utils";
+
+describe("generic build-only destinations", () => {
+  it("serialize to xcodebuild's device-less `generic/platform=…`", () => {
+    const anyIOS = new GenericDestination({ name: "Any iOS Device", platform: "iphoneos", platformArg: "iOS" });
+    const anyIOSSim = new GenericDestination({
+      name: "Any iOS Simulator Device",
+      platform: "iphonesimulator",
+      platformArg: "iOS Simulator",
+    });
+
+    expect(getXcodeBuildDestinationString({ destination: anyIOS })).toBe("generic/platform=iOS");
+    expect(getXcodeBuildDestinationString({ destination: anyIOSSim })).toBe("generic/platform=iOS Simulator");
+    // No id/arch is appended — that's what makes it device-less/build-only.
+    expect(getXcodeBuildDestinationString({ destination: anyIOS })).not.toContain("id=");
+  });
+
+  it("build a stable, prefix-matched id from the platform arg", () => {
+    const anyIOSSim = new GenericDestination({
+      name: "Any iOS Simulator Device",
+      platform: "iphonesimulator",
+      platformArg: "iOS Simulator",
+    });
+    expect(anyIOSSim.id).toBe("generic-ios-simulator");
+    expect(anyIOSSim.type).toBe("Generic");
+  });
+
+  it("every catalog entry round-trips its id through the -destination string", () => {
+    for (const destination of GENERIC_DESTINATIONS) {
+      expect(getXcodeBuildDestinationString({ destination })).toBe(`generic/platform=${destination.platformArg}`);
+      expect(destination.id.startsWith("generic-")).toBe(true);
+    }
+    // The two the issue explicitly asked for are present.
+    const names = GENERIC_DESTINATIONS.map((d) => d.name);
+    expect(names).toContain("Any iOS Device");
+    expect(names).toContain("Any iOS Simulator Device");
+  });
+});

--- a/sweetpad-vscode/src/build/hot-reload.ts
+++ b/sweetpad-vscode/src/build/hot-reload.ts
@@ -37,6 +37,7 @@ export function dylibNameFor(type: DestinationType): string | null {
     case "tvOSDevice":
     case "watchOSDevice":
     case "visionOSDevice":
+    case "generic":
       return null;
   }
 }

--- a/sweetpad-vscode/src/build/manager.ts
+++ b/sweetpad-vscode/src/build/manager.ts
@@ -493,6 +493,13 @@ export class BuildManager {
       xcworkspace: xcworkspace,
     });
 
+    // "Any … Device" is a device-less build-only destination — nothing to run on.
+    if (destination.type === "Generic") {
+      throw new ExtensionError(
+        `"${destination.name}" is a build-only destination — pick a simulator or device to run, or use the Build command.`,
+      );
+    }
+
     const sdk = destination.platform;
 
     const schemeSettings = await getSchemeLaunchSettings({ xcworkspace: xcworkspace, scheme: scheme });
@@ -599,6 +606,13 @@ export class BuildManager {
       sdk: undefined,
       xcworkspace: xcworkspace,
     });
+
+    // "Any … Device" is a device-less build-only destination — nothing to run on.
+    if (destination.type === "Generic") {
+      throw new ExtensionError(
+        `"${destination.name}" is a build-only destination — pick a simulator or device to run, or use the Build command.`,
+      );
+    }
 
     const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 

--- a/sweetpad-vscode/src/build/manager.ts
+++ b/sweetpad-vscode/src/build/manager.ts
@@ -27,6 +27,7 @@ import type { WorkspaceStateService } from "../common/workspace-state";
 import * as iosDeploy from "../common/xcode/ios-deploy";
 import type { DestinationsManager } from "../destination/manager";
 import type { DestinationType } from "../destination/types";
+import { assertRunnableDestination } from "../destination/utils";
 import type { TunnelManager } from "../devices/tunnel";
 import type { DeviceDestination } from "../devices/types";
 import { resolveDeviceRunMethod } from "../devices/utils";
@@ -431,6 +432,7 @@ export class BuildManager {
       configuration: configuration,
       sdk: undefined,
       xcworkspace: xcworkspace,
+      action: "build",
     });
     const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 
@@ -491,14 +493,12 @@ export class BuildManager {
       configuration: configuration,
       sdk: undefined,
       xcworkspace: xcworkspace,
+      action: "run",
     });
 
-    // "Any … Device" is a device-less build-only destination — nothing to run on.
-    if (destination.type === "Generic") {
-      throw new ExtensionError(
-        `"${destination.name}" is a build-only destination — pick a simulator or device to run, or use the Build command.`,
-      );
-    }
+    // The lookup above already refused a build-only destination; restating it is what
+    // makes the per-device dispatch below exhaustive for the compiler.
+    assertRunnableDestination(destination, "run");
 
     const sdk = destination.platform;
 
@@ -605,14 +605,12 @@ export class BuildManager {
       configuration: configuration,
       sdk: undefined,
       xcworkspace: xcworkspace,
+      action: "launch",
     });
 
-    // "Any … Device" is a device-less build-only destination — nothing to run on.
-    if (destination.type === "Generic") {
-      throw new ExtensionError(
-        `"${destination.name}" is a build-only destination — pick a simulator or device to run, or use the Build command.`,
-      );
-    }
+    // The lookup above already refused a build-only destination; restating it is what
+    // makes the per-device dispatch below exhaustive for the compiler.
+    assertRunnableDestination(destination, "launch");
 
     const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 
@@ -1349,6 +1347,7 @@ export class BuildManager {
       configuration: configuration,
       sdk: undefined,
       xcworkspace: xcworkspace,
+      action: "clean",
     });
     const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 
@@ -1403,6 +1402,7 @@ export class BuildManager {
       configuration: configuration,
       sdk: undefined,
       xcworkspace: xcworkspace,
+      action: "test",
     });
     const destinationRaw = getXcodeBuildDestinationString({ destination: destination });
 

--- a/sweetpad-vscode/src/build/provider.ts
+++ b/sweetpad-vscode/src/build/provider.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 import { TaskExecutionScope } from "../common/commands";
 import { getWorkspaceConfig } from "../common/config";
 import { errorReporting } from "../common/error-reporting";
+import { ExtensionError } from "../common/errors";
 import type { ExecutionScopeService } from "../common/execution-scope";
 import { setTaskPresentationOptions } from "../common/tasks/presentation";
 import { loadNodePty } from "../common/tasks/pty";
@@ -126,6 +127,9 @@ class ActionDispatcher {
           return d.udid.toLowerCase() === udidLower;
         case "macOS":
           return isMacOS;
+        case "Generic":
+          // Build-only; no udid — match only when a task names its id directly.
+          return d.id === udidLower;
         default:
           assertUnreachable(d);
       }
@@ -206,6 +210,13 @@ class ActionDispatcher {
       configuration: configuration,
       xcworkspace: xcworkspace,
     });
+
+    // "Any … Device" is a device-less build-only destination — there's nothing to launch.
+    if (destination.type === "Generic") {
+      throw new ExtensionError(
+        `"${destination.name}" is a build-only destination — use the Build task, or pick a simulator or device to launch.`,
+      );
+    }
 
     const destinationRaw = definition.destination ?? getXcodeBuildDestinationString({ destination: destination });
 
@@ -387,6 +398,13 @@ class ActionDispatcher {
       configuration: configuration,
       xcworkspace: xcworkspace,
     });
+
+    // "Any … Device" is a device-less build-only destination — there's nothing to run.
+    if (destination.type === "Generic") {
+      throw new ExtensionError(
+        `"${destination.name}" is a build-only destination — use the Build task, or pick a simulator or device to run.`,
+      );
+    }
 
     const sdk = destination.platform;
 

--- a/sweetpad-vscode/src/build/provider.ts
+++ b/sweetpad-vscode/src/build/provider.ts
@@ -3,7 +3,6 @@ import * as vscode from "vscode";
 import { TaskExecutionScope } from "../common/commands";
 import { getWorkspaceConfig } from "../common/config";
 import { errorReporting } from "../common/error-reporting";
-import { ExtensionError } from "../common/errors";
 import type { ExecutionScopeService } from "../common/execution-scope";
 import { setTaskPresentationOptions } from "../common/tasks/presentation";
 import { loadNodePty } from "../common/tasks/pty";
@@ -16,6 +15,12 @@ import type { WorkspaceContextService } from "../common/workspace-context";
 import type { WorkspaceStateService } from "../common/workspace-state";
 import type { DestinationsManager } from "../destination/manager";
 import type { Destination } from "../destination/types";
+import {
+  type DestinationAction,
+  assertDestinationSupportsAction,
+  assertRunnableDestination,
+  findDestinationForTaskInput,
+} from "../destination/utils";
 import type { ProgressStatusBar } from "../system/status-bar";
 import { BUILD_TASK_PROBLEM_MATCHERS } from "./constants";
 import type { BuildManager } from "./manager";
@@ -100,42 +105,8 @@ class ActionDispatcher {
     destinationsManager: DestinationsManager,
     options: { definition: TaskDefinition },
   ): Promise<Destination | undefined> {
-    // For simulators and devices, we try to find destination by ID
-    // ex: "00000000-0000-0000-0000-000000000000"
-    // ex: "platform=iOS Simulator,id=00000000-0000-0000-0000-000000000000"
-    const udidRaw: string | undefined =
-      options.definition.destinationId ??
-      options.definition.simulator ??
-      options.definition.destination?.match(/id=(.+)/)?.[1];
-
-    const udidLower = udidRaw?.trim()?.toLowerCase();
-
-    // For macOS, we just check if the destination string contains "macos"
-    const isMacOS = options.definition.destination?.toLowerCase().includes("macos") ?? false;
-
     const destinations = await destinationsManager.getDestinations();
-    const destination = destinations.find((d) => {
-      switch (d.type) {
-        case "iOSSimulator":
-        case "watchOSSimulator":
-        case "visionOSSimulator":
-        case "tvOSSimulator":
-        case "iOSDevice":
-        case "watchOSDevice":
-        case "visionOSDevice":
-        case "tvOSDevice":
-          return d.udid.toLowerCase() === udidLower;
-        case "macOS":
-          return isMacOS;
-        case "Generic":
-          // Build-only; no udid — match only when a task names its id directly.
-          return d.id === udidLower;
-        default:
-          assertUnreachable(d);
-      }
-    });
-
-    return destination;
+    return findDestinationForTaskInput(destinations, options.definition);
   }
 
   private async getDestination(options: {
@@ -144,12 +115,16 @@ class ActionDispatcher {
     scheme: string;
     configuration: string;
     xcworkspace: string;
+    action: DestinationAction;
   }): Promise<Destination> {
     // If user has provided the ID of the destination, then use it directly
     const inputDestination = await this.getDestinationByUserInput(this.deps.destinationsManager, {
       definition: options.definition,
     });
     if (inputDestination) {
+      // A task is free to name a build-only destination; only the actions that need a
+      // device have to turn it down, and this says so instead of failing inside xcodebuild.
+      assertDestinationSupportsAction(inputDestination, options.action);
       return inputDestination;
     }
 
@@ -160,6 +135,7 @@ class ActionDispatcher {
       configuration: options.configuration,
       sdk: undefined,
       xcworkspace: options.xcworkspace,
+      action: options.action,
     });
     return destination;
   }
@@ -209,14 +185,12 @@ class ActionDispatcher {
       scheme: scheme,
       configuration: configuration,
       xcworkspace: xcworkspace,
+      action: "launch",
     });
 
-    // "Any … Device" is a device-less build-only destination — there's nothing to launch.
-    if (destination.type === "Generic") {
-      throw new ExtensionError(
-        `"${destination.name}" is a build-only destination — use the Build task, or pick a simulator or device to launch.`,
-      );
-    }
+    // The lookup above already refused a build-only destination; restating it is what
+    // makes the per-device dispatch below exhaustive for the compiler.
+    assertRunnableDestination(destination, "launch");
 
     const destinationRaw = definition.destination ?? getXcodeBuildDestinationString({ destination: destination });
 
@@ -333,6 +307,7 @@ class ActionDispatcher {
       scheme: scheme,
       configuration: configuration,
       xcworkspace: xcworkspace,
+      action: "build",
     });
 
     const destinationRaw = definition.destination ?? getXcodeBuildDestinationString({ destination: destination });
@@ -397,14 +372,12 @@ class ActionDispatcher {
       scheme: scheme,
       configuration: configuration,
       xcworkspace: xcworkspace,
+      action: "run",
     });
 
-    // "Any … Device" is a device-less build-only destination — there's nothing to run.
-    if (destination.type === "Generic") {
-      throw new ExtensionError(
-        `"${destination.name}" is a build-only destination — use the Build task, or pick a simulator or device to run.`,
-      );
-    }
+    // The lookup above already refused a build-only destination; restating it is what
+    // makes the per-device dispatch below exhaustive for the compiler.
+    assertRunnableDestination(destination, "run");
 
     const sdk = destination.platform;
 
@@ -495,6 +468,7 @@ class ActionDispatcher {
       scheme: scheme,
       configuration: configuration,
       xcworkspace: xcworkspace,
+      action: "clean",
     });
 
     const destinationRaw = definition.destination ?? getXcodeBuildDestinationString({ destination: destination });
@@ -545,6 +519,7 @@ class ActionDispatcher {
       scheme: scheme,
       configuration: configuration,
       xcworkspace: xcworkspace,
+      action: "test",
     });
 
     const destinationRaw = definition.destination ?? getXcodeBuildDestinationString({ destination: destination });

--- a/sweetpad-vscode/src/build/utils.spec.ts
+++ b/sweetpad-vscode/src/build/utils.spec.ts
@@ -350,9 +350,7 @@ describe("repairStaleBuildServerConfig", () => {
       workspaceState: stateRemembering("/workspace/App.xcworkspace"),
     });
 
-    expect(mockRepair).toHaveBeenCalledWith(
-      expect.objectContaining({ xcworkspace: "/workspace/App.xcworkspace" }),
-    );
+    expect(mockRepair).toHaveBeenCalledWith(expect.objectContaining({ xcworkspace: "/workspace/App.xcworkspace" }));
   });
 
   it("names no project when the remembered one is a Swift package", async () => {

--- a/sweetpad-vscode/src/build/utils.ts
+++ b/sweetpad-vscode/src/build/utils.ts
@@ -37,7 +37,12 @@ import type { WorkspaceStateService } from "../common/workspace-state";
 import type { DestinationPlatform } from "../destination/constants";
 import type { DestinationsManager } from "../destination/manager";
 import type { Destination } from "../destination/types";
-import { splitSupportedDestinatinos } from "../destination/utils";
+import {
+  type DestinationAction,
+  assertDestinationSupportsAction,
+  filterDestinationsForAction,
+  splitSupportedDestinatinos,
+} from "../destination/utils";
 import type { SimulatorDestination } from "../simulators/types";
 import type { ProgressStatusBar } from "../system/status-bar";
 import { getToolById } from "../tools/constants";
@@ -102,6 +107,8 @@ export async function askDestinationToRunOn(
     configuration: string;
     sdk: string | undefined;
     xcworkspace: string;
+    /** What the caller is about to do with the destination. */
+    action: DestinationAction;
   },
 ): Promise<Destination> {
   progress.updateText("Searching for destinations");
@@ -116,6 +123,9 @@ export async function askDestinationToRunOn(
       (d) => d.id === preferredDestination.id && d.type === preferredDestination.type,
     );
     if (destination) {
+      // A pinned "Any … Device" answers a build, and is refused for anything else rather
+      // than quietly repointing the pin at whatever gets picked instead.
+      assertDestinationSupportsAction(destination, options.action);
       return destination;
     }
   }
@@ -136,6 +146,7 @@ export async function askDestinationToRunOn(
   return await selectDestinationForBuild(destinationsManager, {
     destinations: destinations,
     supportedPlatforms: supportedPlatforms,
+    action: options.action,
   });
 }
 
@@ -144,10 +155,11 @@ export async function selectDestinationForBuild(
   options: {
     destinations: Destination[];
     supportedPlatforms: DestinationPlatform[] | undefined;
+    action: DestinationAction;
   },
 ): Promise<Destination> {
   const { supported, unsupported } = splitSupportedDestinatinos({
-    destinations: options.destinations,
+    destinations: filterDestinationsForAction(options.destinations, options.action),
     supportedPlatforms: options.supportedPlatforms,
   });
 
@@ -1072,7 +1084,7 @@ export function getXcodeBuildDestinationString(options: { destination: Destinati
   if (destination.type === "visionOSDevice") {
     return buildDestinationString({ platform: "visionOS", id: destination.udid });
   }
-  if (destination.type === "Generic") {
+  if (destination.type === "generic") {
     // Device-less platform build, e.g. `generic/platform=iOS`. No id/arch.
     return destination.xcodebuildDestination;
   }

--- a/sweetpad-vscode/src/build/utils.ts
+++ b/sweetpad-vscode/src/build/utils.ts
@@ -1072,6 +1072,10 @@ export function getXcodeBuildDestinationString(options: { destination: Destinati
   if (destination.type === "visionOSDevice") {
     return buildDestinationString({ platform: "visionOS", id: destination.udid });
   }
+  if (destination.type === "Generic") {
+    // Device-less platform build, e.g. `generic/platform=iOS`. No id/arch.
+    return destination.xcodebuildDestination;
+  }
   return assertUnreachable(destination);
 }
 

--- a/sweetpad-vscode/src/destination/commands.ts
+++ b/sweetpad-vscode/src/destination/commands.ts
@@ -6,6 +6,7 @@ import type { AppDeps } from "../common/commands";
 import { getWorkspaceConfig } from "../common/config";
 import { selectDestinationForTesting } from "../testing/utils";
 import type { DestinationTreeItem } from "./tree";
+import { assertRunnableDestination } from "./utils";
 
 /**
  * Trigger VS Code's built-in tree find on the Destinations view. Workaround until
@@ -31,6 +32,7 @@ export async function selectDestinationForBuildCommand(deps: AppDeps, item?: Des
   const destination = await selectDestinationForBuild(deps.destinationsManager, {
     destinations: destinations,
     supportedPlatforms: undefined, // All platforms
+    action: "build",
   });
   if (getWorkspaceConfig("build.destination")) {
     return;
@@ -46,6 +48,7 @@ export async function selectDestinationForBuildCommand(deps: AppDeps, item?: Des
 
 export async function selectDestinationForTestingCommand(deps: AppDeps, item?: DestinationTreeItem) {
   if (item) {
+    assertRunnableDestination(item.destination, "test");
     deps.destinationsManager.setWorkspaceDestinationForTesting(item.destination);
     return;
   }

--- a/sweetpad-vscode/src/destination/constants.ts
+++ b/sweetpad-vscode/src/destination/constants.ts
@@ -40,6 +40,7 @@ export const DESTINATION_TYPE_PRIORITY: DestinationType[] = [
   "tvOSDevice",
   "visionOSSimulator",
   "visionOSDevice",
+  "Generic",
 ];
 export const SIMULATOR_TYPE_PRIORITY: SimulatorType[] = [
   "iPhone",

--- a/sweetpad-vscode/src/destination/constants.ts
+++ b/sweetpad-vscode/src/destination/constants.ts
@@ -27,7 +27,6 @@ export const SUPPORTED_DESTINATION_PLATFORMS: DestinationPlatform[] = [
   "appletvsimulator",
   "appletvos",
   "xros",
-  "xrsimulator",
 ];
 
 export const DESTINATION_TYPE_PRIORITY: DestinationType[] = [
@@ -40,7 +39,7 @@ export const DESTINATION_TYPE_PRIORITY: DestinationType[] = [
   "tvOSDevice",
   "visionOSSimulator",
   "visionOSDevice",
-  "Generic",
+  "generic",
 ];
 export const SIMULATOR_TYPE_PRIORITY: SimulatorType[] = [
   "iPhone",

--- a/sweetpad-vscode/src/destination/id-prefixes.spec.ts
+++ b/sweetpad-vscode/src/destination/id-prefixes.spec.ts
@@ -21,6 +21,7 @@ import {
   ALL_DESTINATION_TYPES,
   DESTINATION_ID_PREFIX,
   type Destination,
+  GenericDestination,
   macOSDestination,
   normalizeDestinationId,
 } from "./types";
@@ -77,6 +78,7 @@ const DESTINATIONS: Destination[] = [
   device(watchOSDeviceDestination),
   device(tvOSDeviceDestination),
   device(visionOSDeviceDestination),
+  new GenericDestination({ name: "Any iOS Device", platform: "iphoneos", platformArg: "iOS" }),
 ];
 
 describe("DESTINATION_ID_PREFIX", () => {

--- a/sweetpad-vscode/src/destination/manager.ts
+++ b/sweetpad-vscode/src/destination/manager.ts
@@ -379,7 +379,7 @@ export class DestinationsManager {
       const simulators = await this.getvisionOSSimulators();
       destination = simulators.find((simulator) => simulator.id === options.destinationId);
     }
-    if (!destination && types.includes("Generic")) {
+    if (!destination && types.includes("generic")) {
       destination = this.getGenericDestinations().find((generic) => generic.id === options.destinationId);
     }
     return destination;

--- a/sweetpad-vscode/src/destination/manager.ts
+++ b/sweetpad-vscode/src/destination/manager.ts
@@ -29,6 +29,8 @@ import {
   ALL_DESTINATION_TYPES,
   type Destination,
   type DestinationType,
+  GENERIC_DESTINATIONS,
+  type GenericDestination,
   type SelectedDestination,
   macOSDestination,
   normalizeDestinationId,
@@ -212,6 +214,11 @@ export class DestinationsManager {
     return this.macOSDestinations();
   }
 
+  /** The static build-only "Any … Device" destinations. No I/O to enumerate. */
+  getGenericDestinations(): GenericDestination[] {
+    return [...GENERIC_DESTINATIONS];
+  }
+
   /** Describing the local Mac needs no I/O, so this stays available synchronously. */
   private macOSDestinations(): macOSDestination[] {
     const currentArch = getMacOSArchitecture() ?? "arm64";
@@ -299,6 +306,10 @@ export class DestinationsManager {
       }
     }
 
+    // Build-only "Any … Device" destinations. The picker filters them to the
+    // scheme's supported platforms, so e.g. an iOS project only sees the iOS ones.
+    destinations.push(...this.getGenericDestinations());
+
     // Most used destinations should be on top of the list
     if (options?.mostUsedSort) {
       const usageStats = this.workspaceState.get("build.xcodeDestinationsUsageStatistics") ?? {};
@@ -326,6 +337,7 @@ export class DestinationsManager {
         ...this.simulatorsManager.getCachedSimulators(),
         ...this.devicesManager.getCachedDevices(),
         ...this.macOSDestinations(),
+        ...this.getGenericDestinations(),
       ];
       this.destinationNames = new Map(scanned.map((destination) => [destination.id, destination.name]));
     }
@@ -366,6 +378,9 @@ export class DestinationsManager {
     if (!destination && types.includes("visionOSSimulator")) {
       const simulators = await this.getvisionOSSimulators();
       destination = simulators.find((simulator) => simulator.id === options.destinationId);
+    }
+    if (!destination && types.includes("Generic")) {
+      destination = this.getGenericDestinations().find((generic) => generic.id === options.destinationId);
     }
     return destination;
   }

--- a/sweetpad-vscode/src/destination/tree.ts
+++ b/sweetpad-vscode/src/destination/tree.ts
@@ -494,12 +494,11 @@ export class visionOSDeviceDestinationTreeItem extends BaseDestinationTreeItem i
   }
 }
 
-// Tagged union type for destination tree item (second level)
 /**
  * Tree item representing a generic build-only destination ("Any … Device").
  */
 export class GenericDestinationTreeItem extends BaseDestinationTreeItem implements IDestinationTreeItem {
-  type = "Generic" as const;
+  type = "generic" as const;
   device: GenericDestination;
   provider: DestinationsTreeProvider;
   constructor(options: { device: GenericDestination; provider: DestinationsTreeProvider; isRecent?: boolean }) {
@@ -530,6 +529,7 @@ export class GenericDestinationTreeItem extends BaseDestinationTreeItem implemen
   }
 }
 
+// Tagged union type for destination tree item (second level)
 export type DestinationTreeItem =
   | iOSSimulatorDestinationTreeItem
   | watchOSSimulatorDestinationTreeItem
@@ -606,7 +606,7 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
       if (element.type === "visionOSDevice") {
         return this.getVisionOSDevices();
       }
-      if (element.type === "Generic") {
+      if (element.type === "generic") {
         return this.getGenericDestinations();
       }
       if (element.type === "Recent") {
@@ -685,7 +685,7 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
           isRecent: true,
         });
       }
-      if (destination.type === "Generic") {
+      if (destination.type === "generic") {
         return new GenericDestinationTreeItem({
           device: destination,
           provider: this,
@@ -780,7 +780,7 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
       }),
       new DestinationGroupTreeItem({
         label: "Generic (build-only)",
-        type: "Generic",
+        type: "generic",
         contextValue: "destination-group-generic",
         collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
         icon: "vm",

--- a/sweetpad-vscode/src/destination/tree.ts
+++ b/sweetpad-vscode/src/destination/tree.ts
@@ -14,7 +14,13 @@ import type {
   watchOSSimulatorDestination,
 } from "../simulators/types.js";
 import type { DestinationsManager } from "./manager.js";
-import type { Destination, DestinationType, SelectedDestination, macOSDestination } from "./types.js";
+import type {
+  Destination,
+  DestinationType,
+  GenericDestination,
+  SelectedDestination,
+  macOSDestination,
+} from "./types.js";
 
 function addSelectedMarks(options: {
   description: string;
@@ -489,6 +495,41 @@ export class visionOSDeviceDestinationTreeItem extends BaseDestinationTreeItem i
 }
 
 // Tagged union type for destination tree item (second level)
+/**
+ * Tree item representing a generic build-only destination ("Any … Device").
+ */
+export class GenericDestinationTreeItem extends BaseDestinationTreeItem implements IDestinationTreeItem {
+  type = "Generic" as const;
+  device: GenericDestination;
+  provider: DestinationsTreeProvider;
+  constructor(options: { device: GenericDestination; provider: DestinationsTreeProvider; isRecent?: boolean }) {
+    super({
+      label: options.device.name,
+      collapsibleState: vscode.TreeItemCollapsibleState.None,
+      contextPrefix: "destination-item-generic",
+    });
+    this.device = options.device;
+    this.provider = options.provider;
+
+    this.description = addSelectedMarks({
+      description: "build-only",
+      current: this.device,
+      selectedForBuild: this.provider.selectedDestinationForBuild,
+      selectedForTesting: this.provider.selectedDestinationForTesting,
+    });
+
+    this.iconPath = new vscode.ThemeIcon(this.device.icon, undefined);
+    if (options.isRecent) {
+      this.setContextState("recent", "true");
+    }
+    this.refreshContextValue();
+  }
+
+  get destination(): GenericDestination {
+    return this.device;
+  }
+}
+
 export type DestinationTreeItem =
   | iOSSimulatorDestinationTreeItem
   | watchOSSimulatorDestinationTreeItem
@@ -498,7 +539,8 @@ export type DestinationTreeItem =
   | iOSDeviceDestinationTreeItem
   | watchOSDeviceDestinationTreeItem
   | tvOSDeviceDestinationTreeItem
-  | visionOSDeviceDestinationTreeItem;
+  | visionOSDeviceDestinationTreeItem
+  | GenericDestinationTreeItem;
 
 export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
   public manager: DestinationsManager;
@@ -563,6 +605,9 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
       }
       if (element.type === "visionOSDevice") {
         return this.getVisionOSDevices();
+      }
+      if (element.type === "Generic") {
+        return this.getGenericDestinations();
       }
       if (element.type === "Recent") {
         return await this.getRecentDestinations();
@@ -635,6 +680,13 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
       }
       if (destination.type === "visionOSDevice") {
         return new visionOSDeviceDestinationTreeItem({
+          device: destination,
+          provider: this,
+          isRecent: true,
+        });
+      }
+      if (destination.type === "Generic") {
+        return new GenericDestinationTreeItem({
           device: destination,
           provider: this,
           isRecent: true,
@@ -725,6 +777,13 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
         contextValue: "destination-group-device-visionos",
         collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
         icon: "sweetpad-circle-letter-v",
+      }),
+      new DestinationGroupTreeItem({
+        label: "Generic (build-only)",
+        type: "Generic",
+        contextValue: "destination-group-generic",
+        collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+        icon: "vm",
       }),
     );
 
@@ -833,6 +892,15 @@ export class DestinationsTreeProvider implements vscode.TreeDataProvider<vscode.
 
     return devices.map((device) => {
       return new macOSDestinationTreeItem({
+        device: device,
+        provider: this,
+      });
+    });
+  }
+
+  getGenericDestinations(): DestinationTreeItem[] {
+    return this.manager.getGenericDestinations().map((device) => {
+      return new GenericDestinationTreeItem({
         device: device,
         provider: this,
       });

--- a/sweetpad-vscode/src/destination/types.ts
+++ b/sweetpad-vscode/src/destination/types.ts
@@ -22,7 +22,10 @@ export type DestinationType =
   | "iOSDevice"
   | "watchOSDevice"
   | "tvOSDevice"
-  | "visionOSDevice";
+  | "visionOSDevice"
+  // A device-less "Any <platform> Device" destination (xcodebuild's
+  // `generic/platform=…`). Build-only — it can't be run or debugged.
+  | "Generic";
 
 export type DestinationArch = "arm64" | "x86_64";
 
@@ -36,6 +39,7 @@ export const ALL_DESTINATION_TYPES: DestinationType[] = [
   "watchOSDevice",
   "tvOSDevice",
   "visionOSDevice",
+  "Generic",
 ];
 
 /**
@@ -57,6 +61,7 @@ export const DESTINATION_ID_PREFIX: Record<DestinationType, string> = {
   watchOSDevice: "watchosdevice-",
   tvOSDevice: "tvosdevice-",
   visionOSDevice: "visionosdevice-",
+  Generic: "generic-",
 };
 
 /**
@@ -119,6 +124,78 @@ export class macOSDestination implements IDestination {
   }
 }
 
+/**
+ * A device-less "Any <platform> Device" destination — xcodebuild's
+ * `generic/platform=…`. It binds no specific simulator or device, so it is
+ * **build-only**: building/archiving works, but running and debugging do not.
+ * These are synthetic (no I/O to enumerate), mirroring `macOSDestination`.
+ */
+export class GenericDestination implements IDestination {
+  type = "Generic" as const;
+  typeLabel = "Generic";
+  icon = "vm";
+
+  readonly name: string;
+  readonly platform: DestinationPlatform;
+  /** The label after `generic/platform=`, e.g. "iOS" or "iOS Simulator". */
+  readonly platformArg: string;
+
+  constructor(options: { name: string; platform: DestinationPlatform; platformArg: string }) {
+    this.name = options.name;
+    this.platform = options.platform;
+    this.platformArg = options.platformArg;
+  }
+
+  get id(): string {
+    return `generic-${this.platformArg.toLowerCase().replace(/\s+/g, "-")}`;
+  }
+
+  get label(): string {
+    return this.name;
+  }
+
+  get quickPickDetails(): string {
+    return `Type: ${this.typeLabel} (build-only), Destination: ${this.xcodebuildDestination}`;
+  }
+
+  /** The value passed to `xcodebuild -destination` for a device-less platform build. */
+  get xcodebuildDestination(): string {
+    return `generic/platform=${this.platformArg}`;
+  }
+}
+
+/**
+ * The generic build-only destinations Xcode exposes as "Any … Device". Static, so
+ * they're always offered (a scheme's supported platforms filter them in the picker).
+ */
+export const GENERIC_DESTINATIONS: GenericDestination[] = [
+  new GenericDestination({ name: "Any iOS Device", platform: "iphoneos", platformArg: "iOS" }),
+  new GenericDestination({
+    name: "Any iOS Simulator Device",
+    platform: "iphonesimulator",
+    platformArg: "iOS Simulator",
+  }),
+  new GenericDestination({ name: "Any Mac", platform: "macosx", platformArg: "macOS" }),
+  new GenericDestination({ name: "Any watchOS Device", platform: "watchos", platformArg: "watchOS" }),
+  new GenericDestination({
+    name: "Any watchOS Simulator Device",
+    platform: "watchsimulator",
+    platformArg: "watchOS Simulator",
+  }),
+  new GenericDestination({ name: "Any tvOS Device", platform: "appletvos", platformArg: "tvOS" }),
+  new GenericDestination({
+    name: "Any tvOS Simulator Device",
+    platform: "appletvsimulator",
+    platformArg: "tvOS Simulator",
+  }),
+  new GenericDestination({ name: "Any visionOS Device", platform: "xros", platformArg: "visionOS" }),
+  new GenericDestination({
+    name: "Any visionOS Simulator Device",
+    platform: "xrsimulator",
+    platformArg: "visionOS Simulator",
+  }),
+];
+
 export type Destination =
   | iOSSimulatorDestination
   | watchOSSimulatorDestination
@@ -128,7 +205,8 @@ export type Destination =
   | iOSDeviceDestination
   | watchOSDeviceDestination
   | tvOSDeviceDestination
-  | visionOSDeviceDestination;
+  | visionOSDeviceDestination
+  | GenericDestination;
 
 /**
  * Lightweight representation of a selected destination that can be stored in the workspace state (we can't

--- a/sweetpad-vscode/src/destination/types.ts
+++ b/sweetpad-vscode/src/destination/types.ts
@@ -25,7 +25,7 @@ export type DestinationType =
   | "visionOSDevice"
   // A device-less "Any <platform> Device" destination (xcodebuild's
   // `generic/platform=…`). Build-only — it can't be run or debugged.
-  | "Generic";
+  | "generic";
 
 export type DestinationArch = "arm64" | "x86_64";
 
@@ -39,7 +39,7 @@ export const ALL_DESTINATION_TYPES: DestinationType[] = [
   "watchOSDevice",
   "tvOSDevice",
   "visionOSDevice",
-  "Generic",
+  "generic",
 ];
 
 /**
@@ -61,13 +61,21 @@ export const DESTINATION_ID_PREFIX: Record<DestinationType, string> = {
   watchOSDevice: "watchosdevice-",
   tvOSDevice: "tvosdevice-",
   visionOSDevice: "visionosdevice-",
-  Generic: "generic-",
+  generic: "generic-",
 };
 
 /**
  * Expand a "sweetpad.build.destination" id into the canonical form the destination
  * classes produce, so a hand-written setting can name just the udid.
  */
+/**
+ * The platform slug inside a generic id: lowercase, spaces hyphenated. "iOS Simulator"
+ * becomes "ios-simulator".
+ */
+function genericPlatformSlug(platformArg: string): string {
+  return platformArg.toLowerCase().replace(/\s+/g, "-");
+}
+
 export function normalizeDestinationId(id: string, type: DestinationType): string {
   // A hand-edited setting can name a type that doesn't exist, and there is no prefix to
   // apply for one. Leave the id alone so a fully qualified one still matches; the picker
@@ -76,7 +84,10 @@ export function normalizeDestinationId(id: string, type: DestinationType): strin
   if (!prefix) {
     return id;
   }
-  return id.startsWith(prefix) ? id : `${prefix}${id}`;
+  // A generic id names a platform rather than a udid, so a hand-written "iOS Simulator"
+  // is the same destination as "ios-simulator" and folds into the canonical slug.
+  const value = type === "generic" ? genericPlatformSlug(id) : id;
+  return value.startsWith(prefix) ? value : `${prefix}${value}`;
 }
 
 /**
@@ -131,7 +142,7 @@ export class macOSDestination implements IDestination {
  * These are synthetic (no I/O to enumerate), mirroring `macOSDestination`.
  */
 export class GenericDestination implements IDestination {
-  type = "Generic" as const;
+  type = "generic" as const;
   typeLabel = "Generic";
   icon = "vm";
 
@@ -147,7 +158,7 @@ export class GenericDestination implements IDestination {
   }
 
   get id(): string {
-    return `generic-${this.platformArg.toLowerCase().replace(/\s+/g, "-")}`;
+    return `generic-${genericPlatformSlug(this.platformArg)}`;
   }
 
   get label(): string {
@@ -168,7 +179,7 @@ export class GenericDestination implements IDestination {
  * The generic build-only destinations Xcode exposes as "Any … Device". Static, so
  * they're always offered (a scheme's supported platforms filter them in the picker).
  */
-export const GENERIC_DESTINATIONS: GenericDestination[] = [
+export const GENERIC_DESTINATIONS: readonly GenericDestination[] = [
   new GenericDestination({ name: "Any iOS Device", platform: "iphoneos", platformArg: "iOS" }),
   new GenericDestination({
     name: "Any iOS Simulator Device",

--- a/sweetpad-vscode/src/destination/utils.ts
+++ b/sweetpad-vscode/src/destination/utils.ts
@@ -1,7 +1,9 @@
 import os from "node:os";
 
+import { ExtensionError } from "../common/errors";
+import { assertUnreachable } from "../common/types";
 import type { DestinationPlatform } from "./constants";
-import type { Destination } from "./types";
+import type { Destination, GenericDestination } from "./types";
 
 export function getMacOSArchitecture(): "arm64" | "x86_64" | null {
   const architecture = os.arch();
@@ -47,4 +49,105 @@ export function splitSupportedDestinatinos(options: {
     supported: supportedDestinations,
     unsupported: unsupportedDestinations,
   };
+}
+
+/** Actions that install and launch something, so they need a real simulator or device. */
+export type DeviceAction = "run" | "launch" | "test";
+
+/** What a destination was picked for. */
+export type DestinationAction = "build" | "clean" | DeviceAction;
+
+/**
+ * Every destination that binds a simulator or device. A device-less "Any … Device" is
+ * the one thing a `DeviceAction` cannot be handed.
+ */
+export type RunnableDestination = Exclude<Destination, GenericDestination>;
+
+const DEVICE_ACTIONS: ReadonlySet<DestinationAction> = new Set(["run", "launch", "test"]);
+
+function needsDevice(action: DestinationAction): action is DeviceAction {
+  return DEVICE_ACTIONS.has(action);
+}
+
+/**
+ * Drop the destinations an action can't use, so the picker never offers a dead end.
+ * Resolution is left alone: a pinned or recent "Any … Device" still resolves, and the
+ * asserts below are what turn it into a readable error.
+ */
+export function filterDestinationsForAction(destinations: Destination[], action: DestinationAction): Destination[] {
+  if (!needsDevice(action)) {
+    return destinations;
+  }
+  return destinations.filter((destination) => destination.type !== "generic");
+}
+
+/**
+ * Refuse a device-less destination before it reaches xcodebuild, which would otherwise
+ * fail deep inside the task with a raw "unable to find a destination matching" line.
+ */
+export function assertRunnableDestination(
+  destination: Destination,
+  action: DeviceAction,
+): asserts destination is RunnableDestination {
+  if (destination.type !== "generic") {
+    return;
+  }
+  throw new ExtensionError(
+    `"${destination.name}" is a build-only destination. Pick a simulator or device to ${action}.`,
+  );
+}
+
+/** The same check for callers holding an action they were handed rather than a literal. */
+export function assertDestinationSupportsAction(destination: Destination, action: DestinationAction): void {
+  if (needsDevice(action)) {
+    assertRunnableDestination(destination, action);
+  }
+}
+
+/**
+ * The destination a task named, out of the ones currently known.
+ *
+ * A task can say `destinationId`, the deprecated `simulator`, or a raw `-destination`
+ * string, and the string comes in two shapes: `generic/platform=<platform>` for a
+ * device-less build, and `platform=<platform>,id=<udid>` for everything else.
+ */
+export function findDestinationForTaskInput(
+  destinations: Destination[],
+  input: { destinationId?: string; simulator?: string; destination?: string },
+): Destination | undefined {
+  const udidRaw = input.destinationId ?? input.simulator ?? input.destination?.match(/id=(.+)/)?.[1];
+  const udidLower = udidRaw?.trim()?.toLowerCase();
+
+  // A device-less destination names a platform and nothing else, so it is the one shape
+  // that reads exactly. Taking it first also keeps "generic/platform=macOS" away from the
+  // substring test below, which would otherwise claim it for this Mac.
+  const genericPlatform = input.destination
+    ?.trim()
+    .match(/^generic\/platform=(.+)$/i)?.[1]
+    ?.toLowerCase();
+
+  // For macOS, we just check if the destination string contains "macos"
+  const isMacOS = !genericPlatform && (input.destination?.toLowerCase().includes("macos") ?? false);
+
+  return destinations.find((d) => {
+    switch (d.type) {
+      case "iOSSimulator":
+      case "watchOSSimulator":
+      case "visionOSSimulator":
+      case "tvOSSimulator":
+      case "iOSDevice":
+      case "watchOSDevice":
+      case "visionOSDevice":
+      case "tvOSDevice":
+        return d.udid.toLowerCase() === udidLower;
+      case "macOS":
+        return isMacOS;
+      case "generic":
+        // Build-only, so there is no udid: a task names one by its `-destination` string
+        // or by its id.
+        return genericPlatform ? d.platformArg.toLowerCase() === genericPlatform : d.id === udidLower;
+      default:
+        assertUnreachable(d);
+    }
+  });
 }

--- a/sweetpad-vscode/src/testing/utils.ts
+++ b/sweetpad-vscode/src/testing/utils.ts
@@ -8,7 +8,11 @@ import { type QuickPickItem, showQuickPick } from "../common/quick-pick";
 import type { DestinationPlatform } from "../destination/constants";
 import type { DestinationsManager } from "../destination/manager";
 import type { Destination } from "../destination/types";
-import { splitSupportedDestinatinos } from "../destination/utils";
+import {
+  assertRunnableDestination,
+  filterDestinationsForAction,
+  splitSupportedDestinatinos,
+} from "../destination/utils";
 import type { ProgressStatusBar } from "../system/status-bar";
 import type { TestingManager } from "./manager";
 
@@ -108,6 +112,7 @@ export async function askDestinationToTestOn(
   if (cachedDestination) {
     const destination = destinations.find((d) => d.id === cachedDestination.id && d.type === cachedDestination.type);
     if (destination) {
+      assertRunnableDestination(destination, "test");
       return destination;
     }
   }
@@ -126,7 +131,7 @@ export async function selectDestinationForTesting(
   },
 ): Promise<Destination> {
   const { supported, unsupported } = splitSupportedDestinatinos({
-    destinations: options.destinations,
+    destinations: filterDestinationsForAction(options.destinations, "test"),
     supportedPlatforms: options.supportedPlatforms,
   });
 


### PR DESCRIPTION
## Problem

Xcode's destination menu includes the device-less **"Any iOS Device"**, **"Any iOS Simulator Device"** (and the Mac / watchOS / tvOS / visionOS equivalents) for building or archiving a whole platform without binding a specific simulator or device. SweetPad's destination picker didn't offer them. (#71)

## Fix

Adds a `Generic` destination type — synthetic and I/O-free, modeled on the existing macOS destination — for each platform:

- Any iOS Device / Any iOS Simulator Device
- Any Mac
- Any watchOS Device / Simulator
- Any tvOS Device / Simulator
- Any visionOS Device / Simulator

They appear in the Destinations tree under a new **"Generic (build-only)"** group and in the build destination picker (filtered to the scheme's supported platforms, like every other destination). Building/archiving uses `xcodebuild -destination generic/platform=<platform>`.

Because they bind no device they are **build-only**: selecting one and running/launching/debugging — both in the build manager and the task provider — surfaces a clear *"… is a build-only destination — use the Build task, or pick a simulator or device"* error instead of failing deep in a run path.

Everything routes through the existing plumbing — `DESTINATION_ID_PREFIX`/`normalizeDestinationId`, `findDestination`, recent destinations, and `getXcodeBuildDestinationString` — so a pinned or recent generic destination resolves like any other. The `Destination` union additions made the compiler flag every exhaustive `assertUnreachable` site, so each was handled explicitly.

## Tests

- New `generic-destination.spec.ts` covers `generic/platform=…` serialization and the catalog.
- `id-prefixes.spec.ts` extended so its exhaustive "one destination under test per type" / id-prefix / round-trip checks now cover `Generic`.
- `check:types` is clean for the touched code, `check:lint` and `check:format` pass, and the destination + build unit tests are green (85 tests).

## Notes

- I wasn't able to capture VS Code UI screenshots in this environment — happy to add before/after images of the tree group and picker if you'd like them.
- The CHANGELOG entry is under a new top section; renumber it to whatever the next release version is.

---
Model & harness: Claude Opus 4.8 via Claude Code.

https://claude.ai/code/session_012P398C6HD2mSQmi8z7FEtA
