### PR TITLE
Match Xcode's DerivedData folder name when the project name has a space

### DIFF
--- a/sweetpad-cli/src/cli/commands/derived_data.rs
+++ b/sweetpad-cli/src/cli/commands/derived_data.rs
@@ -269,17 +269,16 @@ fn project_base_name(container: &Container) -> Option<String> {
     Some(name)
 }
 
-/// Xcode names DerivedData folders `<Name>-<hash>`, sanitizing the name by
-/// replacing non-alphanumeric characters with `_` (`My App` → `My_App-<hash>`).
-/// Match the exact name (older layouts) or the raw/sanitized `<Name>-` prefix.
+/// Xcode names a hash-keyed DerivedData folder `<Name>-<hash>`, collapsing
+/// whitespace runs in the name to `_` (`My App` → `My_App-<hash>`; see
+/// [`sweetpad_lib::derived_data::hashed_name`]). A workspace-relative location
+/// writes the bare name instead, which is the exact match below.
 fn matches_project(entry: &str, base: &str) -> bool {
-    let sanitized: String = base
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
-        .collect();
     entry == base
-        || entry.starts_with(&format!("{base}-"))
-        || entry.starts_with(&format!("{sanitized}-"))
+        || entry.starts_with(&format!(
+            "{}-",
+            sweetpad_lib::derived_data::hashed_name(base)
+        ))
 }
 
 /// Recursively sum the size of regular files under `path` (symlinks are not
@@ -355,9 +354,11 @@ mod tests {
         // A different project sharing a prefix must not match.
         assert!(!matches_project("MyAppHelper-abc", "MyApp"));
         assert!(!matches_project("Other-xyz", "MyApp"));
-        // Xcode replaces non-alphanumerics with `_` in the folder name.
+        // Xcode collapses whitespace runs to `_` in the folder name, and
+        // touches nothing else — a hyphen is not sanitized.
         assert!(matches_project("My_App-abcdef123", "My App"));
-        assert!(matches_project("My_App-abcdef123", "My-App"));
+        assert!(matches_project("My-App-abcdef123", "My-App"));
+        assert!(!matches_project("My_App-abcdef123", "My-App"));
         assert!(!matches_project("My_AppHelper-abc", "My App"));
     }
 

--- a/sweetpad-lib/DOCS.md
+++ b/sweetpad-lib/DOCS.md
@@ -740,6 +740,7 @@ unit tests rather than a corpus capture.
 | App-wide `IDECustomDerivedDataLocation` (Settings → Locations) — keeps `<Name>-<hash>` | ✅ | src/derived_data.rs (`stock_layout_when_nothing_is_configured`, `absolute_style_keeps_the_hash`) |
 | Per-container `DerivedDataLocationStyle = AbsolutePath` — keeps `<Name>-<hash>` | ✅ | src/derived_data.rs (`absolute_style_keeps_the_hash`) |
 | Per-container `= WorkspaceRelativePath` — bare `<Name>`, no hash | ✅ | src/derived_data.rs (`workspace_relative_style_drops_the_hash`) |
+| `<Name>-<hash>` collapses whitespace runs in the name to `_`; the bare `<Name>` keeps them | ✅ | src/derived_data.rs (`hashed_name_collapses_whitespace_runs_only`, `hashed_name_leaves_every_other_character_alone`, `stock_layout_collapses_whitespace_in_the_folder_name`, `workspace_relative_style_keeps_whitespace_verbatim`) |
 | `BuildLocationStyle = CustomLocation` × {Absolute, RelativeToDerivedData, RelativeToWorkspace} | ✅ | src/derived_data.rs (`custom_location_*`) |
 | Precedence: `CustomLocation` outranks `-derivedDataPath`, which outranks the container's DerivedData style | ✅ | src/derived_data.rs (`custom_location_outranks_the_derived_data_path_flag`) |
 | Ignored by xcodebuild: the `xcshareddata` copy, `DeterminedByTargets`, app-wide `IDEBuildLocationStyle` | ✅ | src/derived_data.rs (`ignores_the_shared_settings_copy`, `determined_by_targets_is_a_no_op`) |

--- a/sweetpad-lib/src/derived_data.rs
+++ b/sweetpad-lib/src/derived_data.rs
@@ -13,8 +13,11 @@
 //! ignored for these. Xcode's own naming agrees — `IDEFoundation` spells them
 //! `IDEWorkspaceUserSettings_BuildLocationStyle` and friends.
 //!
-//! Two behaviours here are counter-intuitive and are pinned by tests:
+//! Three behaviours here are counter-intuitive and are pinned by tests:
 //!
