### PR TITLE
Pass Xcode's header maps to sourcekit-lsp and prepare every target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,17 +66,24 @@ means the tests stop exercising the shape production actually uses.
 `publish-patch.sh` refuses to cut a release without a `## [<version>]` entry for
 the version it is about to tag.
 
-**Keep each entry to one short sentence, about the length of a CLI release
-note.** The CLI's notes are commit subjects, so they stay terse by construction;
-the extension's are hand-written and have drifted into 60-word sentences that
-pack the symptom, the root cause and the mechanism into one breath, usually
-hinged on a colon. Say what changed from the user's side and stop. Anyone who
-wants the diagnosis has the linked issue.
+**Write each entry as a title, not a sentence.** Ten words is a good ceiling:
+one clause, no colon splicing two halves together, no subordinate clause
+explaining the mechanism. The CLI's notes are commit subjects, so they stay
+terse by construction; the extension's are hand-written, and the failure mode is
+a 60-word entry that packs the symptom, the root cause and the fix into one
+breath. Say what changed from the user's side and stop. Anyone who wants the
+diagnosis has the linked issue.
+
+    too long  - Fix schemes and targets from a workspace's local Swift packages
+                never reaching the Build and Testing panels: a package joins an
+                `.xcworkspace` as a reference to its directory, and SweetPad
+                read only the references ending in `.xcodeproj`
+    a title   - Fix Swift package schemes missing from the Build and Testing
+                panels
 
 Attribution stays as it is: link the issue or PR, and thank the reporter.
 
-    - Fix schemes and targets from a workspace's local Swift packages not
-      appearing in the Build and Testing panels
+    - Fix Swift package schemes missing from the Build and Testing panels
       ([#327](https://github.com/sweetpad-dev/sweetpad/issues/327),
       thanks [@rssole](https://github.com/rssole))
 

--- a/sweetpad-core/src/bsp/control.rs
+++ b/sweetpad-core/src/bsp/control.rs
@@ -52,6 +52,11 @@ impl LogLevel {
 pub(crate) struct TelemetryServer {
     clients: Mutex<Vec<UnixStream>>,
     socket: PathBuf,
+    /// The last `bsp/status` frame, replayed to each new connection. A status is
+    /// a state, not an event: an extension that connects (or reconnects) after
+    /// the server pushed one would otherwise show nothing until the next change,
+    /// which for a failed prepare could be never.
+    last_status: Mutex<Option<String>>,
 }
 
 impl TelemetryServer {
@@ -76,6 +81,7 @@ impl TelemetryServer {
         let server = Arc::new(TelemetryServer {
             clients: Mutex::new(Vec::new()),
             socket: socket.to_path_buf(),
+            last_status: Mutex::new(None),
         });
         let accept = Arc::clone(&server);
         let on_set_level = Arc::new(on_set_level);
@@ -88,10 +94,15 @@ impl TelemetryServer {
                 // (suspended extension host, full socket buffer) would
                 // otherwise block a broadcast forever — wedging the whole
                 // server. A timed-out write fails and drops the client.
-                if let Ok(write_half) = stream.try_clone()
+                if let Ok(mut write_half) = stream.try_clone()
                     && let Ok(mut clients) = accept.clients.lock()
                 {
                     let _ = write_half.set_write_timeout(Some(Duration::from_secs(1)));
+                    if let Ok(last) = accept.last_status.lock()
+                        && let Some(body) = last.as_deref()
+                    {
+                        let _ = write_message(&mut write_half, body);
+                    }
                     clients.push(write_half);
                 }
                 let on_set_level = Arc::clone(&on_set_level);
@@ -121,6 +132,11 @@ impl TelemetryServer {
     #[allow(clippy::needless_pass_by_value)]
     pub(crate) fn broadcast(&self, method: &str, params: Value) {
         let body = json!({ "jsonrpc": "2.0", "method": method, "params": params }).to_string();
+        if method == "bsp/status"
+            && let Ok(mut last) = self.last_status.lock()
+        {
+            *last = Some(body.clone());
+        }
         if let Ok(mut clients) = self.clients.lock() {
             clients.retain_mut(|c| {
                 if write_message(c, &body).is_ok() {

--- a/sweetpad-core/src/bsp/mod.rs
+++ b/sweetpad-core/src/bsp/mod.rs
@@ -11,15 +11,14 @@
 
 mod control;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::fs::OpenOptions;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::mpsc;
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde_json::{Value, json};
 
@@ -100,11 +99,10 @@ pub fn run(args: &[String]) -> Result<(), String> {
     // sourcekit-lsp blocks the requesting target's semantics until our response
     // arrives — so run it on a serialized worker and reply by id when the build
     // finishes, keeping the request loop responsive in the meantime.
-    let (prepare_tx, prepare_rx) = mpsc::channel::<PrepareJob>();
     {
         let server = Arc::clone(&server);
         std::thread::spawn(move || {
-            while let Ok(job) = prepare_rx.recv() {
+            while let Some(job) = server.prepare_queue.take() {
                 server.run_prepare(&job);
             }
         });
@@ -118,6 +116,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
                 // The frame boundary is lost; log why before dying so the
                 // failure is diagnosable instead of a silent exit.
                 server.trace(&format!("fatal framing error: {e}"));
+                server.prepare_queue.close();
                 server.kill_prepare();
                 server.shutdown_telemetry();
                 return Err(e);
@@ -150,6 +149,17 @@ pub fn run(args: &[String]) -> Result<(), String> {
                 if !watching {
                     Arc::clone(&server).spawn_change_watcher();
                     watching = true;
+                    // Warm every target in the background. The cold window —
+                    // the stretch where a target's header maps and generated
+                    // sources don't exist yet, so its ObjC files can't resolve
+                    // their imports — otherwise opens afresh for each target
+                    // the first time somebody opens a file in it. Queued at the
+                    // back, so a target the client actually asks about still
+                    // goes first.
+                    server.prepare_queue.push_back(PrepareJob {
+                        id: None,
+                        targets: server.current_targets(),
+                    });
                 }
             }
             "workspace/buildTargets" => server.reply(id, server.build_targets())?,
@@ -163,9 +173,13 @@ pub fn run(args: &[String]) -> Result<(), String> {
                 // prepare without an id (shouldn't happen) is simply dropped.
                 if let Some(id) = id {
                     let targets = server.requested_targets(params);
-                    if prepare_tx.send(PrepareJob { id, targets }).is_err() {
-                        break; // worker gone
-                    }
+                    // Ahead of the startup warm-up: this one is a file somebody
+                    // has open, and it is the request whose reply sourcekit-lsp
+                    // is blocked on.
+                    server.prepare_queue.push_front(PrepareJob {
+                        id: Some(id),
+                        targets,
+                    });
                 }
             }
             "workspace/waitForBuildSystemUpdates" => server.reply(id, json!({}))?,
@@ -185,6 +199,7 @@ pub fn run(args: &[String]) -> Result<(), String> {
             }
         }
     }
+    server.prepare_queue.close();
     server.kill_prepare();
     server.shutdown_telemetry();
     Ok(())
@@ -226,17 +241,112 @@ struct Server {
     /// orphan a minutes-long xcodebuild (reparented to init, still burning CPU
     /// after every editor restart). The prepare worker reaps it.
     prepare_child: Mutex<Option<std::process::Child>>,
+    /// Work waiting for the prepare worker (see [`PrepareQueue`]).
+    prepare_queue: PrepareQueue,
+    /// Per-target record of the last prepare, so repeats over unchanged project
+    /// files don't re-spawn `xcodebuild`.
+    prepared: Mutex<BTreeMap<String, PrepareRecord>>,
+    /// The last prepare failure, in the shape the extension's Doctor prints.
+    /// Prepare is best-effort by design, so without this a failure reaches only
+    /// the debug log — and a target that never prepares is a target whose ObjC
+    /// files never resolve their imports.
+    last_prepare_failure: Mutex<Option<String>>,
 }
 
 const TARGET_SCHEME: &str = "sweetpad://target/";
 const LANGUAGE_IDS: [&str; 5] = ["swift", "objective-c", "objective-cpp", "c", "cpp"];
 
-/// A queued `buildTarget/prepare`: the request `id` to answer once the build is
-/// done, and the target names to prepare.
+/// A queued `buildTarget/prepare`: the target names to prepare, and the request
+/// `id` to answer once the build is done — `None` for the startup warm-up,
+/// which nobody is waiting on.
 struct PrepareJob {
-    id: Value,
+    id: Option<Value>,
     targets: Vec<String>,
 }
+
+/// The prepare worker's inbox: a double-ended queue rather than a channel, because
+/// the two producers want opposite ends. A `buildTarget/prepare` is a file
+/// somebody just opened and a reply sourcekit-lsp is blocked on, so it goes to
+/// the front; the startup warm-up is speculative and goes to the back, where a
+/// real request can overtake whatever of it is left.
+#[derive(Default)]
+struct PrepareQueue {
+    state: Mutex<PrepareQueueState>,
+    ready: Condvar,
+}
+
+#[derive(Default)]
+struct PrepareQueueState {
+    jobs: VecDeque<PrepareJob>,
+    /// Set on shutdown: pushes are dropped and the worker is let go.
+    closed: bool,
+}
+
+impl PrepareQueue {
+    fn push_front(&self, job: PrepareJob) {
+        self.push(job, true);
+    }
+
+    fn push_back(&self, job: PrepareJob) {
+        self.push(job, false);
+    }
+
+    fn push(&self, job: PrepareJob, front: bool) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        if state.closed {
+            return;
+        }
+        if front {
+            state.jobs.push_front(job);
+        } else {
+            state.jobs.push_back(job);
+        }
+        self.ready.notify_one();
+    }
+
+    /// Block until a job is available, or return `None` once closed.
+    fn take(&self) -> Option<PrepareJob> {
+        let mut state = self.state.lock().ok()?;
+        loop {
+            if let Some(job) = state.jobs.pop_front() {
+                return Some(job);
+            }
+            if state.closed {
+                return None;
+            }
+            state = self.ready.wait(state).ok()?;
+        }
+    }
+
+    /// Stop accepting work, drop what's queued, and wake the worker so it can
+    /// exit. Whatever build is already running is killed separately, by
+    /// [`Server::kill_prepare`].
+    fn close(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.closed = true;
+            state.jobs.clear();
+        }
+        self.ready.notify_all();
+    }
+}
+
+/// What the last prepare of a target did, so a repeat over unchanged inputs can
+/// be skipped and a failure can be reported.
+struct PrepareRecord {
+    /// The project-file stamps it ran against — a change means the answer may
+    /// differ, so the skip no longer applies.
+    stamps: Vec<Option<(u64, SystemTime)>>,
+    ok: bool,
+    at: Instant,
+}
+
+/// How long a *failed* prepare stands in for the next attempt over unchanged
+/// project files. A success is cached until the project changes; a failure is
+/// retried after this, since what broke it (a missing tool, a half-written
+/// file, a source error) often isn't visible in the pbxproj at all.
+const PREPARE_RETRY_AFTER: Duration = Duration::from_secs(60);
 
 /// The portion of config that can change while the server runs — pushed live by
 /// the extension as `bsp/configChanged`. Everything else (project/xcode/derived
@@ -484,6 +594,9 @@ impl Server {
             config_path,
             log_level,
             prepare_child: Mutex::new(None),
+            prepare_queue: PrepareQueue::default(),
+            prepared: Mutex::new(BTreeMap::new()),
+            last_prepare_failure: Mutex::new(None),
         };
         server.bind_telemetry(config.socket.as_deref());
         server.log(&format!(
@@ -818,8 +931,13 @@ impl Server {
 
     /// Send `buildTarget/didChange` marking every current target changed.
     fn notify_targets_changed(&self) {
-        let changes: Vec<Value> = self
-            .current_targets()
+        self.notify_changed(&self.current_targets());
+    }
+
+    /// Send `buildTarget/didChange` for `targets` — the push that tells the
+    /// client to re-pull their options.
+    fn notify_changed(&self, targets: &[String]) {
+        let changes: Vec<Value> = targets
             .iter()
             .map(|t| json!({ "target": target_id(t), "kind": 2 }))
             .collect();
@@ -837,12 +955,60 @@ impl Server {
     /// response would wedge sourcekit-lsp's semantics for that target.
     fn run_prepare(&self, job: &PrepareJob) {
         self.push_status("preparing", Some(&job.targets.join(", ")));
+        let mut built = Vec::new();
+        let mut failure = None;
         for target in &job.targets {
-            self.prepare_target(target);
+            // A build that fails still writes the header maps — they come out of
+            // an early phase, not out of compiling — so an attempt counts as a
+            // change to re-read whether or not it succeeded.
+            let Some(ok) = self.prepare_target(target) else {
+                continue;
+            };
+            built.push(target.clone());
+            if !ok && failure.is_none() {
+                failure = self.last_prepare_failure();
+            }
         }
-        self.push_status("ready", None);
-        let resp = json!({ "jsonrpc": "2.0", "id": job.id, "result": {} });
-        let _ = self.send(&resp);
+        match &failure {
+            Some(detail) => self.push_status("failed", Some(detail)),
+            None => self.push_status("ready", None),
+        }
+        if let Some(id) = &job.id {
+            let resp = json!({ "jsonrpc": "2.0", "id": id, "result": {} });
+            let _ = self.send(&resp);
+        }
+        // The build is what puts a target's header maps and generated sources on
+        // disk, and the editor arguments name those only once they exist — so
+        // whatever the client resolved before this ran is missing them. Nothing
+        // else pushes that: the change watcher fires on project edits, and a
+        // build isn't one. Sent after the reply, so the client re-pulls a target
+        // it already considers prepared.
+        if !built.is_empty() {
+            self.notify_changed(&built);
+        }
+    }
+
+    /// Whether `target` was prepared recently enough, against project files that
+    /// haven't changed since, for another build to be pointless.
+    fn prepare_is_current(&self, target: &str, stamps: &[Option<(u64, SystemTime)>]) -> bool {
+        let Ok(prepared) = self.prepared.lock() else {
+            return false;
+        };
+        let Some(record) = prepared.get(target) else {
+            return false;
+        };
+        record.stamps == stamps && (record.ok || record.at.elapsed() < PREPARE_RETRY_AFTER)
+    }
+
+    /// The `(len, mtime)` of every file a prepare's result depends on: each
+    /// member project and the live config. Same stamps as the change watcher
+    /// polls, which is what makes "unchanged" mean the same thing to both.
+    fn prepare_stamps(&self) -> Vec<Option<(u64, SystemTime)>> {
+        self.projects
+            .iter()
+            .map(|p| file_stamp(&p.join("project.pbxproj")))
+            .chain(self.config_path.as_deref().map(file_stamp))
+            .collect()
     }
 
     /// Prepare `target` so its sources become semantically analyzable: build the
@@ -851,11 +1017,23 @@ impl Server {
     /// whole closure — the target and its transitive deps — is pure Swift;
     /// anything else (packages, C-family, code-gen) falls back to a real
     /// `xcodebuild`, as does a self-build that unexpectedly fails.
-    fn prepare_target(&self, target: &str) {
+    ///
+    /// `None` when the target was already current, else whether the build
+    /// succeeded — either way the client should re-read what's on disk.
+    fn prepare_target(&self, target: &str) -> Option<bool> {
+        let stamps = self.prepare_stamps();
+        if self.prepare_is_current(target, &stamps) {
+            self.log(&format!("prepare: {target} already current; skipping"));
+            return None;
+        }
         let proj = self.project_for_target(target);
         // The self-build fast path is single-project: a workspace target's deps
         // can live in another member, so let xcodebuild handle the closure.
         let deps = project::transitive_dependencies(&proj, target).unwrap_or_default();
+        // `is_self_buildable` is false for a target with any C-family source, so
+        // a closure that qualifies has no header maps or generated sources to
+        // produce — which is what makes it sound to skip the real build here
+        // even though "prepared" then doesn't mean "artifacts on disk".
         let closure_simple = !self.is_workspace()
             && std::iter::once(target)
                 .chain(deps.iter().map(String::as_str))
@@ -868,13 +1046,49 @@ impl Server {
                     "prepare: {target} self-built {} dependency module(s)",
                     deps.len()
                 ));
-                return;
+                self.record_prepare(target, stamps, true, None);
+                return Some(true);
             }
             self.log(&format!(
                 "prepare: {target} self-build failed; falling back to xcodebuild"
             ));
         }
-        self.xcodebuild_prepare(target);
+        Some(self.xcodebuild_prepare(target, stamps))
+    }
+
+    /// The last prepare failure's detail, for the terminal status and the Doctor.
+    fn last_prepare_failure(&self) -> Option<String> {
+        self.last_prepare_failure.lock().ok()?.clone()
+    }
+
+    /// Record how a prepare went, keeping a failure's detail for the terminal
+    /// status and the Doctor — the debug log alone reaches nobody who hasn't
+    /// already been told where it is.
+    fn record_prepare(
+        &self,
+        target: &str,
+        stamps: Vec<Option<(u64, SystemTime)>>,
+        ok: bool,
+        detail: Option<String>,
+    ) {
+        if let Ok(mut prepared) = self.prepared.lock() {
+            prepared.insert(
+                target.to_string(),
+                PrepareRecord {
+                    stamps,
+                    ok,
+                    at: Instant::now(),
+                },
+            );
+        }
+        if let Ok(mut slot) = self.last_prepare_failure.lock() {
+            *slot = (!ok).then(|| {
+                format!(
+                    "{target}: {}",
+                    detail.unwrap_or_else(|| "no detail".to_string())
+                )
+            });
+        }
     }
 
     /// Emit one dependency's `.swiftmodule` with `swiftc` straight into the
@@ -944,39 +1158,52 @@ impl Server {
         }
     }
 
-    /// Build `target` via `xcodebuild` so its dependency `.swiftmodule`s and
-    /// generated inputs land in the DerivedData our search paths point at —
-    /// the fallback for closures the `swiftc` fast path can't emit.
-    /// xcodebuild builds by **scheme** (a bare `-target` build doesn't populate
-    /// the products dir), so a scheme that builds the target is required.
-    fn xcodebuild_prepare(&self, target: &str) {
+    /// The `xcodebuild` invocation that prepares `target`, and a phrase naming
+    /// how, for the log.
+    fn prepare_command(&self, target: &str) -> (Command, String) {
         let owning = self.project_for_target(target);
-        let Some(scheme) = project::scheme_for_target(&owning, target) else {
-            self.log(&format!(
-                "prepare: no scheme builds target {target}; skipping"
-            ));
-            return;
-        };
-        let (sdk, _arch) = self.editor_platform(target);
-        let destination = format!("generic/platform={}", platform_name(&sdk));
+        let scheme = project::scheme_for_target(&owning, target);
+        let (sdk, arch) = self.editor_platform(target);
         let developer = self.developer_dir();
-        let xcodebuild = developer.as_ref().map_or_else(
+        let mut cmd = Command::new(developer.as_ref().map_or_else(
             || PathBuf::from("xcodebuild"),
             |dev| dev.join("usr/bin/xcodebuild"),
-        );
-        let mut cmd = Command::new(&xcodebuild);
+        ));
         if let Some(dev) = &developer {
             cmd.env("DEVELOPER_DIR", dev);
         }
         cmd.arg("build");
-        if self.is_workspace() {
+        // A `-target` build has no scheme to name the workspace's other members,
+        // so it always addresses the owning project directly.
+        if self.is_workspace() && scheme.is_some() {
             cmd.args(["-workspace".as_ref(), self.project_path.as_os_str()]);
         } else {
             cmd.args(["-project".as_ref(), owning.as_os_str()]);
         }
-        cmd.args(["-scheme", &scheme])
-            .args(["-configuration", &self.configuration()])
-            .args(["-destination", &destination])
+        let how = if let Some(scheme) = &scheme {
+            let destination = format!("generic/platform={}", platform_name(&sdk));
+            cmd.args(["-scheme", scheme])
+                .args(["-destination", &destination]);
+            if let Some(dd) = &self.derived_data_path {
+                // An explicit override needs `-derivedDataPath` (which xcodebuild
+                // only accepts with `-scheme`); without it the default
+                // DerivedData already matches our search paths.
+                cmd.args(["-derivedDataPath".as_ref(), dd.as_os_str()]);
+            }
+            format!("scheme {scheme} ({destination})")
+        } else {
+            cmd.args(["-target", target])
+                .args(["-sdk", &sdk])
+                .args(["-arch", &arch]);
+            // The two roots every output path hangs off. Named after the same
+            // DerivedData the arguments resolve against, so `BUILT_PRODUCTS_DIR`
+            // and `TEMP_DIR` land where the editor is already looking.
+            for (key, dir) in self.build_roots() {
+                cmd.arg(format!("{key}={}", dir.display()));
+            }
+            format!("target {target} (-sdk {sdk} -arch {arch})")
+        };
+        cmd.args(["-configuration", &self.configuration()])
             // Prepare only needs modules, not a signed/launchable product, and
             // must not stall on validation prompts in a headless run.
             .args([
@@ -984,15 +1211,24 @@ impl Server {
                 "-skipMacroValidation",
                 "-skipPackagePluginValidation",
             ]);
-        if let Some(dd) = &self.derived_data_path {
-            // An explicit override needs `-derivedDataPath` (which xcodebuild only
-            // accepts with `-scheme`); without it the default DerivedData already
-            // matches our search paths.
-            cmd.args(["-derivedDataPath".as_ref(), dd.as_os_str()]);
-        }
-        self.log(&format!(
-            "prepare: building scheme {scheme} ({destination}) for target {target}"
-        ));
+        (cmd, how)
+    }
+
+    /// Build `target` via `xcodebuild` so its dependency `.swiftmodule`s,
+    /// header maps and generated inputs land in the DerivedData our search paths
+    /// point at — the fallback for closures the `swiftc` fast path can't emit.
+    ///
+    /// By **scheme** where one builds the target, because a scheme build lays
+    /// the whole tree out for us. Where none does, by `-target` with `SYMROOT`
+    /// and `OBJROOT` named explicitly: a bare `-target` build otherwise writes
+    /// into the project's own `build/` directory rather than the DerivedData the
+    /// editor arguments point at, which is the reason this used to skip such a
+    /// target outright. Skipping is no longer an option — the header maps a
+    /// target's ObjC files need to resolve their imports exist only after a
+    /// build of that target.
+    fn xcodebuild_prepare(&self, target: &str, stamps: Vec<Option<(u64, SystemTime)>>) -> bool {
+        let (mut cmd, how) = self.prepare_command(target);
+        self.log(&format!("prepare: building {how} for target {target}"));
         // Spawn (rather than `output()`) so the child stays killable: the pipe
         // handles are taken first, then the child is parked in `prepare_child`
         // where shutdown can reach it while this thread drains the pipes.
@@ -1002,10 +1238,10 @@ impl Server {
         let mut child = match cmd.spawn() {
             Ok(c) => c,
             Err(e) => {
-                self.log(&format!(
-                    "prepare: {target} failed to launch xcodebuild: {e}"
-                ));
-                return;
+                let detail = format!("could not launch xcodebuild: {e}");
+                self.log(&format!("prepare: {target} {detail}"));
+                self.record_prepare(target, stamps, false, Some(detail));
+                return false;
             }
         };
         let stdout_pipe = child.stdout.take();
@@ -1037,17 +1273,44 @@ impl Server {
             .and_then(|mut slot| slot.take())
             .and_then(|mut c| c.wait().ok());
         match status {
-            Some(st) if st.success() => self.log(&format!("prepare: {target} build ok")),
+            Some(st) if st.success() => {
+                self.log(&format!("prepare: {target} build ok"));
+                self.record_prepare(target, stamps, true, None);
+                true
+            }
             Some(st) => {
-                // Best-effort: log the tail and carry on (sourcekit-lsp uses
-                // whatever modules did build).
+                // Best-effort as far as the reply goes — sourcekit-lsp gets
+                // whatever modules did build — but recorded, because a target
+                // that never prepares is a target whose ObjC files never resolve
+                // their imports, and that used to be visible only in a log file
+                // nobody knows to read.
                 let code = st.code().unwrap_or(-1);
                 let stderr = String::from_utf8_lossy(&stderr_buf);
                 let tail: String = stderr.lines().rev().take(8).collect::<Vec<_>>().join(" | ");
                 self.log(&format!("prepare: {target} build exit={code}: {tail}"));
+                self.record_prepare(target, stamps, false, Some(format!("exit={code}: {tail}")));
+                false
             }
-            None => self.log(&format!("prepare: {target} xcodebuild status unavailable")),
+            None => {
+                let detail = "xcodebuild status unavailable".to_string();
+                self.log(&format!("prepare: {target} {detail}"));
+                self.record_prepare(target, stamps, false, Some(detail));
+                false
+            }
         }
+    }
+
+    /// `SYMROOT` / `OBJROOT` for a `-target` build: the products and
+    /// intermediates roots inside the DerivedData the editor arguments resolve
+    /// against. Empty when that directory can't be located, which leaves
+    /// xcodebuild its own defaults rather than a half-pinned tree.
+    fn build_roots(&self) -> Vec<(&'static str, PathBuf)> {
+        self.derived_data_dir().map_or_else(Vec::new, |dd| {
+            vec![
+                ("SYMROOT", dd.join("Build/Products")),
+                ("OBJROOT", dd.join("Build/Intermediates.noindex")),
+            ]
+        })
     }
 
     /// Kill the in-flight prepare build, if any (the prepare worker still owns

--- a/sweetpad-core/tests/bsp_prepare.rs
+++ b/sweetpad-core/tests/bsp_prepare.rs
@@ -1,101 +1,171 @@
 //! v2 of the BSP loop: `buildTarget/prepare` builds a target's dependency
 //! modules on demand, so cross-module `import`s resolve with **no prior build**.
 //!
-//! This drives the `bsp-server bsp` server directly (no sourcekit-lsp): from a
-//! clean DerivedData, it sends `buildTarget/prepare` for `ModuleB` and asserts
-//! (a) the server answers the request and (b) `ModuleA`'s `.swiftmodule` now
-//! exists in the products dir our search paths point at — i.e. preparation
-//! produced the dependency module.
+//! These drive the `bsp-server bsp` server directly (no sourcekit-lsp), from a
+//! clean DerivedData:
+//!
+//! * a pure-Swift closure is prepared by the `swiftc` fast path, and the
+//!   dependency `.swiftmodule` lands in the products dir our search paths name;
+//! * preparing an ObjC target publishes its header maps **and** pushes
+//!   `buildTarget/didChange`, so a client that pulled options against the cold
+//!   tree learns to ask again (GitHub #238 — without the push, the arguments a
+//!   client cached before the build stand, and its ObjC imports never resolve);
+//! * the startup warm-up reaches a target **no scheme builds**, which needs a
+//!   `-target` build with the output roots named explicitly.
 //!
 //! Opt-in: runs `xcodebuild`, so gated on `BSP_ORACLE=1` (+ Xcode 26.5).
 
 use std::io::{Read, Write};
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 const XCODE: &str = "/Applications/Xcode-26.5.0.app";
 
+/// Long enough for a cold `xcodebuild` on a small fixture, short enough that a
+/// wedged server fails the run rather than hanging it.
+const BUILD_TIMEOUT: Duration = Duration::from_secs(300);
+
 fn frame(body: &str) -> Vec<u8> {
     format!("Content-Length: {}\r\n\r\n{body}", body.len()).into_bytes()
 }
 
-#[test]
-fn prepare_builds_dependency_module_from_clean_deriveddata() {
+fn fixture(name: &str, proj: &str) -> String {
+    format!(
+        "{}/fixtures/{name}/project/{proj}",
+        env!("SWEETPAD_LIB_DIR")
+    )
+}
+
+/// Whether the gated preconditions hold; prints why when they don't.
+fn gated() -> bool {
     if std::env::var("BSP_ORACLE").is_err() {
         eprintln!("skipping: set BSP_ORACLE=1 to run the BSP prepare oracle");
-        return;
+        return false;
     }
     if !Path::new(XCODE).exists() {
         eprintln!("skipping: {XCODE} not installed");
+        return false;
+    }
+    true
+}
+
+/// A running BSP server plus everything it has written to stdout so far, so a
+/// test can drive it by frames and wait on what comes back.
+struct Session {
+    child: Child,
+    stdin: std::process::ChildStdin,
+    out: Arc<Mutex<String>>,
+    reader: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Session {
+    fn start(project: &str, dd: &Path, log: &Path) -> Session {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_bsp-server"))
+            .args(["bsp", "--project", project, "--xcode"])
+            .arg(format!("{XCODE}/Contents/Developer"))
+            .arg("--derived-data-path")
+            .arg(dd)
+            .env("SWEETPAD_BSP_LOG", log)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn server");
+        let stdin = child.stdin.take().expect("stdin");
+        let mut stdout = child.stdout.take().expect("stdout");
+        let out = Arc::new(Mutex::new(String::new()));
+        let sink = Arc::clone(&out);
+        let reader = std::thread::spawn(move || {
+            let mut chunk = [0u8; 4096];
+            while let Ok(n) = stdout.read(&mut chunk) {
+                if n == 0 {
+                    break;
+                }
+                sink.lock()
+                    .unwrap()
+                    .push_str(&String::from_utf8_lossy(&chunk[..n]));
+            }
+        });
+        Session {
+            child,
+            stdin,
+            out,
+            reader: Some(reader),
+        }
+    }
+
+    fn send(&mut self, body: &str) {
+        self.stdin.write_all(&frame(body)).expect("write frame");
+        self.stdin.flush().expect("flush");
+    }
+
+    fn text(&self) -> String {
+        self.out.lock().unwrap().clone()
+    }
+
+    /// Poll until `needle` appears in the server's output, returning whether it
+    /// did before `timeout`.
+    fn wait_for(&self, needle: &str, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if self.text().contains(needle) {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+        false
+    }
+
+    fn shutdown(mut self) -> String {
+        let _ = self
+            .stdin
+            .write_all(&frame(r#"{"jsonrpc":"2.0","method":"build/exit"}"#));
+        let _ = self.stdin.flush();
+        drop(self.stdin);
+        let _ = self.child.wait();
+        if let Some(reader) = self.reader.take() {
+            let _ = reader.join();
+        }
+        self.out.lock().unwrap().clone()
+    }
+}
+
+/// The `compilerArguments` of the last `textDocument/sourceKitOptions` reply in
+/// `transcript` — read as raw text, since the frames are concatenated rather
+/// than parsed one at a time.
+fn last_compiler_arguments(transcript: &str) -> String {
+    let key = "\"compilerArguments\":";
+    let start = transcript
+        .rfind(key)
+        .unwrap_or_else(|| panic!("no sourceKitOptions reply in:\n{transcript}"));
+    let rest = &transcript[start + key.len()..];
+    let end = rest.find(']').unwrap_or(rest.len());
+    rest[..=end.min(rest.len() - 1)].to_string()
+}
+
+#[test]
+fn prepare_builds_dependency_module_from_clean_deriveddata() {
+    if !gated() {
         return;
     }
-
-    let root = env!("SWEETPAD_LIB_DIR");
-    let project = format!("{root}/fixtures/_synthetic-multimodule/project/MultiModule.xcodeproj");
+    let project = fixture("_synthetic-multimodule", "MultiModule.xcodeproj");
     let dd = std::env::temp_dir().join(format!("sweetpad-bsp-prep-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dd);
-    let dep_module = dd.join("Build/Products/Debug/ModuleA.swiftmodule");
     let log = std::env::temp_dir().join(format!("sweetpad-bsp-prep-log-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dd);
     let _ = std::fs::remove_file(&log);
+    let dep_module = dd.join("Build/Products/Debug/ModuleA.swiftmodule");
 
-    let mut child = Command::new(env!("CARGO_BIN_EXE_bsp-server"))
-        .args(["bsp", "--project", &project, "--xcode"])
-        .arg(format!("{XCODE}/Contents/Developer"))
-        .arg("--derived-data-path")
-        .arg(&dd)
-        .env("SWEETPAD_BSP_LOG", &log)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn server");
-    let mut stdin = child.stdin.take().unwrap();
-    let mut stdout = child.stdout.take().unwrap();
-
-    let buf = Arc::new(Mutex::new(String::new()));
-    let buf_reader = Arc::clone(&buf);
-    let reader = std::thread::spawn(move || {
-        let mut chunk = [0u8; 4096];
-        while let Ok(n) = stdout.read(&mut chunk) {
-            if n == 0 {
-                break;
-            }
-            buf_reader
-                .lock()
-                .unwrap()
-                .push_str(&String::from_utf8_lossy(&chunk[..n]));
-        }
-    });
-
-    stdin
-        .write_all(&frame(
-            r#"{"jsonrpc":"2.0","id":1,"method":"build/initialize","params":{}}"#,
-        ))
-        .unwrap();
-    stdin
-        .write_all(&frame(r#"{"jsonrpc":"2.0","method":"build/initialized"}"#))
-        .unwrap();
+    let mut session = Session::start(&project, &dd, &log);
+    session.send(r#"{"jsonrpc":"2.0","id":1,"method":"build/initialize","params":{}}"#);
+    session.send(r#"{"jsonrpc":"2.0","method":"build/initialized"}"#);
     // prepare ModuleB → must build its dependency ModuleA's module.
-    stdin.write_all(&frame(r#"{"jsonrpc":"2.0","id":10,"method":"buildTarget/prepare","params":{"targets":[{"uri":"sweetpad://target/ModuleB"}]}}"#)).unwrap();
-    stdin.flush().unwrap();
-
-    // Wait (up to 3 min) for the prepare response.
-    let deadline = Instant::now() + Duration::from_secs(180);
-    let mut replied = false;
-    while Instant::now() < deadline {
-        std::thread::sleep(Duration::from_millis(250));
-        if buf.lock().unwrap().contains(r#""id":10"#) {
-            replied = true;
-            break;
-        }
-    }
-    let _ = stdin.write_all(&frame(r#"{"jsonrpc":"2.0","method":"build/exit"}"#));
-    let _ = stdin.flush();
-    drop(stdin);
-    let _ = child.wait();
-    let _ = reader.join();
+    session.send(
+        r#"{"jsonrpc":"2.0","id":10,"method":"buildTarget/prepare","params":{"targets":[{"uri":"sweetpad://target/ModuleB"}]}}"#,
+    );
+    let replied = session.wait_for(r#""id":10"#, BUILD_TIMEOUT);
+    session.shutdown();
 
     let module_exists = dep_module.exists();
     let log_text = std::fs::read_to_string(&log).unwrap_or_default();
@@ -116,5 +186,173 @@ fn prepare_builds_dependency_module_from_clean_deriveddata() {
     assert!(
         !log_text.contains("building scheme"),
         "should not have fallen back to xcodebuild for a pure-Swift closure; log:\n{log_text}"
+    );
+}
+
+/// GitHub #238, end to end on the server: an ObjC target's arguments gain the
+/// header maps a prepare puts on disk, and the client is *told* to come back for
+/// them.
+///
+/// `build/initialized` is deliberately not sent — it starts the warm-up, which
+/// would prepare the target before this can observe the cold tree.
+#[test]
+fn prepare_publishes_header_maps_and_notifies() {
+    if !gated() {
+        return;
+    }
+    let project = fixture("_synthetic-headermaps", "HeaderMaps.xcodeproj");
+    let widget = format!(
+        "{}/fixtures/_synthetic-headermaps/project/Top/Widget.m",
+        env!("SWEETPAD_LIB_DIR")
+    );
+    let dd = std::env::temp_dir().join(format!("sweetpad-bsp-hm-{}", std::process::id()));
+    let log = std::env::temp_dir().join(format!("sweetpad-bsp-hm-log-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dd);
+    let _ = std::fs::remove_file(&log);
+
+    let options = |id: u32| {
+        format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"method":"textDocument/sourceKitOptions","params":{{"textDocument":{{"uri":"file://{widget}"}},"target":{{"uri":"sweetpad://target/HeaderMaps"}},"language":"objective-c"}}}}"#
+        )
+    };
+
+    let mut session = Session::start(&project, &dd, &log);
+    session.send(r#"{"jsonrpc":"2.0","id":1,"method":"build/initialize","params":{}}"#);
+    session.send(&options(2));
+    assert!(
+        session.wait_for(r#""id":2"#, Duration::from_secs(120)),
+        "no sourceKitOptions reply for the cold tree"
+    );
+    let cold = last_compiler_arguments(&session.text());
+
+    session.send(
+        r#"{"jsonrpc":"2.0","id":3,"method":"buildTarget/prepare","params":{"targets":[{"uri":"sweetpad://target/HeaderMaps"}]}}"#,
+    );
+    let replied = session.wait_for(r#""id":3"#, BUILD_TIMEOUT);
+    let notified = session.wait_for("buildTarget/didChange", Duration::from_secs(10));
+
+    session.send(&options(4));
+    let re_replied = session.wait_for(r#""id":4"#, Duration::from_secs(120));
+    let warm = last_compiler_arguments(&session.text());
+    let transcript = session.shutdown();
+
+    let log_text = std::fs::read_to_string(&log).unwrap_or_default();
+    let _ = std::fs::remove_dir_all(&dd);
+    let _ = std::fs::remove_file(&log);
+
+    assert!(replied, "server never answered buildTarget/prepare");
+    assert!(re_replied, "server never re-answered sourceKitOptions");
+    assert!(
+        !cold.contains(".hmap"),
+        "named header maps from a tree with none:\n{cold}"
+    );
+    assert!(
+        notified,
+        "prepare did not push buildTarget/didChange, so a client that pulled options \
+         against the cold tree keeps them; log:\n{log_text}\ntranscript:\n{transcript}"
+    );
+    for expected in [
+        "HeaderMaps-project-headers.hmap",
+        "HeaderMaps-own-target-headers.hmap",
+        "HeaderMaps-generated-files.hmap",
+        "DerivedSources",
+    ] {
+        assert!(
+            warm.contains(expected),
+            "prepared arguments are missing {expected}:\n{warm}"
+        );
+    }
+}
+
+/// A target no scheme builds still gets prepared — by `-target`, with the output
+/// roots named so its header maps land in the DerivedData the editor arguments
+/// point at rather than in the project's own `build/`. Also the warm-up itself:
+/// nothing here ever sends `buildTarget/prepare`.
+#[test]
+fn startup_warmup_prepares_a_target_no_scheme_builds() {
+    if !gated() {
+        return;
+    }
+    let project = fixture("_synthetic-headermaps", "HeaderMaps.xcodeproj");
+    let dd = std::env::temp_dir().join(format!("sweetpad-bsp-orphan-{}", std::process::id()));
+    let log = std::env::temp_dir().join(format!("sweetpad-bsp-orphan-log-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dd);
+    let _ = std::fs::remove_file(&log);
+    let orphan_hmap = dd.join(
+        "Build/Intermediates.noindex/HeaderMaps.build/Debug/HeaderMapsOrphan.build/\
+         HeaderMapsOrphan-project-headers.hmap",
+    );
+
+    let mut session = Session::start(&project, &dd, &log);
+    session.send(r#"{"jsonrpc":"2.0","id":1,"method":"build/initialize","params":{}}"#);
+    session.send(r#"{"jsonrpc":"2.0","method":"build/initialized"}"#);
+
+    let deadline = Instant::now() + BUILD_TIMEOUT;
+    let mut appeared = false;
+    while Instant::now() < deadline {
+        if orphan_hmap.exists() {
+            appeared = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+    session.shutdown();
+
+    let log_text = std::fs::read_to_string(&log).unwrap_or_default();
+    let _ = std::fs::remove_dir_all(&dd);
+    let _ = std::fs::remove_file(&log);
+
+    assert!(
+        appeared,
+        "warm-up left HeaderMapsOrphan unprepared — expected {}\nlog:\n{log_text}",
+        orphan_hmap.display()
+    );
+    assert!(
+        log_text.contains("building target HeaderMapsOrphan"),
+        "expected the -target path for a target no scheme builds; log:\n{log_text}"
+    );
+}
+
+/// A second prepare over unchanged project files must not re-spawn `xcodebuild`:
+/// with one worker and no coalescing, a client that asks per opened file
+/// serializes a fresh build behind every one of them.
+#[test]
+fn a_repeat_prepare_over_unchanged_inputs_is_skipped() {
+    if !gated() {
+        return;
+    }
+    let project = fixture("_synthetic-headermaps", "HeaderMaps.xcodeproj");
+    let dd = std::env::temp_dir().join(format!("sweetpad-bsp-coalesce-{}", std::process::id()));
+    let log =
+        std::env::temp_dir().join(format!("sweetpad-bsp-coalesce-log-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dd);
+    let _ = std::fs::remove_file(&log);
+
+    let prepare = |id: u32| {
+        format!(
+            r#"{{"jsonrpc":"2.0","id":{id},"method":"buildTarget/prepare","params":{{"targets":[{{"uri":"sweetpad://target/HeaderMaps"}}]}}}}"#
+        )
+    };
+    let mut session = Session::start(&project, &dd, &log);
+    session.send(r#"{"jsonrpc":"2.0","id":1,"method":"build/initialize","params":{}}"#);
+    session.send(&prepare(2));
+    let first = session.wait_for(r#""id":2"#, BUILD_TIMEOUT);
+    session.send(&prepare(3));
+    let second = session.wait_for(r#""id":3"#, Duration::from_secs(60));
+    session.shutdown();
+
+    let log_text = std::fs::read_to_string(&log).unwrap_or_default();
+    let _ = std::fs::remove_dir_all(&dd);
+    let _ = std::fs::remove_file(&log);
+
+    assert!(first && second, "both prepares must be answered");
+    assert_eq!(
+        log_text.matches("prepare: building").count(),
+        1,
+        "the repeat re-ran xcodebuild; log:\n{log_text}"
+    );
+    assert!(
+        log_text.contains("prepare: HeaderMaps already current; skipping"),
+        "the repeat was not recognised as current; log:\n{log_text}"
     );
 }

--- a/sweetpad-core/tests/bsp_typecheck_oracle.rs
+++ b/sweetpad-core/tests/bsp_typecheck_oracle.rs
@@ -9,8 +9,16 @@
 //! `clang -fsyntax-only`) on each target's sources with the args we generate
 //! (pointed at that same DerivedData). The headline metric is the count of
 //! **resolution errors** (`no such module`, `'foo.h' file not found`, …) → it
-//! must be zero, covering both the Swift cross-module import (multi-module
-//! fixture) and the ObjC header search path (objc-headers fixture).
+//! must be zero, covering the Swift cross-module import (multi-module fixture),
+//! the ObjC header search path (objc-headers fixture), and the imports that only
+//! Xcode's header maps and generated-sources dirs resolve — a sibling
+//! directory's header, a mixed target's `-Swift.h`, another target's public
+//! framework header (headermaps fixture, GitHub #238).
+//!
+//! A second test closes the loop from the other side: every search path Xcode
+//! itself passes and that exists on disk must have a counterpart in ours, so a
+//! path class we've never thought about shows up as a failure rather than as
+//! completion that quietly doesn't work.
 //!
 //! Opt-in: builds with `xcodebuild`, so it only runs when `BSP_ORACLE=1` (and
 //! Xcode 26.5 is installed). ⚠️ Pinned to Xcode 26.5 — expand later (DOCS.md §8).
@@ -137,7 +145,9 @@ fn resolve_target(project: &Path, target: &str, dd: &Path) -> TargetCompilerArgu
         .unwrap_or_else(|| panic!("no args for target {target}"))
 }
 
-fn build_fixture(project: &Path, scheme: &str, dd: &Path) {
+/// Build a fixture hermetically into `dd`, returning xcodebuild's transcript
+/// (which carries the `CompileC` lines the search-path check reads back).
+fn build_fixture(project: &Path, scheme: &str, dd: &Path) -> String {
     let build = Command::new("xcodebuild")
         .env("DEVELOPER_DIR", developer_dir())
         .args(["build", "-project"])
@@ -160,6 +170,7 @@ fn build_fixture(project: &Path, scheme: &str, dd: &Path) {
         "fixture build failed ({scheme}):\n{}",
         String::from_utf8_lossy(&build.stderr)
     );
+    String::from_utf8_lossy(&build.stdout).into_owned()
 }
 
 /// Run a front end on a target's sources, returning resolution errors.
@@ -222,7 +233,7 @@ fn bsp_typecheck_oracle() {
     // Swift cross-module: ModuleB imports ModuleA.
     let multimodule = fixture("_synthetic-multimodule", "MultiModule.xcodeproj");
     let dd1 = std::env::temp_dir().join(format!("sweetpad-bsp-mm-{}", std::process::id()));
-    build_fixture(&multimodule, "ModuleB", &dd1);
+    let _ = build_fixture(&multimodule, "ModuleB", &dd1);
     errors.extend(check_target(&multimodule, "ModuleA", &dd1, true));
     errors.extend(check_target(&multimodule, "ModuleB", &dd1, true));
     let _ = std::fs::remove_dir_all(&dd1);
@@ -230,7 +241,7 @@ fn bsp_typecheck_oracle() {
     // ObjC header search path: widget.m #imports include/widget.h via HEADER_SEARCH_PATHS.
     let objc = fixture("_synthetic-objc-headers", "ObjCHeaders.xcodeproj");
     let dd2 = std::env::temp_dir().join(format!("sweetpad-bsp-objc-{}", std::process::id()));
-    build_fixture(&objc, "ObjCHeaders", &dd2);
+    let _ = build_fixture(&objc, "ObjCHeaders", &dd2);
     errors.extend(check_target(&objc, "ObjCHeaders", &dd2, false));
     let _ = std::fs::remove_dir_all(&dd2);
 
@@ -238,12 +249,138 @@ fn bsp_typecheck_oracle() {
     // module Xcode builds into the products dir / PackageFrameworks.
     let spm = fixture("_synthetic-spm", "SpmApp.xcodeproj");
     let dd3 = std::env::temp_dir().join(format!("sweetpad-bsp-spm-{}", std::process::id()));
-    build_fixture(&spm, "SpmApp", &dd3);
+    let _ = build_fixture(&spm, "SpmApp", &dd3);
     errors.extend(check_target(&spm, "SpmApp", &dd3, true));
     let _ = std::fs::remove_dir_all(&dd3);
+
+    // Header maps + generated sources: none of Widget.m's imports is reachable
+    // through HEADER_SEARCH_PATHS, which the fixture doesn't set at all.
+    let hmaps = fixture("_synthetic-headermaps", "HeaderMaps.xcodeproj");
+    let dd4 = std::env::temp_dir().join(format!("sweetpad-bsp-hmap-{}", std::process::id()));
+    let _ = build_fixture(&hmaps, "HeaderMaps", &dd4);
+    errors.extend(check_target(&hmaps, "HeaderMapsCore", &dd4, false));
+    errors.extend(check_target(&hmaps, "HeaderMaps", &dd4, false));
+    let _ = std::fs::remove_dir_all(&dd4);
 
     assert!(
         errors.is_empty(),
         "module/header resolution failures: {errors:?}"
+    );
+}
+
+/// Split a build-log command line into tokens, expanding the `@file` response
+/// arguments Xcode 26 puts most of a `CompileC` invocation behind. Quoting is
+/// naive (fixture paths carry no spaces); only the search-path flags are read
+/// back, and those are never quoted.
+fn command_tokens(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for raw in line.split_whitespace() {
+        let token = raw.trim_matches('\'');
+        match token.strip_prefix('@') {
+            Some(resp) => match std::fs::read_to_string(resp) {
+                Ok(body) => out.extend(
+                    body.split_whitespace()
+                        .map(|t| t.trim_matches('\'').to_string()),
+                ),
+                Err(e) => panic!("read response file {resp}: {e}"),
+            },
+            None => out.push(token.to_string()),
+        }
+    }
+    out
+}
+
+/// The clang command line xcodebuild logged for the first `CompileC` in
+/// `target`. A `CompileC` header line names the target it belongs to; the
+/// invocation is the `…/clang` line inside the block that follows.
+fn xcode_clang_line(log: &str, target: &str) -> Vec<String> {
+    let mut in_block = false;
+    for line in log.lines() {
+        if line.starts_with("CompileC ") {
+            in_block = line.contains(&format!("(in target '{target}' from project"));
+        } else if in_block && line.trim_start().starts_with('/') && line.contains("/clang ") {
+            return command_tokens(line);
+        }
+    }
+    panic!("no CompileC invocation for target {target} in the build log");
+}
+
+/// The `-I` / `-iquote` values in an argv, in either spelling (`-I<path>` joined,
+/// as Xcode writes it, or `-I <path>` separated, as we do).
+fn search_paths(args: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        let a = &args[i];
+        for flag in ["-I", "-iquote"] {
+            if a == flag {
+                if let Some(v) = args.get(i + 1) {
+                    out.push(v.clone());
+                }
+            } else if let Some(v) = a.strip_prefix(flag)
+                && !v.is_empty()
+            {
+                out.push(v.to_string());
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Every header search path Xcode passes **and that exists** must have a
+/// counterpart in ours.
+///
+/// The existence filter is the whole point of the comparison: Xcode names its
+/// generated-sources dirs whether or not a build created them, and we only name
+/// what's there, so an unqualified subset check would fail on paths that hold
+/// nothing. What it does catch is the #238 shape — a class of search path Xcode
+/// relies on and we've never emitted — which the arg-oracle comparator can't,
+/// since it scores header maps and `Intermediates.noindex` paths as geometry.
+#[test]
+fn bsp_clang_search_paths_cover_xcodes() {
+    if std::env::var("BSP_ORACLE").is_err() {
+        eprintln!("skipping: set BSP_ORACLE=1 to run the BSP search-path coverage check");
+        return;
+    }
+    if !Path::new(XCODE).exists() {
+        eprintln!("skipping: {XCODE} not installed");
+        return;
+    }
+
+    let project = fixture("_synthetic-headermaps", "HeaderMaps.xcodeproj");
+    let dd = std::env::temp_dir().join(format!("sweetpad-bsp-cover-{}", std::process::id()));
+    let log = build_fixture(&project, "HeaderMaps", &dd);
+
+    let mut missing = Vec::new();
+    for target in ["HeaderMapsCore", "HeaderMaps"] {
+        let ours = search_paths(
+            &resolve_target(&project, target, &dd)
+                .clang
+                .unwrap_or_else(|| panic!("{target} has no clang invocation"))
+                .arguments,
+        );
+        let theirs = search_paths(&xcode_clang_line(&log, target));
+        let live: Vec<&String> = theirs
+            .iter()
+            .filter(|p| Path::new(p).exists())
+            .filter(|p| !ours.contains(p))
+            .collect();
+        eprintln!(
+            "[{target}] xcode search paths={} (live) ours={} missing={}",
+            theirs.iter().filter(|p| Path::new(p).exists()).count(),
+            ours.len(),
+            live.len()
+        );
+        for p in &live {
+            eprintln!("    missing {p}");
+            missing.push(format!("{target}: {p}"));
+        }
+    }
+    let _ = std::fs::remove_dir_all(&dd);
+
+    assert!(
+        missing.is_empty(),
+        "search paths xcode passes and we don't: {missing:?}"
     );
 }

--- a/sweetpad-lib/DOCS.md
+++ b/sweetpad-lib/DOCS.md
@@ -226,6 +226,7 @@ Hand-built fixtures cover paths no real corpus project exercises:
 | `_synthetic-rich` | Rich settings: UBSan (+ sub-checks), exceptions, hidden visibility, warnings, `SWIFT_STRICT_CONCURRENCY = complete` (`scripts/18_rich_settings.py`) |
 | `_synthetic-multimodule` | App + two framework targets with a real cross-module `import` — the BSP pilot fixture (`scripts/19_multimodule.py`) |
 | `_synthetic-objc-headers` | ObjC header search paths for the BSP loop (`scripts/20_objc_headers.py`) |
+| `_synthetic-headermaps` | The ObjC imports only Xcode's header maps and generated-sources dirs resolve — a sibling dir's header, a mixed target's `-Swift.h`, a framework target's public header, with no `HEADER_SEARCH_PATHS` anywhere (`scripts/23_header_maps.py`) |
 | `_synthetic-multiplatform` | One `SDKROOT = auto` target with `SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx` — the IceCubesApp shape that keeps the SDK-binding regression in CI |
 | `_synthetic-{coredata,assetsym,strcat,intents,cocoapods,macro,tests}` | BSP generated-source / CocoaPods / Swift-macro / XCTest coverage — each a forced `Probe*.swift` referencing a build-time-generated / Pod / macro-expanded symbol |
 | `_synthetic-spm`, `_synthetic-workspace` | SwiftPM package products (`-F …/PackageFrameworks`); multi-project `.xcworkspace` resolution |
@@ -253,7 +254,7 @@ Hand-built fixtures cover paths no real corpus project exercises:
 | `14_compare_versions.py` | Cross-version delta: diffs two versions' per-target settings, canonicalizing path drift and dropping version-echo keys, split into behavioural vs path-geometry buckets |
 | `15_custom_configuration.py` | `_synthetic-custom-config` |
 | `16_capture_compiler_args.py` | Compiler-args oracle capture (build stdout → per-tool argv JSON) |
-| `17_static_library.py` / `18_rich_settings.py` / `19_multimodule.py` / `20_objc_headers.py` | Synthetic fixtures above |
+| `17_static_library.py` / `18_rich_settings.py` / `19_multimodule.py` / `20_objc_headers.py` / `23_header_maps.py` | Synthetic fixtures above |
 | `21_mutation_audit.py` | Injects plausible resolver bugs and checks a fast net goes red — measures the coverage of the coverage (7/7 caught by the fast tier; `--e2e` proves the de-exoneration reclassifies the SDKROOT=auto class) |
 
 ### 4.5 Oracle data sources and the tests that consume them
@@ -563,13 +564,37 @@ the build server via `buildTarget/prepare` — *we* must produce the modules.
   `membershipExceptions`), target dependency edges, Swift-package products
   (`-F …/PackageFrameworks`), corpus soundness checks.
 - **v2 — seamless background indexing**: advertises `prepareProvider: true`;
-  `buildTarget/prepare` runs an incremental `xcodebuild` **by scheme** (a bare
-  `-target` build doesn't populate the products dir;
-  `project::scheme_for_target` maps target → scheme) on a serialized worker,
+  `buildTarget/prepare` runs an incremental `xcodebuild` **by scheme**
+  (`project::scheme_for_target` maps target → scheme) on a serialized worker,
   best-effort. This is where we surpass `xcode-build-server` (no prepare
   there). Validated from a clean DerivedData: real headless sourcekit-lsp
   resolves cross-module imports with 0 diagnostics. Caveat: Xcode has no fast
   declarations-only prepare, so prepare = a real incremental build.
+
+  Prepare is load-bearing rather than opportunistic since the clang search
+  paths became a function of build state (`compiler_args::header_map_paths`),
+  which is what the rest of its shape follows from:
+
+  - it pushes `buildTarget/didChange` for what it built, so a client that
+    pulled options against the cold tree comes back for the header maps the
+    build has now written — nothing else does, since the pbxproj watcher fires
+    on project edits and a build isn't one;
+  - a target **no scheme builds** is prepared by `-target` with `SYMROOT` /
+    `OBJROOT` named, which is what puts its output in the DerivedData the
+    editor arguments resolve against rather than the project's own `build/`;
+  - `build/initialized` queues a warm-up over every target, at the back of the
+    queue so a `buildTarget/prepare` — a file somebody has open, and a reply
+    sourcekit-lsp is blocked on — overtakes it;
+  - a repeat over unchanged project files is skipped (a failure is retried
+    after `PREPARE_RETRY_AFTER`), so asking per opened file doesn't serialize a
+    fresh `xcodebuild` behind each one;
+  - a failure is recorded and pushed as a `failed` status, which the
+    extension's Doctor reports. The reply is still sent — a missing one wedges
+    sourcekit-lsp's semantics for that target — so the failure needs a channel
+    of its own.
+
+  The `swiftc` fast path below produces no header maps, but needs none: it
+  requires the whole closure to be pure Swift.
 - **v3 — self-built prepare (Swift fast path)**: if the prepared target's
   transitive closure is `project::is_self_buildable` (pure Swift; no package
   products, C-family sources, script phases, or build rules), emit each
@@ -584,8 +609,13 @@ the build server via `buildTarget/prepare` — *we* must produce the modules.
 All layers are headless and self-labeling (no human in the iteration):
 
 - **Layer 0 — type-check oracle** (`tests/bsp_typecheck_oracle.rs`, opt-in
-  `BSP_ORACLE=1`): `swiftc -typecheck` with our generated args → 0
-  module-resolution errors, including cross-module imports.
+  `BSP_ORACLE=1`): `swiftc -typecheck` / `clang -fsyntax-only` with our
+  generated args → 0 module-resolution errors, including cross-module imports
+  and the header-map surface (`_synthetic-headermaps`). The same file carries
+  a **search-path coverage** check from the other side: every `-I`/`-iquote`
+  Xcode's own `CompileC` line passes, and that exists on disk, must have a
+  counterpart in ours — the net the arg-oracle comparator can't be, since it
+  scores header maps and `Intermediates.noindex` paths as geometry.
 - **Layer 1 — conformance** (`tests/bsp_conformance.rs`, fast/hermetic/
   ungated): scripted JSON-RPC pinning the full reply surface — capability set,
   item shapes, membership fallback, unowned-file and unknown-method edges,

--- a/sweetpad-lib/fixtures/_synthetic-headermaps/project/Core/CoreThing.h
+++ b/sweetpad-lib/fixtures/_synthetic-headermaps/project/Core/CoreThing.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface CoreThing : NSObject
++ (NSString *)coreName;
+@end

--- a/sweetpad-lib/fixtures/_synthetic-headermaps/project/Core/CoreThing.m
+++ b/sweetpad-lib/fixtures/_synthetic-headermaps/project/Core/CoreThing.m
@@ -1,0 +1,5 @@
+#import "CoreThing.h"
+
+@implementation CoreThing
++ (NSString *)coreName { return @"core"; }
+@end

--- a/sweetpad-lib/fixtures/_synthetic-headermaps/project/Deep/DeepThing.h
+++ b/sweetpad-lib/fixtures/_synthetic-headermaps/project/Deep/DeepThing.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface DeepThing : NSObject
++ (NSString *)deepName;
+@end

--- a/sweetpad-lib/fixtures/_synthetic-headermaps/project/Deep/DeepThing.m
+++ b/sweetpad-lib/fixtures/_synthetic-headermaps/project/Deep/DeepThing.m
@@ -1,0 +1,5 @@
+#import "DeepThing.h"
+
+@implementation DeepThing
++ (NSString *)deepName { return @"deep"; }
+@end

--- a/sweetpad-lib/fixtures/_synthetic-headermaps/project/HeaderMaps.xcodeproj/project.pbxproj
+++ b/sweetpad-lib/fixtures/_synthetic-headermaps/project/HeaderMaps.xcodeproj/project.pbxproj
@@ -1,0 +1,219 @@
+// !$*UTF8*$!
+{
+    archiveVersion = 1;
+    classes = {};
+    objectVersion = 60;
+    objects = {
+        56BD5EB085EA5104A6B51893 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreThing.h; sourceTree = "<group>"; };
+        B2C0679565C75F75856CB87E = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CoreThing.m; sourceTree = "<group>"; };
+        BCA05D6E6B515E99B0EAFECC = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeepThing.h; sourceTree = "<group>"; };
+        FAC6237BC73F5CB28F4D11FD = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DeepThing.m; sourceTree = "<group>"; };
+        21D4FACB5606504694E1D73C = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Greeter.swift; sourceTree = "<group>"; };
+        327C40EC73AB50F7AA1DBDE4 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OrphanThing.m; sourceTree = "<group>"; };
+        074BADC9E1DF5BD484ACE1D0 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Widget.h; sourceTree = "<group>"; };
+        4BE0562F1F8D514480C54447 = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Widget.m; sourceTree = "<group>"; };
+        CEE502C21DAD52928F0A3E7E = {isa = PBXBuildFile; fileRef = 56BD5EB085EA5104A6B51893; settings = {ATTRIBUTES = (Public, ); }; };
+        7BDB76F77A4D5917BCB69C64 = {isa = PBXBuildFile; fileRef = B2C0679565C75F75856CB87E; };
+        DE0CDBF0AFCC5B3FBB6A59A5 = {isa = PBXBuildFile; fileRef = FAC6237BC73F5CB28F4D11FD; };
+        AE2E787B73B958C3AEFF84BF = {isa = PBXBuildFile; fileRef = 21D4FACB5606504694E1D73C; };
+        C21C8C7F142258CEA7832790 = {isa = PBXBuildFile; fileRef = 327C40EC73AB50F7AA1DBDE4; };
+        F5934D47D2D154B5876DC5D7 = {isa = PBXBuildFile; fileRef = 4BE0562F1F8D514480C54447; };
+        7D065EE841E15FA9A84960DE = { isa = PBXGroup; children = (56BD5EB085EA5104A6B51893, B2C0679565C75F75856CB87E); path = Core; sourceTree = "<group>"; };
+        8AD788E542C457DEBDC73967 = { isa = PBXGroup; children = (BCA05D6E6B515E99B0EAFECC, FAC6237BC73F5CB28F4D11FD); path = Deep; sourceTree = "<group>"; };
+        CA16933869875D489650D57E = { isa = PBXGroup; children = (327C40EC73AB50F7AA1DBDE4); path = Orphan; sourceTree = "<group>"; };
+        53A8C5D3704853CD9FCA53BA = { isa = PBXGroup; children = (21D4FACB5606504694E1D73C, 074BADC9E1DF5BD484ACE1D0, 4BE0562F1F8D514480C54447); path = Top; sourceTree = "<group>"; };
+        CCC841058FF35CA889793D03 = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libHeaderMaps.a; sourceTree = BUILT_PRODUCTS_DIR; };
+        7F6ACDFC6219579AB74B7226 = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HeaderMapsCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+        08A94CDD8D175DD6B8CCFD4F = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libHeaderMapsOrphan.a; sourceTree = BUILT_PRODUCTS_DIR; };
+        646DCB242A835F9E8F3D322B = { isa = PBXGroup; children = (7F6ACDFC6219579AB74B7226, CCC841058FF35CA889793D03, 08A94CDD8D175DD6B8CCFD4F); name = Products; sourceTree = "<group>"; };
+        BBEBFEDC43B15A44B29EAE65 = { isa = PBXGroup; children = (7D065EE841E15FA9A84960DE, 8AD788E542C457DEBDC73967, CA16933869875D489650D57E, 53A8C5D3704853CD9FCA53BA, 646DCB242A835F9E8F3D322B); sourceTree = "<group>"; };
+        32255C7891D65E5FA3FA033D = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (7BDB76F77A4D5917BCB69C64);
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        90FD9B1C0F6C58A3A0C548D4 = {
+            isa = PBXHeadersBuildPhase;
+            buildActionMask = 2147483647;
+            files = (CEE502C21DAD52928F0A3E7E);
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        85BD55C209355E2DB6EB2A5A = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (F5934D47D2D154B5876DC5D7, AE2E787B73B958C3AEFF84BF, DE0CDBF0AFCC5B3FBB6A59A5);
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        04E87E0693155C4F9CB17E7A = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = 3C6C96CD30D45E5A91F1B596;
+            buildPhases = (90FD9B1C0F6C58A3A0C548D4, 32255C7891D65E5FA3FA033D);
+            buildRules = ();
+            dependencies = ();
+            name = HeaderMapsCore;
+            productName = HeaderMapsCore;
+            productReference = 7F6ACDFC6219579AB74B7226;
+            productType = "com.apple.product-type.framework";
+        };
+        E305F5CB534C59118F5E9B75 = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = 1429E44A58935AEF86D7BFAF;
+            buildPhases = (85BD55C209355E2DB6EB2A5A);
+            buildRules = ();
+            dependencies = (B6B6F7084DA853FDABE30ABE);
+            name = HeaderMaps;
+            productName = HeaderMaps;
+            productReference = CCC841058FF35CA889793D03;
+            productType = "com.apple.product-type.library.static";
+        };
+        096C80F0A53B5603B2660360 = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (C21C8C7F142258CEA7832790);
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        D0F84FF8FF7C56559EA2CBB6 = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = B638DF4505935A398914BD5B;
+            buildPhases = (096C80F0A53B5603B2660360);
+            buildRules = ();
+            dependencies = ();
+            name = HeaderMapsOrphan;
+            productName = HeaderMapsOrphan;
+            productReference = 08A94CDD8D175DD6B8CCFD4F;
+            productType = "com.apple.product-type.library.static";
+        };
+        612879D6285D57F9AEC0EB99 = {
+            isa = PBXContainerItemProxy;
+            containerPortal = 5B77E0CBC03C5DF7B60F059E;
+            proxyType = 1;
+            remoteGlobalIDString = 04E87E0693155C4F9CB17E7A;
+            remoteInfo = HeaderMapsCore;
+        };
+        B6B6F7084DA853FDABE30ABE = {
+            isa = PBXTargetDependency;
+            target = 04E87E0693155C4F9CB17E7A;
+            targetProxy = 612879D6285D57F9AEC0EB99;
+        };
+        5B77E0CBC03C5DF7B60F059E = {
+            isa = PBXProject;
+            attributes = { LastUpgradeCheck = 1500; };
+            buildConfigurationList = 0D9FFC6E47AD5EBEAA2F2FA9;
+            compatibilityVersion = "Xcode 14.0";
+            developmentRegion = en;
+            hasScannedForEncodings = 0;
+            knownRegions = (en, Base);
+            mainGroup = BBEBFEDC43B15A44B29EAE65;
+            productRefGroup = 646DCB242A835F9E8F3D322B;
+            projectDirPath = "";
+            projectRoot = "";
+            targets = (04E87E0693155C4F9CB17E7A, E305F5CB534C59118F5E9B75, D0F84FF8FF7C56559EA2CBB6);
+        };
+        7490C74BABC655EFABE63573 = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ALWAYS_SEARCH_USER_PATHS = NO;
+                MACOSX_DEPLOYMENT_TARGET = 12.0;
+                ONLY_ACTIVE_ARCH = YES;
+                SDKROOT = macosx;
+            };
+            name = Debug;
+        };
+        51012A84A8CE53848EB43F68 = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ALWAYS_SEARCH_USER_PATHS = NO;
+                MACOSX_DEPLOYMENT_TARGET = 12.0;
+                ONLY_ACTIVE_ARCH = YES;
+                SDKROOT = macosx;
+            };
+            name = Release;
+        };
+        0D9FFC6E47AD5EBEAA2F2FA9 = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                7490C74BABC655EFABE63573,
+                51012A84A8CE53848EB43F68,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+        F5357DB9611C58AB8E612829 = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                GENERATE_INFOPLIST_FILE = YES;
+            };
+            name = Debug;
+        };
+        A645969DE1FA5D78B16F3AAF = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                GENERATE_INFOPLIST_FILE = YES;
+            };
+            name = Release;
+        };
+        3C6C96CD30D45E5A91F1B596 = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                F5357DB9611C58AB8E612829,
+                A645969DE1FA5D78B16F3AAF,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+        50F6DB2C292E5B1880A6D2F4 = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_VERSION = 5.0;
+                SWIFT_OBJC_INTERFACE_HEADER_NAME = "HeaderMaps-Swift.h";
+            };
+            name = Debug;
+        };
+        C0351E789617553FB69B3784 = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_VERSION = 5.0;
+                SWIFT_OBJC_INTERFACE_HEADER_NAME = "HeaderMaps-Swift.h";
+            };
+            name = Release;
+        };
+        1429E44A58935AEF86D7BFAF = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                50F6DB2C292E5B1880A6D2F4,
+                C0351E789617553FB69B3784,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+        550BE39BE88A5274922ABD3F = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                PRODUCT_NAME = "$(TARGET_NAME)";
+            };
+            name = Debug;
+        };
+        DE4850F247F95026A0CC9607 = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                PRODUCT_NAME = "$(TARGET_NAME)";
+            };
+            name = Release;
+        };
+        B638DF4505935A398914BD5B = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                550BE39BE88A5274922ABD3F,
+                DE4850F247F95026A0CC9607,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+    };
+    rootObject = 5B77E0CBC03C5DF7B60F059E;
+}

--- a/sweetpad-lib/fixtures/_synthetic-headermaps/project/HeaderMaps.xcodeproj/xcshareddata/xcschemes/HeaderMaps.xcscheme
+++ b/sweetpad-lib/fixtures/_synthetic-headermaps/project/HeaderMaps.xcodeproj/xcshareddata/xcschemes/HeaderMaps.xcscheme
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme LastUpgradeVersion="1500" version="1.7">
+   <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
+      <BuildActionEntries>
+         <BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">
+            <BuildableReference
+               BuildableIdentifier="primary"
+               BlueprintIdentifier="04E87E0693155C4F9CB17E7A"
+               BuildableName="HeaderMapsCore.framework"
+               BlueprintName="HeaderMapsCore"
+               ReferencedContainer="container:HeaderMaps.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">
+            <BuildableReference
+               BuildableIdentifier="primary"
+               BlueprintIdentifier="E305F5CB534C59118F5E9B75"
+               BuildableName="libHeaderMaps.a"
+               BlueprintName="HeaderMaps"
+               ReferencedContainer="container:HeaderMaps.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+</Scheme>

--- a/sweetpad-lib/fixtures/_synthetic-headermaps/project/Orphan/OrphanThing.m
+++ b/sweetpad-lib/fixtures/_synthetic-headermaps/project/Orphan/OrphanThing.m
@@ -1,0 +1,9 @@
+// This target is in no scheme, so only a `-target` build prepares it.
+#import "DeepThing.h"
+
+@interface OrphanThing : NSObject
+@end
+
+@implementation OrphanThing
++ (NSString *)name { return [DeepThing deepName]; }
+@end

--- a/sweetpad-lib/fixtures/_synthetic-headermaps/project/Top/Greeter.swift
+++ b/sweetpad-lib/fixtures/_synthetic-headermaps/project/Top/Greeter.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+@objc public class Greeter: NSObject {
+    @objc public func greeting() -> String { "hello" }
+}

--- a/sweetpad-lib/fixtures/_synthetic-headermaps/project/Top/Widget.h
+++ b/sweetpad-lib/fixtures/_synthetic-headermaps/project/Top/Widget.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface Widget : NSObject
++ (NSString *)describe;
+@end

--- a/sweetpad-lib/fixtures/_synthetic-headermaps/project/Top/Widget.m
+++ b/sweetpad-lib/fixtures/_synthetic-headermaps/project/Top/Widget.m
@@ -1,0 +1,16 @@
+#import "Widget.h"
+// A sibling directory's header, named by no HEADER_SEARCH_PATHS entry: only the
+// project header map resolves it.
+#import "DeepThing.h"
+// This target's Swift half, which exists only once a build has generated it.
+#import "HeaderMaps-Swift.h"
+// Another target's public header, reached through the framework it installs.
+#import <HeaderMapsCore/CoreThing.h>
+
+@implementation Widget
++ (NSString *)describe {
+  return [NSString stringWithFormat:@"%@ %@ %@", [DeepThing deepName],
+                                    [CoreThing coreName],
+                                    [[Greeter new] greeting]];
+}
+@end

--- a/sweetpad-lib/scripts/23_header_maps.py
+++ b/sweetpad-lib/scripts/23_header_maps.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""Synthetic header-map fixture for the BSP harness (see DOCS.md §8 (BSP server)).
+
+`_synthetic-objc-headers` covers the one ObjC import that resolves without any
+header map: a header in a directory `HEADER_SEARCH_PATHS` names. Real projects
+mostly don't look like that, and the imports they do use — a sibling directory's
+header, the `-Swift.h` a mixed target generates, another target's public header —
+resolve through Xcode's header maps and generated-sources dirs. This fixture is
+those three imports and nothing else, with no `HEADER_SEARCH_PATHS` anywhere, so
+the editor arguments have to carry the real search paths or `Widget.m` fails to
+parse (GitHub #238).
+
+Three targets:
+  HeaderMapsCore    a framework installing `CoreThing.h` as a public header
+  HeaderMaps        a mixed ObjC/Swift static library whose `Widget.m` imports
+                    `"DeepThing.h"` (a sibling dir), `"HeaderMaps-Swift.h"`
+                    (generated) and `<HeaderMapsCore/CoreThing.h>` (the framework)
+  HeaderMapsOrphan  the same cross-directory import from a target **no scheme
+                    builds** — the shape `buildTarget/prepare` has to reach with
+                    a `-target` build, since there is no scheme to name
+
+Output (committed):
+  fixtures/_synthetic-headermaps/project/HeaderMaps.xcodeproj
+  fixtures/_synthetic-headermaps/project/{Core,Deep,Top}/…
+
+Flags:
+  --force   overwrite an existing project
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import textwrap
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import common  # noqa: E402
+
+SLUG = "_synthetic-headermaps"
+
+SOURCES = {
+    "Core/CoreThing.h": """\
+#import <Foundation/Foundation.h>
+
+@interface CoreThing : NSObject
++ (NSString *)coreName;
+@end
+""",
+    "Core/CoreThing.m": """\
+#import "CoreThing.h"
+
+@implementation CoreThing
++ (NSString *)coreName { return @"core"; }
+@end
+""",
+    "Deep/DeepThing.h": """\
+#import <Foundation/Foundation.h>
+
+@interface DeepThing : NSObject
++ (NSString *)deepName;
+@end
+""",
+    "Deep/DeepThing.m": """\
+#import "DeepThing.h"
+
+@implementation DeepThing
++ (NSString *)deepName { return @"deep"; }
+@end
+""",
+    "Top/Greeter.swift": """\
+import Foundation
+
+@objc public class Greeter: NSObject {
+    @objc public func greeting() -> String { "hello" }
+}
+""",
+    "Orphan/OrphanThing.m": """\
+// This target is in no scheme, so only a `-target` build prepares it.
+#import "DeepThing.h"
+
+@interface OrphanThing : NSObject
+@end
+
+@implementation OrphanThing
++ (NSString *)name { return [DeepThing deepName]; }
+@end
+""",
+    "Top/Widget.h": """\
+#import <Foundation/Foundation.h>
+
+@interface Widget : NSObject
++ (NSString *)describe;
+@end
+""",
+    "Top/Widget.m": """\
+#import "Widget.h"
+// A sibling directory's header, named by no HEADER_SEARCH_PATHS entry: only the
+// project header map resolves it.
+#import "DeepThing.h"
+// This target's Swift half, which exists only once a build has generated it.
+#import "HeaderMaps-Swift.h"
+// Another target's public header, reached through the framework it installs.
+#import <HeaderMapsCore/CoreThing.h>
+
+@implementation Widget
++ (NSString *)describe {
+  return [NSString stringWithFormat:@"%@ %@ %@", [DeepThing deepName],
+                                    [CoreThing coreName],
+                                    [[Greeter new] greeting]];
+}
+@end
+""",
+}
+
+# No HEADER_SEARCH_PATHS: every import in Widget.m has to resolve some other way.
+PROJECT_SETTINGS = {
+    "ALWAYS_SEARCH_USER_PATHS": "NO",
+    "MACOSX_DEPLOYMENT_TARGET": "12.0",
+    "ONLY_ACTIVE_ARCH": "YES",
+    "SDKROOT": "macosx",
+}
+
+LIB_SETTINGS = {
+    "PRODUCT_NAME": "$(TARGET_NAME)",
+    "SWIFT_VERSION": "5.0",
+    # Named rather than defaulted so the generated header's path is the same
+    # whatever a product type's spec says it should be.
+    "SWIFT_OBJC_INTERFACE_HEADER_NAME": "HeaderMaps-Swift.h",
+}
+
+ORPHAN_SETTINGS = {
+    "PRODUCT_NAME": "$(TARGET_NAME)",
+}
+
+FRAMEWORK_SETTINGS = {
+    "PRODUCT_NAME": "$(TARGET_NAME)",
+    "GENERATE_INFOPLIST_FILE": "YES",
+}
+
+
+def _uuid(seed: str) -> str:
+    return uuid.uuid5(uuid.NAMESPACE_URL, f"sweetpad/headermaps/{seed}").hex[:24].upper()
+
+
+def _quote(value: str) -> str:
+    """pbxproj leaves bare identifiers unquoted and quotes everything else — a
+    bare `$(TARGET_NAME)` is a parse error, not a variable reference."""
+    if value and all(c.isalnum() or c in "_." for c in value):
+        return value
+    return f'"{value}"'
+
+
+def _config_list(name: str, settings: dict[str, str]) -> str:
+    """The two XCBuildConfigurations for `name` plus the list that holds them."""
+    body = ""
+    rendered = "".join(f"                {k} = {_quote(v)};\n" for k, v in settings.items())
+    for cfg in ("Debug", "Release"):
+        body += (
+            f'        {_uuid(f"cfg_{name}_{cfg}")} = {{\n'
+            f"            isa = XCBuildConfiguration;\n"
+            f"            buildSettings = {{\n"
+            f"{rendered}"
+            f"            }};\n"
+            f"            name = {cfg};\n"
+            f"        }};\n"
+        )
+    entries = "\n".join(
+        f'                {_uuid(f"cfg_{name}_{c}")},' for c in ("Debug", "Release")
+    )
+    body += (
+        f'        {_uuid(f"bcl_{name}")} = {{\n'
+        f"            isa = XCConfigurationList;\n"
+        f"            buildConfigurations = (\n"
+        f"{entries}\n"
+        f"            );\n"
+        f"            defaultConfigurationIsVisible = 0;\n"
+        f"            defaultConfigurationName = Release;\n"
+        f"        }};\n"
+    )
+    return body
+
+
+def render_pbxproj() -> str:
+    u = _uuid
+    refs = {path: u(f"ref_{path}") for path in SOURCES}
+    builds = {path: u(f"build_{path}") for path in SOURCES}
+
+    objects = ""
+    for path in SOURCES:
+        kind = {
+            ".h": "sourcecode.c.h",
+            ".m": "sourcecode.c.objc",
+            ".swift": "sourcecode.swift",
+        }[Path(path).suffix]
+        objects += (
+            f'        {refs[path]} = {{isa = PBXFileReference; '
+            f"lastKnownFileType = {kind}; path = {Path(path).name}; "
+            f'sourceTree = "<group>"; }};\n'
+        )
+    # The framework's public header is the only one in a Headers build phase;
+    # that attribute is what installs it into HeaderMapsCore.framework/Headers.
+    objects += (
+        f'        {builds["Core/CoreThing.h"]} = {{isa = PBXBuildFile; '
+        f'fileRef = {refs["Core/CoreThing.h"]}; settings = {{ATTRIBUTES = (Public, ); }}; }};\n'
+    )
+    for path in SOURCES:
+        if Path(path).suffix in (".m", ".swift"):
+            objects += (
+                f"        {builds[path]} = {{isa = PBXBuildFile; "
+                f"fileRef = {refs[path]}; }};\n"
+            )
+
+    groups = {"Core": ["Core/CoreThing.h", "Core/CoreThing.m"],
+              "Deep": ["Deep/DeepThing.h", "Deep/DeepThing.m"],
+              "Orphan": ["Orphan/OrphanThing.m"],
+              "Top": ["Top/Greeter.swift", "Top/Widget.h", "Top/Widget.m"]}
+    for name, members in groups.items():
+        children = ", ".join(refs[m] for m in members)
+        objects += (
+            f'        {u(f"group_{name}")} = {{ isa = PBXGroup; children = ({children}); '
+            f'path = {name}; sourceTree = "<group>"; }};\n'
+        )
+
+    objects += (
+        f'        {u("product_lib")} = {{isa = PBXFileReference; explicitFileType = archive.ar; '
+        f"includeInIndex = 0; path = libHeaderMaps.a; sourceTree = BUILT_PRODUCTS_DIR; }};\n"
+        f'        {u("product_fw")} = {{isa = PBXFileReference; explicitFileType = wrapper.framework; '
+        f"includeInIndex = 0; path = HeaderMapsCore.framework; sourceTree = BUILT_PRODUCTS_DIR; }};\n"
+        f'        {u("product_orphan")} = {{isa = PBXFileReference; explicitFileType = archive.ar; '
+        f"includeInIndex = 0; path = libHeaderMapsOrphan.a; sourceTree = BUILT_PRODUCTS_DIR; }};\n"
+        f'        {u("products_group")} = {{ isa = PBXGroup; '
+        f'children = ({u("product_fw")}, {u("product_lib")}, {u("product_orphan")}); name = Products; sourceTree = "<group>"; }};\n'
+        f'        {u("main_group")} = {{ isa = PBXGroup; children = ({u("group_Core")}, '
+        f'{u("group_Deep")}, {u("group_Orphan")}, {u("group_Top")}, {u("products_group")}); sourceTree = "<group>"; }};\n'
+    )
+
+    lib_sources = ", ".join(
+        builds[p] for p in ("Top/Widget.m", "Top/Greeter.swift", "Deep/DeepThing.m")
+    )
+    objects += textwrap.indent(textwrap.dedent(f"""\
+        {u("phase_fw_sources")} = {{
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = ({builds["Core/CoreThing.m"]});
+            runOnlyForDeploymentPostprocessing = 0;
+        }};
+        {u("phase_fw_headers")} = {{
+            isa = PBXHeadersBuildPhase;
+            buildActionMask = 2147483647;
+            files = ({builds["Core/CoreThing.h"]});
+            runOnlyForDeploymentPostprocessing = 0;
+        }};
+        {u("phase_lib_sources")} = {{
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = ({lib_sources});
+            runOnlyForDeploymentPostprocessing = 0;
+        }};
+        {u("target_fw")} = {{
+            isa = PBXNativeTarget;
+            buildConfigurationList = {u("bcl_fw")};
+            buildPhases = ({u("phase_fw_headers")}, {u("phase_fw_sources")});
+            buildRules = ();
+            dependencies = ();
+            name = HeaderMapsCore;
+            productName = HeaderMapsCore;
+            productReference = {u("product_fw")};
+            productType = "com.apple.product-type.framework";
+        }};
+        {u("target_lib")} = {{
+            isa = PBXNativeTarget;
+            buildConfigurationList = {u("bcl_lib")};
+            buildPhases = ({u("phase_lib_sources")});
+            buildRules = ();
+            dependencies = ({u("dep_lib_on_fw")});
+            name = HeaderMaps;
+            productName = HeaderMaps;
+            productReference = {u("product_lib")};
+            productType = "com.apple.product-type.library.static";
+        }};
+        {u("phase_orphan_sources")} = {{
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = ({builds["Orphan/OrphanThing.m"]});
+            runOnlyForDeploymentPostprocessing = 0;
+        }};
+        {u("target_orphan")} = {{
+            isa = PBXNativeTarget;
+            buildConfigurationList = {u("bcl_orphan")};
+            buildPhases = ({u("phase_orphan_sources")});
+            buildRules = ();
+            dependencies = ();
+            name = HeaderMapsOrphan;
+            productName = HeaderMapsOrphan;
+            productReference = {u("product_orphan")};
+            productType = "com.apple.product-type.library.static";
+        }};
+        {u("proxy_fw")} = {{
+            isa = PBXContainerItemProxy;
+            containerPortal = {u("project")};
+            proxyType = 1;
+            remoteGlobalIDString = {u("target_fw")};
+            remoteInfo = HeaderMapsCore;
+        }};
+        {u("dep_lib_on_fw")} = {{
+            isa = PBXTargetDependency;
+            target = {u("target_fw")};
+            targetProxy = {u("proxy_fw")};
+        }};
+        {u("project")} = {{
+            isa = PBXProject;
+            attributes = {{ LastUpgradeCheck = 1500; }};
+            buildConfigurationList = {u("bcl_proj")};
+            compatibilityVersion = "Xcode 14.0";
+            developmentRegion = en;
+            hasScannedForEncodings = 0;
+            knownRegions = (en, Base);
+            mainGroup = {u("main_group")};
+            productRefGroup = {u("products_group")};
+            projectDirPath = "";
+            projectRoot = "";
+            targets = ({u("target_fw")}, {u("target_lib")}, {u("target_orphan")});
+        }};
+    """), " " * 8)
+
+    for name, settings in (
+        ("proj", PROJECT_SETTINGS),
+        ("fw", FRAMEWORK_SETTINGS),
+        ("lib", LIB_SETTINGS),
+        ("orphan", ORPHAN_SETTINGS),
+    ):
+        objects += _config_list(name, settings)
+
+    return (
+        "// !$*UTF8*$!\n{\n"
+        "    archiveVersion = 1;\n"
+        "    classes = {};\n"
+        "    objectVersion = 60;\n"
+        "    objects = {\n"
+        f"{objects}"
+        "    };\n"
+        f'    rootObject = {u("project")};\n'
+        "}\n"
+    )
+
+
+def render_scheme() -> str:
+    """Both targets, built in dependency order — the library's PBXTargetDependency
+    on the framework is what puts `CoreThing.h` in the products dir before
+    `Widget.m` imports it."""
+    entries = ""
+    for target, key, product in (
+        ("HeaderMapsCore", "target_fw", "HeaderMapsCore.framework"),
+        ("HeaderMaps", "target_lib", "libHeaderMaps.a"),
+    ):
+        entries += (
+            '         <BuildActionEntry buildForTesting="YES" buildForRunning="YES"'
+            ' buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">\n'
+            "            <BuildableReference\n"
+            '               BuildableIdentifier="primary"\n'
+            f'               BlueprintIdentifier="{_uuid(key)}"\n'
+            f'               BuildableName="{product}"\n'
+            f'               BlueprintName="{target}"\n'
+            '               ReferencedContainer="container:HeaderMaps.xcodeproj">\n'
+            "            </BuildableReference>\n"
+            "         </BuildActionEntry>\n"
+        )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<Scheme LastUpgradeVersion="1500" version="1.7">\n'
+        '   <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">\n'
+        "      <BuildActionEntries>\n"
+        f"{entries}"
+        "      </BuildActionEntries>\n"
+        "   </BuildAction>\n"
+        "</Scheme>\n"
+    )
+
+
+def materialize(root: Path) -> Path:
+    for path, body in SOURCES.items():
+        target = root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+    xcodeproj = root / "HeaderMaps.xcodeproj"
+    xcodeproj.mkdir(parents=True, exist_ok=True)
+    (xcodeproj / "project.pbxproj").write_text(render_pbxproj())
+    schemes = xcodeproj / "xcshareddata" / "xcschemes"
+    schemes.mkdir(parents=True, exist_ok=True)
+    (schemes / "HeaderMaps.xcscheme").write_text(render_scheme())
+    return xcodeproj
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--force", action="store_true")
+    args = ap.parse_args()
+    root = common.FIXTURES_DIR / SLUG / "project"
+    if root.exists() and not args.force:
+        common.log(f"exists, skip (use --force): {root}")
+        return 0
+    xcodeproj = materialize(root)
+    common.log(f"wrote {xcodeproj}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sweetpad-lib/src/compiler_args.rs
+++ b/sweetpad-lib/src/compiler_args.rs
@@ -8,8 +8,9 @@
 //! defaults a current Xcode always passes (`-enable-batch-mode`,
 //! `-explicit-module-build`, `-no-color-diagnostics`, …). It does **not** emit
 //! the per-build output/intermediate geometry (`-o`, `-output-file-map`,
-//! `-emit-module-path`, header maps, the module cache): those are validation-
-//! out-of-scope (see the oracle comparator) and have no consumer here.
+//! `-emit-module-path`, the module cache): those are validation-out-of-scope
+//! (see the oracle comparator) and have no consumer here. The clang header
+//! maps are the exception the editor forces — see [`header_map_paths`].
 //!
 //! Mappings are grounded against the captured oracle
 //! (`fixtures/<slug>/.../compiler-args/`). Where a flag is a fixed build-system
@@ -473,7 +474,7 @@ pub fn clang_arguments(
     // Header/framework search paths live in the core build-settings spec, not the
     // Clang tool spec, so the option loop below never emits them — the editor's
     // front end needs them to find project headers and framework modules.
-    emit_clang_search_paths(&mut a, settings);
+    emit_clang_search_paths(&mut a, settings, arch);
     // An option applies when its language, arch, and condition gates all pass. A
     // `FileTypes` is satisfied by a language the target compiles (or is empty, =
     // every C-family input; or `file_types` is empty = no info, gate nothing); an
@@ -522,46 +523,118 @@ pub fn clang_arguments(
 }
 
 /// Emit the clang header/framework search paths. The build system adds these
-/// from the core build settings (not the Clang xcspec): the products dir's
-/// generated-headers `include` subdir + `HEADER_SEARCH_PATHS` as `-I`, the
+/// from the core build settings (not the Clang xcspec): the target's generated
+/// header maps, the products dir's generated-headers `include` subdir +
+/// `HEADER_SEARCH_PATHS` as `-I`, the target's generated-sources dirs, the
 /// products dir + `FRAMEWORK_SEARCH_PATHS` as `-F`, and the user/system header
-/// paths as `-iquote`/`-isystem`. Each list is de-duplicated (a setting often
-/// re-inherits the products dir), as `emit_library_paths` does for `-L`.
-fn emit_clang_search_paths(a: &mut ArgBuilder, settings: &Settings) {
+/// paths as `-iquote`/`-isystem`. Each `flag`/path pair is emitted once (a
+/// setting often re-inherits the products dir), as `emit_library_paths` does
+/// for `-L`.
+fn emit_clang_search_paths(a: &mut ArgBuilder, settings: &Settings, arch: &str) {
     let get = |k: &str| settings.get(k).map(String::as_str);
     let products = get("BUILT_PRODUCTS_DIR");
+    let mut paths: Vec<(&str, String)> = header_map_paths(settings);
 
     // `-I`: the products generated-headers dir, then HEADER_SEARCH_PATHS. (Bare
     // `BUILT_PRODUCTS_DIR` is a Swift-module path, not a clang header path.)
-    let mut includes: Vec<String> = Vec::new();
     if let Some(p) = products {
-        includes.push(format!("{p}/include"));
+        paths.push(("-I", format!("{p}/include")));
     }
-    includes.extend(ws_unquoted(get("HEADER_SEARCH_PATHS")));
-    emit_unique_pairs(a, "-I", &includes);
+    paths.extend(
+        ws_unquoted(get("HEADER_SEARCH_PATHS"))
+            .into_iter()
+            .map(|p| ("-I", p)),
+    );
+
+    // The target's generated sources: the `<Product>-Swift.h` an ObjC file in a
+    // mixed target imports, the `_vers.c` stamp, Core Data / Intents classes.
+    // Per-variant and per-arch first, then the flat dir, as the build system
+    // orders them.
+    if let Some(dir) = get("DERIVED_FILE_DIR") {
+        let variant = get("CURRENT_VARIANT").unwrap_or("normal");
+        for derived in [
+            format!("{dir}-{variant}/{arch}"),
+            format!("{dir}/{arch}"),
+            dir.to_string(),
+        ] {
+            if Path::new(&derived).is_dir() {
+                paths.push(("-I", derived));
+            }
+        }
+    }
 
     // `-F`: the products dir, then FRAMEWORK_SEARCH_PATHS.
-    let mut frameworks: Vec<String> = products.map(str::to_string).into_iter().collect();
-    frameworks.extend(ws_unquoted(get("FRAMEWORK_SEARCH_PATHS")));
-    emit_unique_pairs(a, "-F", &frameworks);
-
-    for p in ws_unquoted(get("USER_HEADER_SEARCH_PATHS")) {
-        a.pair("-iquote", &p);
+    if let Some(p) = products {
+        paths.push(("-F", p.to_string()));
     }
-    for p in ws_unquoted(get("SYSTEM_HEADER_SEARCH_PATHS")) {
-        a.pair("-isystem", &p);
+    paths.extend(
+        ws_unquoted(get("FRAMEWORK_SEARCH_PATHS"))
+            .into_iter()
+            .map(|p| ("-F", p)),
+    );
+    paths.extend(
+        ws_unquoted(get("USER_HEADER_SEARCH_PATHS"))
+            .into_iter()
+            .map(|p| ("-iquote", p)),
+    );
+    paths.extend(
+        ws_unquoted(get("SYSTEM_HEADER_SEARCH_PATHS"))
+            .into_iter()
+            .map(|p| ("-isystem", p)),
+    );
+
+    let mut seen: BTreeSet<(&str, String)> = BTreeSet::new();
+    for (flag, path) in paths {
+        if seen.insert((flag, path.clone())) {
+            a.pair(flag, &path);
+        }
     }
 }
 
-/// Emit `flag value` for each path, skipping duplicates (order preserved).
-fn emit_unique_pairs(a: &mut ArgBuilder, flag: &str, paths: &[String]) {
-    let mut seen: Vec<&str> = Vec::new();
-    for p in paths {
-        if !seen.contains(&p.as_str()) {
-            a.pair(flag, p);
-            seen.push(p);
-        }
+/// The target's generated header maps, in the order the build system passes
+/// them. A header map indexes every header a target can see by the spelling
+/// that reaches it, which is what resolves `#import "Other.h"` for a header no
+/// `HEADER_SEARCH_PATHS` entry names — a sibling directory's header, another
+/// target's. Without them the editor reports `file not found`, and because a
+/// failed `#import` is fatal to clang, every declaration below it becomes an
+/// "undeclared identifier" too.
+///
+/// The basenames key off `PRODUCT_NAME` rather than the target name (a target
+/// that renames its product gets maps named after the product). Only maps that
+/// are on disk are named: a header map is written by the build, so pointing the
+/// editor at one from a cold tree would say nothing a re-query after
+/// `buildTarget/prepare` could act on.
+fn header_map_paths(settings: &Settings) -> Vec<(&'static str, String)> {
+    let get = |k: &str| settings.get(k).map(String::as_str);
+    if get("USE_HEADERMAP") == Some("NO") {
+        return Vec::new();
     }
+    let (Some(dir), Some(product)) = (get("TEMP_DIR"), get("PRODUCT_NAME")) else {
+        return Vec::new();
+    };
+    let mut out: Vec<(&'static str, String)> = Vec::new();
+    let mut push = |flag: &'static str, suffix: &str| {
+        let path = format!("{dir}/{product}{suffix}");
+        if Path::new(&path).is_file() {
+            out.push((flag, path));
+        }
+    };
+    push("-iquote", "-generated-files.hmap");
+    push("-I", "-own-target-headers.hmap");
+    // A build writes both cross-target maps but puts only one on the command
+    // line: the framework-entry map where the frameworks are in the same
+    // project, the other where a VFS overlay carries those entries instead. We
+    // name both, since we emit no overlay (its path is a per-build hash) and
+    // the framework-entry map is what recovers what the overlay would have
+    // resolved. Naming the superset grants the editor nothing the build would
+    // refuse: its extra entries are framework-style spellings for headers the
+    // build installs.
+    push("-I", "-all-non-framework-target-headers.hmap");
+    push("-I", "-all-target-headers.hmap");
+    if get("HEADERMAP_INCLUDES_PROJECT_HEADERS") != Some("NO") {
+        push("-iquote", "-project-headers.hmap");
+    }
+    out
 }
 
 /// Emit one `-L` per unique library search path: the products dir (always —
@@ -1727,5 +1800,204 @@ mod tests {
         // Absent / unknown product types are assumed to link.
         assert!(links(None));
         assert!(links(Some("com.apple.product-type.future-unknown")));
+    }
+
+    /// A unique scratch dir standing in for a target's build tree — the header
+    /// maps and generated-sources dirs are only emitted when they exist, so
+    /// these tests have to put real files on disk.
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "sweetpad-hmap-{}-{name}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        dir
+    }
+
+    /// The `(flag, value)` pairs in an argv, for asserting on search paths.
+    fn pairs(args: &[String]) -> Vec<(String, String)> {
+        args.windows(2)
+            .map(|w| (w[0].clone(), w[1].clone()))
+            .collect()
+    }
+
+    /// Settings for a target whose build tree is `temp`, with the four header
+    /// maps optionally written out.
+    fn hmap_settings(temp: &Path, product: &str, written: bool) -> Settings {
+        if written {
+            for suffix in [
+                "-generated-files.hmap",
+                "-own-target-headers.hmap",
+                "-all-non-framework-target-headers.hmap",
+                "-project-headers.hmap",
+            ] {
+                std::fs::write(temp.join(format!("{product}{suffix}")), "").expect("write hmap");
+            }
+        }
+        let mut s = Settings::new();
+        s.insert("TEMP_DIR".into(), temp.to_string_lossy().into_owned());
+        s.insert("PRODUCT_NAME".into(), product.into());
+        s.insert(
+            "BUILT_PRODUCTS_DIR".into(),
+            "/dd/Build/Products/Debug".into(),
+        );
+        s
+    }
+
+    #[test]
+    fn header_maps_emit_once_the_build_has_written_them() {
+        let temp = scratch("written");
+        let s = hmap_settings(&temp, "Widget", true);
+        let mut a = ArgBuilder::default();
+        emit_clang_search_paths(&mut a, &s, "arm64");
+        let got = pairs(&a.into_vec());
+        let t = temp.to_string_lossy();
+        for (flag, suffix) in [
+            ("-iquote", "-generated-files.hmap"),
+            ("-I", "-own-target-headers.hmap"),
+            ("-I", "-all-non-framework-target-headers.hmap"),
+            ("-iquote", "-project-headers.hmap"),
+        ] {
+            let want = (flag.to_string(), format!("{t}/Widget{suffix}"));
+            assert!(got.contains(&want), "missing {want:?} in {got:?}");
+        }
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn header_maps_are_silent_before_the_build_writes_them() {
+        let temp = scratch("cold");
+        let s = hmap_settings(&temp, "Widget", false);
+        let mut a = ArgBuilder::default();
+        emit_clang_search_paths(&mut a, &s, "arm64");
+        let args = a.into_vec();
+        assert!(
+            !args.iter().any(|a| a.contains(".hmap")),
+            "named a header map that is not on disk: {args:?}"
+        );
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn header_map_basename_follows_the_product_not_the_target() {
+        let temp = scratch("product");
+        let mut s = hmap_settings(&temp, "DifferentProductName", true);
+        s.insert("TARGET_NAME".into(), "Widget".into());
+        let mut a = ArgBuilder::default();
+        emit_clang_search_paths(&mut a, &s, "arm64");
+        let args = a.into_vec();
+        assert!(
+            args.iter()
+                .any(|a| a.ends_with("/DifferentProductName-project-headers.hmap")),
+            "keyed the header maps off the target name: {args:?}"
+        );
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn header_map_gates_follow_xcodes() {
+        let temp = scratch("gates");
+        let mut off = hmap_settings(&temp, "Widget", true);
+        off.insert("USE_HEADERMAP".into(), "NO".into());
+        let mut a = ArgBuilder::default();
+        emit_clang_search_paths(&mut a, &off, "arm64");
+        let args = a.into_vec();
+        assert!(
+            !args.iter().any(|a| a.contains(".hmap")),
+            "USE_HEADERMAP = NO still emitted header maps: {args:?}"
+        );
+
+        let mut no_project = hmap_settings(&temp, "Widget", true);
+        no_project.insert("HEADERMAP_INCLUDES_PROJECT_HEADERS".into(), "NO".into());
+        let mut a = ArgBuilder::default();
+        emit_clang_search_paths(&mut a, &no_project, "arm64");
+        let args = a.into_vec();
+        assert!(
+            args.iter().any(|a| a.ends_with("-own-target-headers.hmap")),
+            "the other maps should survive the project-headers gate: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a.ends_with("-project-headers.hmap")),
+            "HEADERMAP_INCLUDES_PROJECT_HEADERS = NO still emitted it: {args:?}"
+        );
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn both_cross_target_maps_are_named_when_the_build_wrote_them() {
+        // Which of the two a build puts on the command line depends on whether a
+        // VFS overlay is carrying the framework-style entries; we emit no
+        // overlay, so we name both and let the one that is empty cost nothing.
+        let temp = scratch("cross-target");
+        let s = hmap_settings(&temp, "Widget", false);
+        std::fs::write(temp.join("Widget-all-target-headers.hmap"), "").expect("write hmap");
+        let mut a = ArgBuilder::default();
+        emit_clang_search_paths(&mut a, &s, "arm64");
+        let args = a.into_vec();
+        assert!(
+            args.iter()
+                .any(|a| a.ends_with("/Widget-all-target-headers.hmap"))
+        );
+
+        std::fs::write(
+            temp.join("Widget-all-non-framework-target-headers.hmap"),
+            "",
+        )
+        .expect("write hmap");
+        let mut a = ArgBuilder::default();
+        emit_clang_search_paths(&mut a, &s, "arm64");
+        let args = a.into_vec();
+        for suffix in [
+            "/Widget-all-non-framework-target-headers.hmap",
+            "/Widget-all-target-headers.hmap",
+        ] {
+            assert!(
+                args.iter().any(|a| a.ends_with(suffix)),
+                "missing {suffix} in {args:?}"
+            );
+        }
+        let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn generated_sources_dirs_are_emitted_when_they_exist() {
+        // `<Product>-Swift.h` lands in one of these; which ones a build creates
+        // depends on whether it generates per-arch sources at all.
+        let temp = scratch("derived");
+        let derived = temp.join("DerivedSources");
+        std::fs::create_dir_all(derived.join("arm64")).expect("create derived dirs");
+        std::fs::create_dir_all(temp.join("DerivedSources-normal/arm64"))
+            .expect("create variant dir");
+        let mut s = hmap_settings(&temp, "Widget", false);
+        s.insert(
+            "DERIVED_FILE_DIR".into(),
+            derived.to_string_lossy().into_owned(),
+        );
+        let mut a = ArgBuilder::default();
+        emit_clang_search_paths(&mut a, &s, "arm64");
+        let got = pairs(&a.into_vec());
+        let d = derived.to_string_lossy();
+        for want in [
+            format!("{d}-normal/arm64"),
+            format!("{d}/arm64"),
+            d.to_string(),
+        ] {
+            assert!(
+                got.contains(&("-I".to_string(), want.clone())),
+                "missing -I {want} in {got:?}"
+            );
+        }
+
+        // A tree with only the flat dir names only the flat dir.
+        let _ = std::fs::remove_dir_all(derived.join("arm64"));
+        let _ = std::fs::remove_dir_all(temp.join("DerivedSources-normal"));
+        let mut a = ArgBuilder::default();
+        emit_clang_search_paths(&mut a, &s, "arm64");
+        let got = pairs(&a.into_vec());
+        assert!(got.contains(&("-I".to_string(), d.to_string())));
+        assert!(!got.contains(&("-I".to_string(), format!("{d}/arm64"))));
+        let _ = std::fs::remove_dir_all(&temp);
     }
 }

--- a/sweetpad-lib/tests/serializer_roundtrip.rs
+++ b/sweetpad-lib/tests/serializer_roundtrip.rs
@@ -40,6 +40,14 @@ const NOT_BYTE_EXACT: &[(&str, &str)] = &[
         "hand-written: 4-space indentation instead of tabs",
     ),
     (
+        "_synthetic-headermaps/project/HeaderMaps.xcodeproj/project.pbxproj",
+        "hand-written: 4-space indentation instead of tabs",
+    ),
+    (
+        "_synthetic-headermaps/project/HeaderMaps.xcodeproj/xcshareddata/xcschemes/HeaderMaps.xcscheme",
+        "hand-written: attributes inline in the open tag",
+    ),
+    (
         "_synthetic-multimodule/project/MultiModule.xcodeproj/project.pbxproj",
         "hand-written: 4-space indentation instead of tabs",
     ),

--- a/sweetpad-vscode/CHANGELOG.md
+++ b/sweetpad-vscode/CHANGELOG.md
@@ -4,7 +4,10 @@ New features, improvements and bug fixes for SweetPad are documented in this fil
 
 ## [0.2.13] - 2026-08-24
 
-- Fix autocomplete failing on a first BSP setup because `buildServer.json` was written before the config file it names ([#326](https://github.com/sweetpad-dev/sweetpad/issues/326))
+- Autocomplete now works in every target from the start
+- "SweetPad: Diagnose BSP" now reports the last background build's error
+- Fix Objective-C imports reporting `'Header.h' file not found` on code that builds ([#238](https://github.com/sweetpad-dev/sweetpad/issues/238))
+- Fix autocomplete coming up empty on a first BSP setup ([#326](https://github.com/sweetpad-dev/sweetpad/issues/326))
 
 ## [0.2.12] - 2026-08-24
 

--- a/sweetpad-vscode/src/bsp/bridge.ts
+++ b/sweetpad-vscode/src/bsp/bridge.ts
@@ -14,6 +14,8 @@ export const BSP_LOG_LEVELS: readonly BspLogLevel[] = ["off", "error", "info", "
 
 export type BspSnapshot = {
   connected: boolean;
+  /** The server's last `bsp/status` phase: "ready", "preparing", "failed". */
+  phase?: string;
   detail?: string;
   level: BspLogLevel;
 };
@@ -30,6 +32,7 @@ const RECONNECT_DELAY_MS = 1000;
 export class BspBridge implements vscode.Disposable {
   private readonly output: vscode.OutputChannel;
   private level: BspLogLevel = "info";
+  private phase: string | undefined;
   private detail: string | undefined;
 
   private socketPath: string | undefined;
@@ -79,6 +82,14 @@ export class BspBridge implements vscode.Disposable {
         if (params?.message) {
           this.output.appendLine(`[${params.level ?? "info"}] ${params.message}`);
         }
+      });
+      // The server replays its last status on connect, so this reflects where
+      // things stand rather than only what has happened since we dialled in —
+      // which matters for "failed", a phase that may never be followed by
+      // another one.
+      connection.onNotification("bsp/status", (params: { phase?: string; detail?: string | null }) => {
+        this.phase = params?.phase;
+        this.detail = params?.detail ?? undefined;
       });
       connection.onClose(() => this.handleDrop());
       connection.onError(() => this.handleDrop());
@@ -141,6 +152,7 @@ export class BspBridge implements vscode.Disposable {
   snapshot(): BspSnapshot {
     return {
       connected: this.connection !== undefined,
+      phase: this.phase,
       detail: this.detail,
       level: this.level,
     };

--- a/sweetpad-vscode/src/bsp/commands.spec.ts
+++ b/sweetpad-vscode/src/bsp/commands.spec.ts
@@ -6,8 +6,14 @@ import type { Mock } from "vitest";
 
 import { getWorkspaceFolderPaths } from "../build/utils";
 import { getWorkspaceConfig, isWorkspaceConfigSetByUser } from "../common/config";
-import { getBuildServerProvider, isPreservingForeignBuildServer, isSweetpadBuildServerActive } from "./commands";
+import {
+  getBuildServerProvider,
+  isPreservingForeignBuildServer,
+  isSweetpadBuildServerActive,
+  preparedCheck,
+} from "./commands";
 import { getBspConfigFile } from "./paths";
+import type { BspStatusSnapshot } from "./service";
 
 /** argv for the config the extension maintains: project comes from bsp.json. */
 const managedArgv = () => ["/opt/homebrew/bin/sweetpad", "bsp", "serve", "--config", getBspConfigFile(workspace)];
@@ -212,5 +218,34 @@ describe("isSweetpadBuildServerActive", () => {
     // two. That server reads neither our bsp.json nor our socket, and calling
     // it active would have us write and report against something we don't run.
     await expect(isSweetpadBuildServerActive(workspace)).resolves.toBe(false);
+  });
+});
+
+const snapshot = (phase: string | null, phaseDetail: string | null = null): BspStatusSnapshot => ({
+  bspConnected: true,
+  scheme: "App",
+  configuration: "Debug",
+  logLevel: "info",
+  phase,
+  phaseDetail,
+});
+
+describe("preparedCheck", () => {
+  it("reports a failed prepare with the server's detail", () => {
+    const check = preparedCheck(snapshot("failed", "App: exit=65: clang: error: no such file"));
+    expect(check.ok).toBe(false);
+    expect(check.detail).toBe("App: exit=65: clang: error: no such file");
+    expect(check.hint).toBeDefined();
+  });
+
+  it("does not call a prepare that has not run a failure", () => {
+    const check = preparedCheck(snapshot(null));
+    expect(check.ok).toBe(true);
+    expect(check.detail).toBe("not run yet");
+  });
+
+  it("distinguishes a prepare still running from a finished one", () => {
+    expect(preparedCheck(snapshot("preparing")).detail).toBe("in progress");
+    expect(preparedCheck(snapshot("ready")).detail).toBe("ready");
   });
 });

--- a/sweetpad-vscode/src/bsp/commands.ts
+++ b/sweetpad-vscode/src/bsp/commands.ts
@@ -18,8 +18,9 @@ import { isFileExists, readJsonFile } from "../common/files";
 import { assertUnreachable } from "../common/types";
 import { isVersionAtLeast } from "../common/version";
 import { getBspConfigFile } from "./paths";
+import type { BspStatusSnapshot } from "./service";
 
-type DoctorCheck = {
+export type DoctorCheck = {
   ok: boolean;
   label: string;
   detail?: string;
@@ -317,6 +318,31 @@ async function collectCliDrivenChecks(config: Record<string, unknown>, workspace
   ];
 }
 
+/**
+ * How the last `buildTarget/prepare` went.
+ *
+ * Preparing a target is what puts its header maps and generated sources on
+ * disk, and the editor arguments name those only once they exist — so a target
+ * that never prepares is a target whose ObjC files never resolve their imports.
+ * The server carries on regardless (a missing reply would wedge sourcekit-lsp),
+ * which is exactly why the failure needs somewhere to surface.
+ */
+export function preparedCheck(snap: BspStatusSnapshot): DoctorCheck {
+  if (snap.phase === "failed") {
+    return {
+      ok: false,
+      label: "Last prepare",
+      detail: snap.phaseDetail ?? "failed",
+      hint: "Run 'SweetPad: Show BSP logs' for the full output, or run the same build from the terminal to see the whole error.",
+    };
+  }
+  return {
+    ok: true,
+    label: "Last prepare",
+    detail: snap.phase === "preparing" ? "in progress" : (snap.phase ?? "not run yet"),
+  };
+}
+
 async function collectSweetpadChecks(deps: AppDeps): Promise<DoctorCheck[]> {
   const workspaceRoot = deps.workspaceContext.root;
   const config = await readBuildServerJson(workspaceRoot);
@@ -354,6 +380,8 @@ async function collectSweetpadChecks(deps: AppDeps): Promise<DoctorCheck[]> {
     detail: snap.scheme ?? undefined,
     hint: "Pick a scheme with 'SweetPad: Select scheme for build'.",
   });
+
+  checks.push(preparedCheck(snap));
 
   const developerDir = await getDeveloperDir({ workspaceRoot: deps.workspaceContext.root });
   checks.push({

--- a/sweetpad-vscode/src/bsp/service.ts
+++ b/sweetpad-vscode/src/bsp/service.ts
@@ -17,6 +17,9 @@ export type BspStatusSnapshot = {
   scheme: string | null;
   configuration: string | null;
   logLevel: BspLogLevel;
+  /** The server's last reported phase, and its detail when that phase is "failed". */
+  phase: string | null;
+  phaseDetail: string | null;
 };
 
 /**
@@ -134,6 +137,8 @@ export class BspService implements vscode.Disposable {
       scheme: this.buildManager.getDefaultSchemeForBuild() ?? null,
       configuration: this.buildManager.getDefaultConfigurationForBuild() ?? null,
       logLevel: b.level,
+      phase: b.phase ?? null,
+      phaseDetail: b.detail ?? null,
     };
   }
 


### PR DESCRIPTION
Xcode resolves quoted imports through header maps it writes during a build, not through `-I`, so the BSP's editor arguments left Objective-C files reporting `'file not found'` on code that compiles, and every type below the failed import underlined with it. The BSP now emits those maps and the DerivedSources include dirs once a build has written them, and prepares every target at startup so one has, including targets no scheme builds. Also adds the fixture and the live search-path coverage check this needed, since the existing arg oracle treats `.hmap` and `Intermediates.noindex` paths as geometry and excludes them from scoring on both sides, so it could never have scored this.

Fixes #238.