+//! - The `<Name>` of a `<Name>-<hash>` folder is whitespace-collapsed (see
+//!   [`hashed_name`]); the bare `<Name>` a workspace-relative location writes
+//!   is not.
 //! - `BuildLocationStyle = CustomLocation` outranks `-derivedDataPath`. The
 //!   flag still moves DerivedData, but products and intermediates stay where
 //!   the container's custom location puts them.
@@ -109,11 +112,12 @@ fn apply(
     } else {
         match derived_data_override(settings, container) {
             // "Relative to workspace" keys the folder by bare name — the hash
-            // segment only exists to disambiguate a shared root.
+            // segment only exists to disambiguate a shared root. The name is
+            // spelled verbatim here, unlike the hash-keyed arms below.
             Some((base, false)) => (base.join(name), base),
-            Some((base, true)) => (base.join(format!("{name}-{hash}")), base),
+            Some((base, true)) => (base.join(hashed_folder(name, hash)), base),
             None => (
-                app_root.join(format!("{name}-{hash}")),
+                app_root.join(hashed_folder(name, hash)),
                 app_root.to_path_buf(),
             ),
         }
@@ -135,6 +139,45 @@ fn apply(
         intermediates: folder.join("Build/Intermediates.noindex"),
         derived_data_root: root,
     }
+}
+
+/// The `<Name>-<hash>` folder a hash-keyed DerivedData location writes.
+fn hashed_folder(name: &str, hash: &str) -> String {
+    format!("{}-{hash}", hashed_name(name))
+}
+
+/// Xcode's spelling of a container name inside a `<Name>-<hash>` DerivedData
+/// folder: every run of whitespace becomes a single `_`, so `ARTA NYC` keys
+/// `ARTA_NYC-<hash>` and `A  B` keys `A_B-<hash>`.
+///
+/// Whitespace is the only thing touched, and only these four characters count
+/// as whitespace: space, tab, LF, CR. `IDEFoundation` builds the folder name in
+/// `+[IDEWorkspaceArena nameForWorkspaceArenaWithBaseName:gristInput:]`, which
+/// calls `dvt_stringByReplacingWhitespaceRunsWithCharacter:'_' range:` — and
+/// that tests each UTF-16 unit against the bitmask `0x1_0000_2600` under a
+/// `c <= 0x20` guard. So vertical tab and form feed pass through, as does every
+/// Unicode space (U+00A0, U+2002, …) — this is not Foundation's
+/// `whitespaceAndNewlineCharacterSet`. Punctuation (`+ @ ( ) , & ' . - % ~ ! =
+/// # :`) and non-ASCII letters are untouched, there is no case folding, and
+/// there is no length cap: a name long enough to push the folder past 255 bytes
+/// fails the build outright rather than being truncated.
+///
+/// The hash itself is computed from the container's *unsanitized* path (see
+/// [`crate::xcode_hash`]), so only this one segment differs.
+#[must_use]
+pub fn hashed_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut in_run = false;
+    for c in name.chars() {
+        let is_whitespace = matches!(c, ' ' | '\t' | '\n' | '\r');
+        if !is_whitespace {
+            out.push(c);
+        } else if !in_run {
+            out.push('_');
+        }
+        in_run = is_whitespace;
+    }
+    out
 }
 
 /// The root every per-container folder sits in: the app-wide custom location
@@ -374,6 +417,123 @@ mod tests {
         assert_eq!(
             out.derived_data_root,
             PathBuf::from(format!("{HOME}/Library/Developer/Xcode/DerivedData"))
+        );
+    }
+
+    /// The whitespace rule, pinned against live `xcodebuild -showBuildSettings`
+    /// 26.5 and against the bitmask `dvt_stringByReplacingWhitespaceRunsWithCharacter:`
+    /// tests each character with.
+    #[test]
+    fn hashed_name_collapses_whitespace_runs_only() {
+        assert_eq!(hashed_name("ARTA NYC"), "ARTA_NYC");
+        assert_eq!(hashed_name("MyApp"), "MyApp");
+        // A run of any length — of mixed members, too — is one `_`.
+        assert_eq!(hashed_name("A  B"), "A_B");
+        assert_eq!(hashed_name("A   B"), "A_B");
+        assert_eq!(hashed_name("A B  C"), "A_B_C");
+        assert_eq!(hashed_name("A \t\r\nB"), "A_B");
+        // Tab, LF and CR each count; the edges are replaced, not trimmed.
+        assert_eq!(hashed_name("T\tS"), "T_S");
+        assert_eq!(hashed_name("T\nS"), "T_S");
+        assert_eq!(hashed_name("T\rS"), "T_S");
+        assert_eq!(hashed_name(" AB"), "_AB");
+        assert_eq!(hashed_name("AB "), "AB_");
+        assert_eq!(hashed_name("   "), "_");
+    }
+
+    /// Everything the bitmask's `c <= 0x20` guard lets through, which is
+    /// everything a "replace non-alphanumerics" reading would have mangled.
+    #[test]
+    fn hashed_name_leaves_every_other_character_alone() {
+        for name in [
+            "A+B",
+            "A@B",
+            "A(B)",
+            "A,B",
+            "A&B",
+            "A'B",
+            "A.B",
+            "A-B",
+            "A%B",
+            "A~B",
+            "A!B",
+            "A=B",
+            "A#B",
+            "A:B",
+            "Å",
+            "Kingfisher-Demo",
+        ] {
+            assert_eq!(hashed_name(name), name, "{name} should pass through");
+        }
+        // Vertical tab and form feed sit outside the mask despite being ASCII
+        // whitespace, so they are not Foundation's whitespace set.
+        assert_eq!(hashed_name("T\u{b}S"), "T\u{b}S");
+        assert_eq!(hashed_name("T\u{c}S"), "T\u{c}S");
+        // Nor is it `whitespaceAndNewlineCharacterSet`: Unicode spaces stay.
+        assert_eq!(hashed_name("T\u{a0}S"), "T\u{a0}S");
+        assert_eq!(hashed_name("T\u{2002}S"), "T\u{2002}S");
+    }
+
+    /// The whole of issue #329: a spaced container builds into `ARTA_NYC-…`,
+    /// so resolving `ARTA NYC-…` names a directory that never exists.
+    #[test]
+    fn stock_layout_collapses_whitespace_in_the_folder_name() {
+        let out = resolve(
+            Path::new("/src/ARTA NYC.xcworkspace"),
+            "ARTA NYC",
+            HASH,
+            HOME,
+            None,
+            /* consult_xcode */ false,
+        );
+        assert_eq!(
+            out.products,
+            PathBuf::from(format!(
+                "{HOME}/Library/Developer/Xcode/DerivedData/ARTA_NYC-{HASH}/Build/Products"
+            ))
+        );
+    }
+
+    #[test]
+    fn absolute_style_collapses_whitespace_in_the_folder_name() {
+        let out = apply(
+            &WorkspaceSettings {
+                derived_data_style: Some("AbsolutePath".into()),
+                derived_data_location: Some("/level2".into()),
+                ..WorkspaceSettings::default()
+            },
+            &container(),
+            "ARTA NYC",
+            HASH,
+            Path::new("/app-root"),
+            None,
+        );
+        assert_eq!(
+            out.products,
+            PathBuf::from(format!("/level2/ARTA_NYC-{HASH}/Build/Products"))
+        );
+    }
+
+    /// The bare-name style keeps the space. `IDEWorkspaceArena` only sanitizes
+    /// on the branch that appends the hash, and `xcodebuild` agrees: a
+    /// workspace-relative location writes `MyDD/ARTA NYC/Build/Products`.
+    #[test]
+    fn workspace_relative_style_keeps_whitespace_verbatim() {
+        let out = apply(
+            &WorkspaceSettings {
+                derived_data_style: Some("WorkspaceRelativePath".into()),
+                derived_data_location: Some("MyDD".into()),
+                ..WorkspaceSettings::default()
+            },
+            Path::new("/src/ARTA NYC.xcworkspace"),
+            "ARTA NYC",
+            HASH,
+            Path::new("/app-root"),
+            None,
+        );
+        assert_eq!(
+            out.products,
+            PathBuf::from("/src/MyDD/ARTA NYC/Build/Products")
         );
     }
 

--- a/sweetpad-vscode/CHANGELOG.md
+++ b/sweetpad-vscode/CHANGELOG.md
@@ -8,6 +8,7 @@ New features, improvements and bug fixes for SweetPad are documented in this fil
 - "SweetPad: Diagnose BSP" now reports the last background build's error
 - Fix Objective-C imports reporting `'Header.h' file not found` on code that builds ([#238](https://github.com/sweetpad-dev/sweetpad/issues/238))
 - Fix autocomplete coming up empty on a first BSP setup ([#326](https://github.com/sweetpad-dev/sweetpad/issues/326))
+- Fix apps not launching when the workspace name has a space ([#329](https://github.com/sweetpad-dev/sweetpad/issues/329), thanks [@richardgroves](https://github.com/richardgroves))
 
 ## [0.2.12] - 2026-08-24
 


### PR DESCRIPTION
Fixes #329. Xcode writes `ARTA NYC.xcworkspace`'s DerivedData to `ARTA_NYC-<hash>`, so the resolver named a directory that never existed: the build succeeded and the launch then looked for the app somewhere it had never been written. Xcode collapses each run of space, tab, LF or CR to a single `_`, and only where the folder is keyed by hash — a workspace-relative location keeps the name verbatim — so the collapse sits at the `<name>-<hash>` spelling rather than at the name. This also corrects `derived-data`'s project scoping, which guessed the rule as "replace every non-alphanumeric" and could therefore match a different project's folder.