### PR TITLE
List schemes from every local Swift package a container reaches (#327)

### DIFF
--- a/sweetpad-cli/CLI_DESIGN.md
+++ b/sweetpad-cli/CLI_DESIGN.md
@@ -568,7 +568,11 @@ sweetpad completions <shell>          clap_complete-generated scripts
 with a ready `-destination` specifier. SPM containers are supported for
 `scheme`/`build`/`test`/`run`: schemes are read straight from the manifest via
 `swift package dump-package` (the product names xcodebuild would synthesize —
-no xcodebuild spawn, no pbxproj needed).
+no xcodebuild spawn, no pbxproj needed). A project or workspace container reads
+the same manifests for the local packages around it, walking `.package(path:)`
+from every package the container references; `sweetpad-lib/DOCS.md` §9 has the
+rules and `sweetpad-core/src/package_members.rs` the cache that keeps the
+spawns off the common path.
 
 Notes / heuristics:
 - `test run` exits non-zero on failures; the `--json` summary lands on stdout

--- a/sweetpad-cli/src/cli/commands/project.rs
+++ b/sweetpad-cli/src/cli/commands/project.rs
@@ -503,9 +503,9 @@ fn gather(container: &Container) -> Result<Info, CliError> {
             let ws = sweetpad_lib::workspace::open(p).map_err(|e| {
                 CliError::new(format!("failed to read workspace {}: {e}", p.display()))
             })?;
-            // `info` is an explicit enumeration, so it pays for the members'
+            // `info` is an explicit enumeration, so it pays for the packages'
             // manifests rather than under-reporting what the workspace holds.
-            let members = sweetpad_core::package_members::resolve(&ws.package_refs, None);
+            let members = sweetpad_core::package_members::resolve_workspace(&ws, None);
             Ok(Info {
                 kind: "workspace",
                 name: ws.name.clone(),
@@ -523,19 +523,23 @@ fn gather(container: &Container) -> Result<Info, CliError> {
             let proj = sweetpad_lib::project::open(p).map_err(|e| {
                 CliError::new(format!("failed to read project {}: {e}", p.display()))
             })?;
+            let members = sweetpad_core::package_members::resolve_project(&proj, None);
             Ok(Info {
                 kind: "project",
                 name: proj.name.clone(),
                 path,
-                targets: proj.targets.iter().map(|t| t.name.clone()).collect(),
+                targets: proj
+                    .targets_with_packages(&sweetpad_core::package_members::target_pairs(&members)),
                 configurations: proj.configurations.clone(),
-                schemes: proj.schemes.clone(),
+                schemes: proj
+                    .schemes_with_packages(&sweetpad_core::package_members::scheme_pairs(&members)),
             })
         }
         Container::SwiftPackage(_) => {
             // No pbxproj to read; evaluate the manifest instead. Targets are
             // every declared target; schemes mirror the synthesized set
-            // (products, or non-test targets). SwiftPM builds are debug/release.
+            // (products plus the package aggregate). SwiftPM builds are
+            // debug/release.
             let manifest = crate::cli::swiftpm::manifest(container)?;
             Ok(Info {
                 kind: "package",

--- a/sweetpad-cli/src/cli/resolve.rs
+++ b/sweetpad-cli/src/cli/resolve.rs
@@ -640,14 +640,17 @@ pub fn schemes(container: &Container) -> Result<Vec<String>, CliError> {
     match container {
         Container::Workspace(p) => sweetpad_lib::workspace::open(p)
             .map(|w| {
-                let members = sweetpad_core::package_members::resolve(&w.package_refs, None);
+                let members = sweetpad_core::package_members::resolve_workspace(&w, None);
                 w.merged_schemes_with_packages(&sweetpad_core::package_members::scheme_pairs(
                     &members,
                 ))
             })
             .map_err(|e| CliError::new(format!("failed to read workspace {}: {e}", p.display()))),
         Container::Project(p) => sweetpad_lib::project::open(p)
-            .map(|proj| proj.schemes)
+            .map(|proj| {
+                let members = sweetpad_core::package_members::resolve_project(&proj, None);
+                proj.schemes_with_packages(&sweetpad_core::package_members::scheme_pairs(&members))
+            })
             .map_err(|e| CliError::new(format!("failed to read project {}: {e}", p.display()))),
         // Swift packages have no pbxproj; derive schemes from the manifest
         // (this drives SPM build/test/run) — no xcodebuild needed.
@@ -656,7 +659,7 @@ pub fn schemes(container: &Container) -> Result<Vec<String>, CliError> {
 }
 
 /// The scheme candidates readable from project files alone — everything
-/// [`schemes`] returns except the products of a workspace's local SwiftPM
+/// [`schemes`] returns except the products of the container's local SwiftPM
 /// packages, which cost a `swift package dump-package` per package.
 ///
 /// Only safe where a *shorter* list changes nothing: validating a name the
@@ -668,7 +671,10 @@ pub fn schemes_without_packages(container: &Container) -> Result<Vec<String>, Cl
         Container::Workspace(p) => sweetpad_lib::workspace::open(p)
             .map(|w| w.merged_schemes())
             .map_err(|e| CliError::new(format!("failed to read workspace {}: {e}", p.display()))),
-        _ => schemes(container),
+        Container::Project(p) => sweetpad_lib::project::open(p)
+            .map(|proj| proj.schemes)
+            .map_err(|e| CliError::new(format!("failed to read project {}: {e}", p.display()))),
+        Container::SwiftPackage(_) => schemes(container),
     }
 }
 

--- a/sweetpad-cli/src/cli/swiftpm.rs
+++ b/sweetpad-cli/src/cli/swiftpm.rs
@@ -54,21 +54,14 @@ pub struct DeclaredDep {
 
 impl Manifest {
     /// Scheme candidates for the package, matching `xcodebuild -list`: one
-    /// scheme per product, plus the `<name>-Package` aggregate scheme xcodebuild
-    /// synthesizes to build the whole package. Falls back to non-test target
-    /// names (still plus the aggregate) when a package declares no products, so
-    /// scheme selection always has candidates.
+    /// scheme per product, plus the `<name>-Package` aggregate scheme
+    /// xcodebuild synthesizes to build the whole package. A target no product
+    /// exposes gets no scheme of its own, so a package that declares no
+    /// products offers just the aggregate — which still builds and tests
+    /// everything in it.
     #[must_use]
     pub fn scheme_names(&self) -> Vec<String> {
-        let mut names: Vec<String> = if self.products.is_empty() {
-            self.targets
-                .iter()
-                .filter(|t| !t.is_test())
-                .map(|t| t.name.clone())
-                .collect()
-        } else {
-            self.products.iter().map(|p| p.name.clone()).collect()
-        };
+        let mut names: Vec<String> = self.products.iter().map(|p| p.name.clone()).collect();
         names.push(format!("{}-Package", self.name));
         names
     }
@@ -515,14 +508,14 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_non_test_targets_when_no_products() {
+    fn a_package_with_no_products_offers_just_the_aggregate() {
         let m = parse_manifest(
             r#"{ "name": "P", "products": [],
                  "targets": [ { "name": "Lib", "type": "regular" },
                               { "name": "LibTests", "type": "test" } ] }"#,
         )
         .unwrap();
-        assert_eq!(m.scheme_names(), vec!["Lib", "P-Package"]);
+        assert_eq!(m.scheme_names(), vec!["P-Package"]);
     }
 
     #[test]

--- a/sweetpad-cli/src/cli/swiftpm.rs
+++ b/sweetpad-cli/src/cli/swiftpm.rs
@@ -53,16 +53,55 @@ pub struct DeclaredDep {
 }
 
 impl Manifest {
-    /// Scheme candidates for the package, matching `xcodebuild -list`: one
-    /// scheme per product, plus the `<name>-Package` aggregate scheme
-    /// xcodebuild synthesizes to build the whole package. A target no product
-    /// exposes gets no scheme of its own, so a package that declares no
-    /// products offers just the aggregate — which still builds and tests
-    /// everything in it.
+    /// Scheme candidates for a package opened on its own, matching what
+    /// `xcodebuild -list` prints in a package directory. How many products the
+    /// package has decides the shape (measured on Xcode 26.5; the two-product
+    /// form is the same back to 15.4 in the captures):
+    ///
+    /// | products | schemes |
+    /// |---|---|
+    /// | none | `<name>-Package` alone |
+    /// | one | `<name>` alone — the package's own name, whatever the product is called |
+    /// | two or more | `<name>-Package` plus one scheme per product |
+    ///
+    /// The single-product collapse is easy to get wrong in both directions: a
+    /// package with one library product answers to neither that product's name
+    /// nor the aggregate, and one whose only product is the implicit
+    /// executable behind an `executableTarget` answers to the package name
+    /// too.
     #[must_use]
     pub fn scheme_names(&self) -> Vec<String> {
+        let products = self.effective_products();
+        if products.len() == 1 {
+            return vec![self.name.clone()];
+        }
+        let mut names = vec![format!("{}-Package", self.name)];
+        names.extend(products);
+        names
+    }
+
+    /// The package's products as SwiftPM sees them: the declared ones, plus
+    /// the implicit executable product it synthesizes for each
+    /// `executableTarget` no declared product already covers.
+    ///
+    /// `dump-package` reports only what the manifest wrote — `swift package
+    /// describe` is what shows the implicit ones, and it resolves the whole
+    /// dependency graph to do it. Reconstructing them here keeps the read
+    /// offline.
+    #[must_use]
+    pub fn effective_products(&self) -> Vec<String> {
+        let covered: std::collections::HashSet<&str> = self
+            .products
+            .iter()
+            .flat_map(|p| p.targets.iter().map(String::as_str))
+            .collect();
         let mut names: Vec<String> = self.products.iter().map(|p| p.name.clone()).collect();
-        names.push(format!("{}-Package", self.name));
+        names.extend(
+            self.targets
+                .iter()
+                .filter(|t| t.is_executable() && !covered.contains(t.name.as_str()))
+                .map(|t| t.name.clone()),
+        );
         names
     }
 
@@ -161,6 +200,11 @@ pub struct Product {
     pub name: String,
     #[serde(rename = "type", default)]
     pub kind: serde_json::Value,
+    /// The targets this product exposes — what says whether an
+    /// `executableTarget` already has a product, in
+    /// [`Manifest::effective_products`].
+    #[serde(default)]
+    pub targets: Vec<String>,
 }
 
 impl Product {
@@ -185,6 +229,13 @@ impl Target {
     #[must_use]
     pub fn is_test(&self) -> bool {
         self.kind == "test"
+    }
+
+    /// Whether SwiftPM would synthesize an executable product for this target
+    /// when no declared product covers it.
+    #[must_use]
+    pub fn is_executable(&self) -> bool {
+        self.kind == "executable"
     }
 }
 
@@ -495,10 +546,65 @@ mod tests {
     }
 
     #[test]
-    fn schemes_are_products_plus_package_aggregate() {
+    fn two_products_get_the_aggregate_and_a_scheme_each() {
         let m = parse_manifest(DUMP).unwrap();
-        // Products, then xcodebuild's `<name>-Package` aggregate scheme.
-        assert_eq!(m.scheme_names(), vec!["DemoKit", "demo", "Demo-Package"]);
+        assert_eq!(m.scheme_names(), vec!["Demo-Package", "DemoKit", "demo"]);
+    }
+
+    /// Grounded on `xcodebuild -list` (26.5): a package whose only product is
+    /// a library answers to its own name, not the product's and not the
+    /// aggregate's.
+    #[test]
+    fn a_single_product_collapses_to_the_package_name() {
+        let m = parse_manifest(
+            r#"{ "name": "P", "products": [
+                     { "name": "Lib", "type": { "library": ["automatic"] }, "targets": ["T"] } ],
+                 "targets": [ { "name": "T", "type": "regular" } ] }"#,
+        )
+        .unwrap();
+        assert_eq!(m.scheme_names(), vec!["P"]);
+    }
+
+    /// The implicit executable product SwiftPM synthesizes counts toward that
+    /// collapse: `xcodebuild -list` on a package whose whole manifest is one
+    /// `executableTarget` prints the package name alone.
+    #[test]
+    fn an_executable_target_counts_as_a_product() {
+        let m = parse_manifest(
+            r#"{ "name": "MyTool", "products": [],
+                 "targets": [ { "name": "runner", "type": "executable" } ] }"#,
+        )
+        .unwrap();
+        assert_eq!(m.effective_products(), vec!["runner"]);
+        assert_eq!(m.scheme_names(), vec!["MyTool"]);
+    }
+
+    /// One declared product plus an `executableTarget` it does not cover is
+    /// two products, so the aggregate comes back and both are listed.
+    #[test]
+    fn an_uncovered_executable_target_is_a_product_of_its_own() {
+        let m = parse_manifest(
+            r#"{ "name": "D", "products": [
+                     { "name": "LibA", "type": { "library": ["automatic"] }, "targets": ["TA"] } ],
+                 "targets": [ { "name": "TA", "type": "regular" },
+                              { "name": "TC", "type": "executable" } ] }"#,
+        )
+        .unwrap();
+        assert_eq!(m.scheme_names(), vec!["D-Package", "LibA", "TC"]);
+    }
+
+    /// An `executableTarget` a declared product already exposes gets no
+    /// second, implicit product of its own.
+    #[test]
+    fn an_executable_target_behind_a_product_is_not_counted_twice() {
+        let m = parse_manifest(
+            r#"{ "name": "E", "products": [
+                     { "name": "tool", "type": { "executable": null }, "targets": ["e1"] } ],
+                 "targets": [ { "name": "e1", "type": "executable" } ] }"#,
+        )
+        .unwrap();
+        assert_eq!(m.effective_products(), vec!["tool"]);
+        assert_eq!(m.scheme_names(), vec!["E"]);
     }
 
     #[test]

--- a/sweetpad-core/src/package_members.rs
+++ b/sweetpad-core/src/package_members.rs
@@ -39,10 +39,14 @@
 //!
 //! A target that no product exposes never gets a scheme, so a package that
 //! declares no products contributes nothing but its test targets — and,
-//! without a container or a membership, nothing at all. The `<name>-Package`
-//! aggregate belongs to a package opened on its own; `xcodebuild` does not
-//! synthesize it for a package inside a container, so listing it here would
-//! offer a scheme `xcodebuild` then rejects.
+//! without a container or a membership, nothing at all. An `executableTarget`
+//! is exposed even when the manifest says nothing: SwiftPM synthesizes a
+//! product of the same name for it, and `xcodebuild` schedules a scheme for
+//! that product like any other.
+//!
+//! The `<name>-Package` aggregate belongs to a package opened on its own;
+//! `xcodebuild` does not synthesize it for a package inside a container, so
+//! listing it here would offer a scheme `xcodebuild` then rejects.
 //!
 //! Not modeled: a *remote* package's scheme files. `xcodebuild` lists those
 //! too (ice-cubes gets `RevenueCatUI` from the RevenueCat checkout's
@@ -101,6 +105,14 @@ pub struct PackageMember {
 /// `(len, mtime_nanos)` of a `Package.swift` — changed either way means the
 /// cached names are stale.
 type Stamp = (u64, u128);
+
+/// Which reading of the cached fields an entry holds. Bump it whenever a field
+/// starts meaning something different, so entries a build with the older
+/// reading wrote are a miss rather than trusted: the stamp catches an edited
+/// manifest, and only this catches an unedited one whose names this code
+/// derives differently — `products`, for one, counts implicit executables that
+/// a plain read of `dump-package` does not.
+const CACHE_SCHEMA: u64 = 1;
 
 /// What one manifest says, before a role turns it into schemes.
 #[derive(Debug, Clone)]
@@ -196,6 +208,9 @@ fn cached_manifest(
     current: Stamp,
 ) -> Option<ManifestNames> {
     let entry = entries.get(&path.to_string_lossy().into_owned())?;
+    if entry.get("schema").and_then(Value::as_u64) != Some(CACHE_SCHEMA) {
+        return None;
+    }
     let len = entry.get("len")?.as_u64()?;
     let mtime = entry.get("mtime")?.as_str()?.parse::<u128>().ok()?;
     if (len, mtime) != current {
@@ -215,6 +230,7 @@ fn cached_manifest(
 fn cache_entry(current: Stamp, names: &ManifestNames) -> Value {
     let (len, mtime) = current;
     serde_json::json!({
+        "schema": CACHE_SCHEMA,
         "len": len,
         // u128 exceeds JSON's safe integer range; keep it as a string so a
         // round-trip can't quietly lose precision.
@@ -451,11 +467,45 @@ fn dump_package(dir: &Path, developer_dir: Option<&Path>) -> Option<Value> {
 
 fn read_manifest(manifest: &Value) -> ManifestNames {
     ManifestNames {
-        products: names_in(manifest, "products", |_| true),
+        products: products_with_implicit_executables(manifest),
         test_targets: names_in(manifest, "targets", is_test_target),
         targets: names_in(manifest, "targets", |_| true),
         path_deps: path_dependencies(manifest),
     }
+}
+
+/// The products `xcodebuild` gives schemes to: the ones the manifest declares,
+/// plus the one SwiftPM synthesizes for each `executableTarget` that no
+/// declared product already covers.
+///
+/// The implicit ones are as real as the rest — a package whose whole manifest
+/// is `targets: [.executableTarget(name: "runner")]` contributes a `runner`
+/// scheme to the container that reaches it. `swift package describe` reports
+/// them, but it resolves the dependency graph to do so; `dump-package` only
+/// evaluates the manifest, and reports what the manifest wrote. Reconstructing
+/// them here keeps the walk offline.
+fn products_with_implicit_executables(manifest: &Value) -> Vec<String> {
+    let covered: HashSet<&str> = manifest
+        .get("products")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.get("targets")?.as_array())
+                .flatten()
+                .filter_map(Value::as_str)
+                .collect()
+        })
+        .unwrap_or_default();
+    let mut out = names_in(manifest, "products", |_| true);
+    out.extend(
+        names_in(manifest, "targets", |target| {
+            target.get("type").and_then(Value::as_str) == Some("executable")
+        })
+        .into_iter()
+        .filter(|name| !covered.contains(name.as_str())),
+    );
+    out
 }
 
 fn names_in(manifest: &Value, key: &str, keep: impl Fn(&Value) -> bool) -> Vec<String> {
@@ -553,6 +603,40 @@ mod tests {
             .unwrap();
         }
         dir
+    }
+
+    /// An `executableTarget` no declared product covers is a product all the
+    /// same — `dump-package` does not write it, `xcodebuild -list` schedules a
+    /// scheme for it, so the walk reconstructs it.
+    #[test]
+    fn an_executable_target_no_product_covers_is_a_product() {
+        let names = read_manifest(&serde_json::json!({
+            "name": "Tool",
+            "products": [{"name": "tool", "targets": ["e1"]}],
+            "targets": [
+                {"name": "e1", "type": "executable"},
+                {"name": "e2", "type": "executable"},
+                {"name": "Core", "type": "regular"},
+            ],
+        }));
+        assert_eq!(names.products, vec!["tool", "e2"]);
+    }
+
+    /// A manifest whose whole body is one `executableTarget` still contributes
+    /// that target's scheme to the container that reached it.
+    #[test]
+    fn a_product_less_executable_package_still_has_a_scheme() {
+        let dir = package_dir("exec-only", None);
+        let names = read_manifest(&serde_json::json!({
+            "name": "Tool",
+            "products": [],
+            "targets": [{"name": "runner", "type": "executable"}],
+        }));
+        assert_eq!(
+            schemes_for(&dir, PackageRole::Dependency, &names),
+            vec!["runner"]
+        );
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/sweetpad-core/src/package_members.rs
+++ b/sweetpad-core/src/package_members.rs
@@ -1,13 +1,56 @@
-//! What the local SwiftPM packages in a workspace contribute: scheme and
-//! target names.
+//! What the local SwiftPM packages around an Xcode container contribute:
+//! scheme and target names.
 //!
-//! `sweetpad_lib::workspace` reports which members are packages
-//! ([`sweetpad_lib::workspace::Workspace::package_refs`]) but cannot name what
-//! they hold: a package's schemes and targets come from its manifest, and
+//! `sweetpad_lib` reports which directories are packages
+//! ([`sweetpad_lib::workspace::Workspace::package_refs`],
+//! [`sweetpad_lib::project::Project::package_refs`]) but cannot name what they
+//! hold: a package's schemes and targets come from its manifest, and
 //! `Package.swift` is Swift source that only the toolchain can evaluate.
 //! `swift package dump-package` compiles it against `libPackageDescription`
 //! and runs it, so reading the manifest means spawning — which belongs here
 //! rather than in the file-format crate.
+//!
+//! **The graph is wider than the workspace's own members.** Xcode resolves the
+//! whole local package graph and gives every package in it schemes: the
+//! `FileRef` members of the `.xcworkspace`, the packages a member project
+//! declares (`XCLocalSwiftPackageReference` — dragging a package into an app
+//! project rather than into the workspace), and everything those reach through
+//! `.package(path:)`. Only a manifest names a path dependency, so the walk
+//! lives here, one round of concurrent dumps per level.
+//!
+//! **Every local package contributes its products and its scheme files; only
+//! some contribute their test targets.** Measured against `xcodebuild -list`:
+//!
+//! | | products | scheme files | test targets |
+//! |---|---|---|---|
+//! | `FileRef` in the `.xcworkspace` | ✅ | ✅ | ✅ |
+//! | package whose scheme container still resolves | ✅ | ✅ | ✅ |
+//! | any other local package | ✅ | ✅ | — |
+//!
+//! A `.swiftpm/xcode` scheme container holding a scheme that names a buildable
+//! the manifest still declares is Xcode's mark that somebody opened the
+//! package in it, which promotes the package from a dependency to something
+//! you build and test in its own right. ice-cubes' `Packages/Env` ships one
+//! `Env.xcscheme` naming its `Env` target, and `xcodebuild` lists `EnvTests`
+//! next to it; move that container away and neither appears. Its
+//! `Packages/NetworkClient` ships only a `NetworkTests.xcscheme` left over
+//! from a rename — it names a target no longer in the manifest, and
+//! `xcodebuild` autocreates nothing for that package.
+//!
+//! A target that no product exposes never gets a scheme, so a package that
+//! declares no products contributes nothing but its test targets — and,
+//! without a container or a membership, nothing at all. The `<name>-Package`
+//! aggregate belongs to a package opened on its own; `xcodebuild` does not
+//! synthesize it for a package inside a container, so listing it here would
+//! offer a scheme `xcodebuild` then rejects.
+//!
+//! Not modeled: a *remote* package's scheme files. `xcodebuild` lists those
+//! too (ice-cubes gets `RevenueCatUI` from the RevenueCat checkout's
+//! container), but they live in a `SourcePackages` checkout under DerivedData
+//! that only a resolved build knows the path to.
+//!
+//! **Targets include test targets** in every case, unlike schemes: a target
+//! list exists to drive `-only-testing:`, where a test target is the point.
 //!
 //! **The spawn is slow enough to need a cache.** A cold `dump-package` takes
 //! seconds (SwiftPM compiles the manifest); a warm one still costs the `swift`
@@ -15,16 +58,8 @@
 //! `(len, mtime)` — the same stamp `sweetpad_lib`'s parse caches use — so the
 //! cost is paid once per manifest edit instead of once per command. The CLI is
 //! one-shot, so an in-process memo alone would never hit.
-//!
-//! **A member package's schemes are its products, with no `<name>-Package`
-//! aggregate.** `xcodebuild -list` synthesizes that aggregate for a package
-//! opened on its own but not for one inside a workspace, so listing it here
-//! would offer a scheme `xcodebuild` then rejects.
-//!
-//! **Targets include test targets**, unlike schemes: a target list exists to
-//! drive `-only-testing:`, where a test target is the whole point.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -33,12 +68,31 @@ use std::time::UNIX_EPOCH;
 
 use serde_json::Value;
 
-/// What one local package contributes to its workspace.
+use sweetpad_lib::project::Project;
+use sweetpad_lib::workspace::{Workspace, package_scheme_root};
+
+/// How a package was reached. A workspace member's test targets are schemes
+/// whether or not it has been opened in Xcode; every other package's are only
+/// once it has (see the module docs).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageRole {
+    /// A `FileRef` in the `.xcworkspace` — the workspace's own package.
+    WorkspaceMember,
+    /// Reached from a project's `XCLocalSwiftPackageReference` or its group
+    /// tree, or as another package's `.package(path:)` dependency.
+    Dependency,
+}
+
+/// What one local package contributes to the container that reached it.
 #[derive(Debug, Clone)]
 pub struct PackageMember {
-    /// The package directory, as it appeared in `package_refs`.
+    /// The package directory, canonicalized so the same package reached two
+    /// ways is resolved once.
     pub path: PathBuf,
-    /// Scheme names — the manifest's products (see the module docs).
+    /// How the walk reached this package.
+    pub role: PackageRole,
+    /// Scheme names — the package's scheme files and products, plus its test
+    /// targets where those count (see the module docs).
     pub schemes: Vec<String>,
     /// Every target the manifest declares, test targets included.
     pub targets: Vec<String>,
@@ -47,6 +101,16 @@ pub struct PackageMember {
 /// `(len, mtime_nanos)` of a `Package.swift` — changed either way means the
 /// cached names are stale.
 type Stamp = (u64, u128);
+
+/// What one manifest says, before a role turns it into schemes.
+#[derive(Debug, Clone)]
+struct ManifestNames {
+    products: Vec<String>,
+    test_targets: Vec<String>,
+    targets: Vec<String>,
+    /// Absolute directories of the manifest's `.package(path:)` dependencies.
+    path_deps: Vec<PathBuf>,
+}
 
 fn stamp(path: &Path) -> Option<Stamp> {
     let meta = fs::metadata(path).ok()?;
@@ -57,6 +121,13 @@ fn stamp(path: &Path) -> Option<Stamp> {
         .ok()?
         .as_nanos();
     Some((meta.len(), mtime))
+}
+
+/// Resolve symlinks and `..` so the same package reached through a workspace
+/// `FileRef` and through a sibling's `.package(path:)` is one cache key and
+/// one dump. Falls back to the path as given when it cannot be canonicalized.
+fn canonical(dir: &Path) -> PathBuf {
+    fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf())
 }
 
 /// `<state>/sweetpad/package-members.json` — one object keyed by absolute
@@ -116,100 +187,222 @@ fn string_list(entry: &Value, key: &str) -> Option<Vec<String>> {
 }
 
 /// A cached entry is usable only when the manifest stamp still matches *and*
-/// it carries every field this version reads — an entry written before
-/// `targets` existed is treated as a miss rather than as a package with no
-/// targets.
-fn cached_member(
+/// it carries every field this version reads — an entry written by a build
+/// that recorded fewer fields is treated as a miss rather than as a package
+/// with nothing in it.
+fn cached_manifest(
     entries: &BTreeMap<String, Value>,
     path: &Path,
     current: Stamp,
-) -> Option<PackageMember> {
+) -> Option<ManifestNames> {
     let entry = entries.get(&path.to_string_lossy().into_owned())?;
     let len = entry.get("len")?.as_u64()?;
     let mtime = entry.get("mtime")?.as_str()?.parse::<u128>().ok()?;
     if (len, mtime) != current {
         return None;
     }
-    Some(PackageMember {
-        path: path.to_path_buf(),
-        schemes: string_list(entry, "schemes")?,
+    Some(ManifestNames {
+        products: string_list(entry, "products")?,
+        test_targets: string_list(entry, "testTargets")?,
         targets: string_list(entry, "targets")?,
+        path_deps: string_list(entry, "pathDependencies")?
+            .into_iter()
+            .map(PathBuf::from)
+            .collect(),
     })
 }
 
-/// Resolve every package in `package_dirs`, each paired with the path it came
-/// from so the `*_with_packages` methods on
-/// [`sweetpad_lib::workspace::Workspace`] can match results back to members
-/// the workspace still references.
+fn cache_entry(current: Stamp, names: &ManifestNames) -> Value {
+    let (len, mtime) = current;
+    serde_json::json!({
+        "len": len,
+        // u128 exceeds JSON's safe integer range; keep it as a string so a
+        // round-trip can't quietly lose precision.
+        "mtime": mtime.to_string(),
+        "products": names.products,
+        "testTargets": names.test_targets,
+        "targets": names.targets,
+        "pathDependencies": names.path_deps
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect::<Vec<_>>(),
+    })
+}
+
+/// The scheme names one package contributes: whatever its `.swiftpm/xcode`
+/// container names, its products, and — for a workspace member, or a package
+/// somebody has opened in Xcode — its test targets.
+fn schemes_for(dir: &Path, role: PackageRole, names: &ManifestNames) -> Vec<String> {
+    let files = sweetpad_lib::scheme::container_schemes(&package_scheme_root(dir));
+    let opened_in_xcode = has_a_scheme_that_resolves(dir, &files, names);
+    let mut out = files;
+    out.extend(names.products.iter().cloned());
+    if role == PackageRole::WorkspaceMember || opened_in_xcode {
+        out.extend(names.test_targets.iter().cloned());
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Whether any scheme in the package's container names a buildable the
+/// manifest still declares (see the module docs). A scheme that fails to parse
+/// counts as not resolving, so a malformed file cannot turn autocreation on.
+fn has_a_scheme_that_resolves(dir: &Path, files: &[String], names: &ManifestNames) -> bool {
+    if files.is_empty() {
+        return false;
+    }
+    let declared: HashSet<&str> = names
+        .products
+        .iter()
+        .chain(names.targets.iter())
+        .map(String::as_str)
+        .collect();
+    let root = package_scheme_root(dir);
+    files.iter().any(|name| {
+        sweetpad_lib::scheme::find_scheme_file(&root, name)
+            .and_then(|path| sweetpad_lib::scheme::parse_file(&path).ok())
+            .is_some_and(|scheme| {
+                scheme
+                    .build_entries
+                    .iter()
+                    .any(|entry| declared.contains(entry.buildable.blueprint_name.as_str()))
+            })
+    })
+}
+
+/// Walk the local package graph from `roots` and report what each package
+/// contributes, roots first and then each level of `.package(path:)`
+/// dependencies.
+///
+/// A package reached twice is resolved once, keeping the role it was first
+/// reached with — so pass workspace members ahead of everything else, since
+/// theirs is the role that adds test-target schemes.
 ///
 /// Cache hits cost a single file read. Misses run `dump-package` for each
-/// stale package concurrently, so a workspace with several packages pays one
-/// manifest evaluation's latency rather than the sum. A package whose manifest
-/// fails to evaluate contributes nothing and is not cached, so the next call
-/// retries — a broken manifest is usually mid-edit.
+/// stale package in the level concurrently, so a graph pays one manifest
+/// evaluation's latency per level rather than the sum. A package whose
+/// manifest fails to evaluate contributes nothing and is not cached, so the
+/// next call retries — a broken manifest is usually mid-edit.
 #[must_use]
-pub fn resolve(package_dirs: &[PathBuf], developer_dir: Option<&Path>) -> Vec<PackageMember> {
+pub fn resolve(
+    roots: &[(PathBuf, PackageRole)],
+    developer_dir: Option<&Path>,
+) -> Vec<PackageMember> {
     let mut entries = read_cache();
+    let mut changed = false;
     let mut out: Vec<PackageMember> = Vec::new();
-    let mut stale: Vec<(PathBuf, Stamp)> = Vec::new();
+    let mut seen: HashSet<PathBuf> = HashSet::new();
 
-    for dir in package_dirs {
-        let Some(current) = stamp(&dir.join("Package.swift")) else {
-            continue;
-        };
-        if let Some(member) = cached_member(&entries, dir, current) {
-            out.push(member);
-        } else {
-            stale.push((dir.clone(), current));
+    let mut level: Vec<(PathBuf, PackageRole)> = Vec::new();
+    for (dir, role) in roots {
+        let dir = canonical(dir);
+        if seen.insert(dir.clone()) {
+            level.push((dir, *role));
         }
     }
 
-    if stale.is_empty() {
-        return out;
-    }
-
-    let dumped: Vec<(Stamp, Option<PackageMember>)> = std::thread::scope(|scope| {
-        let handles: Vec<_> = stale
+    while !level.is_empty() {
+        let stamps: Vec<Option<Stamp>> = level
             .iter()
-            .map(|(dir, st)| {
-                let dir = dir.clone();
-                let st = *st;
-                scope.spawn(move || {
-                    let member = dump_package(&dir, developer_dir).map(|m| PackageMember {
-                        path: dir,
-                        schemes: product_schemes(&m),
-                        targets: target_names(&m),
-                    });
-                    (st, member)
-                })
-            })
+            .map(|(dir, _)| stamp(&dir.join("Package.swift")))
             .collect();
-        handles.into_iter().filter_map(|h| h.join().ok()).collect()
-    });
+        let mut names: Vec<Option<ManifestNames>> = level
+            .iter()
+            .zip(&stamps)
+            .map(|((dir, _), st)| st.and_then(|st| cached_manifest(&entries, dir, st)))
+            .collect();
 
-    let mut changed = false;
-    for ((len, mtime), member) in dumped {
-        let Some(member) = member else {
-            continue;
-        };
-        entries.insert(
-            member.path.to_string_lossy().into_owned(),
-            serde_json::json!({
-                "len": len,
-                // u128 exceeds JSON's safe integer range; keep it as a string
-                // so a round-trip can't quietly lose precision.
-                "mtime": mtime.to_string(),
-                "schemes": member.schemes,
-                "targets": member.targets,
-            }),
-        );
-        changed = true;
-        out.push(member);
+        let misses: Vec<usize> = (0..level.len())
+            .filter(|&i| stamps[i].is_some() && names[i].is_none())
+            .collect();
+        let dumped: Vec<(usize, Option<ManifestNames>)> = std::thread::scope(|scope| {
+            let handles: Vec<_> = misses
+                .iter()
+                .map(|&i| {
+                    let dir = level[i].0.clone();
+                    scope.spawn(move || {
+                        (
+                            i,
+                            dump_package(&dir, developer_dir).map(|m| read_manifest(&m)),
+                        )
+                    })
+                })
+                .collect();
+            handles.into_iter().filter_map(|h| h.join().ok()).collect()
+        });
+        for (i, dumped) in dumped {
+            let Some(dumped) = dumped else {
+                continue;
+            };
+            if let Some(st) = stamps[i] {
+                entries.insert(
+                    level[i].0.to_string_lossy().into_owned(),
+                    cache_entry(st, &dumped),
+                );
+                changed = true;
+            }
+            names[i] = Some(dumped);
+        }
+
+        let mut next: Vec<(PathBuf, PackageRole)> = Vec::new();
+        for ((dir, role), names) in level.drain(..).zip(names) {
+            let Some(names) = names else {
+                continue;
+            };
+            for dep in &names.path_deps {
+                let dep = canonical(dep);
+                if seen.insert(dep.clone()) {
+                    next.push((dep, PackageRole::Dependency));
+                }
+            }
+            out.push(PackageMember {
+                schemes: schemes_for(&dir, role, &names),
+                path: dir,
+                role,
+                targets: names.targets,
+            });
+        }
+        level = next;
     }
+
     if changed {
         write_cache(&entries);
     }
     out
+}
+
+/// Every local package a workspace draws schemes and targets from: its own
+/// `FileRef` members first (so they keep the role that adds test-target
+/// schemes), then the packages its member projects declare, then everything
+/// those reach through `.package(path:)`.
+#[must_use]
+pub fn resolve_workspace(ws: &Workspace, developer_dir: Option<&Path>) -> Vec<PackageMember> {
+    let mut roots: Vec<(PathBuf, PackageRole)> = ws
+        .package_refs
+        .iter()
+        .map(|p| (p.clone(), PackageRole::WorkspaceMember))
+        .collect();
+    roots.extend(
+        ws.project_package_refs()
+            .into_iter()
+            .map(|p| (p, PackageRole::Dependency)),
+    );
+    resolve(&roots, developer_dir)
+}
+
+/// Every local package a standalone `.xcodeproj` draws schemes and targets
+/// from: the ones it declares, then everything those reach through
+/// `.package(path:)`. None of them is a workspace member, so none contributes
+/// test-target schemes.
+#[must_use]
+pub fn resolve_project(project: &Project, developer_dir: Option<&Path>) -> Vec<PackageMember> {
+    let roots: Vec<(PathBuf, PackageRole)> = project
+        .package_refs
+        .iter()
+        .map(|p| (p.clone(), PackageRole::Dependency))
+        .collect();
+    resolve(&roots, developer_dir)
 }
 
 /// The `(path, schemes)` pairs
@@ -256,25 +449,13 @@ fn dump_package(dir: &Path, developer_dir: Option<&Path>) -> Option<Value> {
     serde_json::from_str(&text[start..]).ok()
 }
 
-/// Product names from a dumped manifest — one scheme each, which is what
-/// `xcodebuild -list` reports for a package inside a workspace (a `.plugin`
-/// product gets a scheme too). Falls back to non-test target names when a
-/// package declares no products, so a target-only package still offers
-/// something to select. The `<name>-Package` aggregate is deliberately absent
-/// (see the module docs).
-fn product_schemes(manifest: &Value) -> Vec<String> {
-    let products = names_in(manifest, "products", |_| true);
-    if products.is_empty() {
-        names_in(manifest, "targets", |t| !is_test_target(t))
-    } else {
-        products
+fn read_manifest(manifest: &Value) -> ManifestNames {
+    ManifestNames {
+        products: names_in(manifest, "products", |_| true),
+        test_targets: names_in(manifest, "targets", is_test_target),
+        targets: names_in(manifest, "targets", |_| true),
+        path_deps: path_dependencies(manifest),
     }
-}
-
-/// Every declared target, tests included — a target list drives
-/// `-only-testing:`, so dropping test targets would remove the useful half.
-fn target_names(manifest: &Value) -> Vec<String> {
-    names_in(manifest, "targets", |_| true)
 }
 
 fn names_in(manifest: &Value, key: &str, keep: impl Fn(&Value) -> bool) -> Vec<String> {
@@ -292,8 +473,25 @@ fn names_in(manifest: &Value, key: &str, keep: impl Fn(&Value) -> bool) -> Vec<S
         .unwrap_or_default()
 }
 
-/// A manifest target is a test target when its `type` union carries the `test`
-/// tag (`{"test":{}}`); older dumps spell the same thing as a plain string.
+/// The directories of the manifest's `.package(path:)` dependencies.
+/// `dump-package` writes them as `{"fileSystem": [{"path": "/abs/dir", …}]}`,
+/// already absolute; a git dependency (`sourceControl`) lives in a checkout
+/// Xcode manages and gets no schemes, so it is skipped.
+fn path_dependencies(manifest: &Value) -> Vec<PathBuf> {
+    let Some(deps) = manifest.get("dependencies").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    deps.iter()
+        .filter_map(|dep| dep.get("fileSystem")?.as_array())
+        .flatten()
+        .filter_map(|entry| entry.get("path")?.as_str())
+        .map(PathBuf::from)
+        .collect()
+}
+
+/// A manifest target is a test target when its `type` is the `test` tag —
+/// a plain string in current dumps, a single-key union (`{"test":{}}`) in
+/// older ones.
 fn is_test_target(target: &Value) -> bool {
     match target.get("type") {
         Some(Value::Object(map)) => map.contains_key("test"),
@@ -311,76 +509,191 @@ mod tests {
             "name": "MyLib",
             "products": [{"name": "LibA"}, {"name": "MyPlugin"}],
             "targets": [
-                {"name": "LibA", "type": {"regular": {}}},
-                {"name": "MyPlugin", "type": {"plugin": {}}},
-                {"name": "LibATests", "type": {"test": {}}},
+                {"name": "LibA", "type": "regular"},
+                {"name": "MyPlugin", "type": "plugin"},
+                {"name": "LibATests", "type": "test"},
             ],
         })
     }
 
-    #[test]
-    fn products_become_schemes_without_the_package_aggregate() {
-        assert_eq!(product_schemes(&manifest()), vec!["LibA", "MyPlugin"]);
+    /// A package directory with nothing in it but, optionally, a scheme
+    /// container holding `<file>.xcscheme` naming `<blueprint>` — Xcode's mark
+    /// that the package has been opened in it.
+    fn package_dir(tag: &str, scheme_file: Option<(&str, &str)>) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static N: AtomicU32 = AtomicU32::new(0);
+        let n = N.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("sweetpad-pkg-{tag}-{}-{n}", std::process::id()));
+        let schemes = package_scheme_root(&dir).join("xcshareddata/xcschemes");
+        fs::create_dir_all(&schemes).unwrap();
+        if let Some((file, blueprint)) = scheme_file {
+            fs::write(
+                schemes.join(format!("{file}.xcscheme")),
+                format!(
+                    r#"<?xml version="1.0" encoding="UTF-8"?>
+<Scheme version = "1.7">
+   <BuildAction>
+      <BuildActionEntries>
+         <BuildActionEntry buildForRunning = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "{blueprint}"
+               BuildableName = "{blueprint}"
+               BlueprintName = "{blueprint}"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+</Scheme>
+"#
+                ),
+            )
+            .unwrap();
+        }
+        dir
     }
 
     #[test]
-    fn targets_keep_test_targets_that_schemes_drop() {
+    fn a_workspace_member_adds_its_test_targets_to_its_products() {
+        let dir = package_dir("member", None);
+        let names = read_manifest(&manifest());
         assert_eq!(
-            target_names(&manifest()),
+            schemes_for(&dir, PackageRole::WorkspaceMember, &names),
+            vec!["LibA", "LibATests", "MyPlugin"]
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_dependency_contributes_products_only() {
+        let dir = package_dir("dependency", None);
+        let names = read_manifest(&manifest());
+        assert_eq!(
+            schemes_for(&dir, PackageRole::Dependency, &names),
+            vec!["LibA", "MyPlugin"]
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_dependency_opened_in_xcode_adds_its_scheme_files_and_test_targets() {
+        let dir = package_dir("opened", Some(("LibA", "LibA")));
+        let names = read_manifest(&manifest());
+        assert_eq!(
+            schemes_for(&dir, PackageRole::Dependency, &names),
+            vec!["LibA", "LibATests", "MyPlugin"]
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_scheme_left_over_from_a_rename_does_not_turn_autocreation_on() {
+        // ice-cubes' NetworkClient ships only `NetworkTests.xcscheme`, naming a
+        // target its manifest no longer has; `xcodebuild` autocreates nothing
+        // for it, so its `NetworkClientTests` never becomes a scheme.
+        let dir = package_dir("stale", Some(("NetworkTests", "NetworkTests")));
+        let names = read_manifest(&manifest());
+        assert_eq!(
+            schemes_for(&dir, PackageRole::Dependency, &names),
+            vec!["LibA", "MyPlugin", "NetworkTests"]
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_scheme_file_naming_nothing_in_the_manifest_is_a_scheme_all_the_same() {
+        // ice-cubes' StatusKit ships `StatusKit-Package.xcscheme`, an
+        // aggregate no product or target declares.
+        let dir = package_dir("aggregate", Some(("MyLib-Package", "MyLib")));
+        let names = read_manifest(&manifest());
+        assert!(
+            schemes_for(&dir, PackageRole::Dependency, &names)
+                .contains(&"MyLib-Package".to_string())
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn targets_keep_test_targets_that_a_dependency_role_drops_from_schemes() {
+        assert_eq!(
+            read_manifest(&manifest()).targets,
             vec!["LibA", "MyPlugin", "LibATests"]
         );
     }
 
     #[test]
-    fn targets_stand_in_when_a_package_declares_no_products() {
+    fn a_target_no_product_exposes_is_not_a_scheme() {
         let m = serde_json::json!({
             "name": "MyLib",
             "products": [],
             "targets": [
-                {"name": "Core", "type": {"regular": {}}},
-                {"name": "CoreTests", "type": {"test": {}}},
+                {"name": "Core", "type": "regular"},
+                {"name": "CoreTests", "type": "test"},
             ],
         });
-        assert_eq!(product_schemes(&m), vec!["Core"]);
+        let names = read_manifest(&m);
+        // A product-less package offers its tests to a workspace that owns it,
+        // and nothing at all to a container that only depends on it.
+        let dir = package_dir("no-products", None);
+        assert_eq!(
+            schemes_for(&dir, PackageRole::WorkspaceMember, &names),
+            vec!["CoreTests"]
+        );
+        assert!(schemes_for(&dir, PackageRole::Dependency, &names).is_empty());
+        let _ = fs::remove_dir_all(&dir);
         // The same manifest still reports both as targets.
-        assert_eq!(target_names(&m), vec!["Core", "CoreTests"]);
+        assert_eq!(names.targets, vec!["Core", "CoreTests"]);
     }
 
     #[test]
-    fn a_string_typed_test_target_is_still_recognized() {
+    fn a_union_typed_test_target_is_still_recognized() {
         let m = serde_json::json!({
             "name": "MyLib",
             "products": [],
-            "targets": [{"name": "Core"}, {"name": "CoreTests", "type": "test"}],
+            "targets": [{"name": "Core"}, {"name": "CoreTests", "type": {"test": {}}}],
         });
-        assert_eq!(product_schemes(&m), vec!["Core"]);
+        let names = read_manifest(&m);
+        assert_eq!(names.test_targets, vec!["CoreTests"]);
+    }
+
+    #[test]
+    fn path_dependencies_are_followed_and_git_ones_are_not() {
+        let m = serde_json::json!({
+            "name": "MyLib",
+            "dependencies": [
+                {"fileSystem": [{"identity": "sibling", "path": "/pkgs/Sibling"}]},
+                {"sourceControl": [{"identity": "alamofire", "location": {}}]},
+            ],
+        });
+        assert_eq!(
+            read_manifest(&m).path_deps,
+            vec![PathBuf::from("/pkgs/Sibling")]
+        );
     }
 
     #[test]
     fn a_cache_entry_is_reused_only_while_the_stamp_matches() {
+        let names = read_manifest(&manifest());
         let mut entries = BTreeMap::new();
-        entries.insert(
-            "/pkg".to_string(),
-            serde_json::json!({
-                "len": 10, "mtime": "99",
-                "schemes": ["LibA"], "targets": ["LibA", "LibATests"],
-            }),
-        );
-        let hit = cached_member(&entries, Path::new("/pkg"), (10, 99)).unwrap();
-        assert_eq!(hit.schemes, vec!["LibA"]);
-        assert_eq!(hit.targets, vec!["LibA", "LibATests"]);
-        assert!(cached_member(&entries, Path::new("/pkg"), (11, 99)).is_none());
-        assert!(cached_member(&entries, Path::new("/pkg"), (10, 100)).is_none());
-        assert!(cached_member(&entries, Path::new("/other"), (10, 99)).is_none());
+        entries.insert("/pkg".to_string(), cache_entry((10, 99), &names));
+
+        let hit = cached_manifest(&entries, Path::new("/pkg"), (10, 99)).unwrap();
+        assert_eq!(hit.products, vec!["LibA", "MyPlugin"]);
+        assert_eq!(hit.test_targets, vec!["LibATests"]);
+        assert!(cached_manifest(&entries, Path::new("/pkg"), (11, 99)).is_none());
+        assert!(cached_manifest(&entries, Path::new("/pkg"), (10, 100)).is_none());
+        assert!(cached_manifest(&entries, Path::new("/other"), (10, 99)).is_none());
     }
 
     #[test]
-    fn an_entry_missing_targets_is_a_miss_not_an_empty_target_list() {
+    fn an_entry_missing_a_field_is_a_miss_not_an_empty_list() {
         let mut entries = BTreeMap::new();
         entries.insert(
             "/pkg".to_string(),
-            serde_json::json!({"len": 10, "mtime": "99", "schemes": ["LibA"]}),
+            serde_json::json!({"len": 10, "mtime": "99", "products": ["LibA"]}),
         );
-        assert!(cached_member(&entries, Path::new("/pkg"), (10, 99)).is_none());
+        assert!(cached_manifest(&entries, Path::new("/pkg"), (10, 99)).is_none());
     }
 }

--- a/sweetpad-core/tests/spm_graph_oracle.rs
+++ b/sweetpad-core/tests/spm_graph_oracle.rs
@@ -17,6 +17,10 @@
 //!   `.swiftpm/xcode` scheme container — products, scheme files, test targets;
 //! - `NestedDep` and `DepChild`, reached only through `.package(path:)` —
 //!   products alone;
+//! - `project/Modules/Nest/Synced`, two levels under a synchronized folder the
+//!   pbxproj lists no members for — found by scanning the disk;
+//! - `project/Modules/Tool`, whose whole manifest is one `executableTarget` —
+//!   the implicit product SwiftPM synthesizes for it is a scheme;
 //! - `MultiLib`'s `TC`, a target no product exposes, and `NestedDep`'s
 //!   `NestedTests`, a test target in a package nobody opened — neither is a
 //!   scheme.
@@ -43,6 +47,8 @@ const WORKSPACE_SCHEMES: &[&str] = &[
     "LibA",
     "NestedLib",
     "SpmApp",
+    "SyncedLib",
+    "SyncedTool",
     "TATests",
 ];
 
@@ -57,6 +63,8 @@ const WORKSPACE_TARGETS: &[&str] = &[
     "TATests",
     "Dep",
     "DepTests",
+    "SA",
+    "SyncedTool",
     "Nested",
     "NestedTests",
     "DC",
@@ -65,10 +73,31 @@ const WORKSPACE_TARGETS: &[&str] = &[
 
 /// `xcodebuild -list -project SpmApp.xcodeproj` — the same graph minus the
 /// workspace's own member package.
-const PROJECT_SCHEMES: &[&str] = &["Dep", "DepChildLib", "DepTests", "SpmApp"];
+const PROJECT_SCHEMES: &[&str] = &[
+    "Dep",
+    "DepChildLib",
+    "DepTests",
+    "SpmApp",
+    "SyncedLib",
+    "SyncedTool",
+];
 
 fn fixture() -> PathBuf {
     common::fixtures_root().join("_synthetic-spm-graph")
+}
+
+/// The local packages the member project reaches: the one it declares, then
+/// the two under its synchronized folder, in the order the group-tree walk
+/// hands them back.
+fn project_packages() -> Vec<PathBuf> {
+    [
+        "project/Dep",
+        "project/Modules/Nest/Synced",
+        "project/Modules/Tool",
+    ]
+    .iter()
+    .map(|rel| fixture().join(rel))
+    .collect()
 }
 
 /// Manifests are Swift source, so every assertion here needs the toolchain.
@@ -87,10 +116,7 @@ fn a_workspace_lists_every_local_package_it_reaches() {
     }
     let ws = workspace::open(&fixture().join("Graph.xcworkspace")).unwrap();
     assert_eq!(ws.package_refs, vec![fixture().join("MultiLib")]);
-    assert_eq!(
-        ws.project_package_refs(),
-        vec![fixture().join("project/Dep")]
-    );
+    assert_eq!(ws.project_package_refs(), project_packages());
 
     let members = package_members::resolve_workspace(&ws, None);
     assert_eq!(
@@ -126,7 +152,7 @@ fn a_bare_project_lists_the_packages_it_declares() {
         return;
     }
     let proj = project::open(&fixture().join("project/SpmApp.xcodeproj")).unwrap();
-    assert_eq!(proj.package_refs, vec![fixture().join("project/Dep")]);
+    assert_eq!(proj.package_refs, project_packages());
 
     let members = package_members::resolve_project(&proj, None);
     assert_eq!(

--- a/sweetpad-core/tests/spm_graph_oracle.rs
+++ b/sweetpad-core/tests/spm_graph_oracle.rs
@@ -1,0 +1,198 @@
+//! Local package graph oracle: the schemes and targets an Xcode container
+//! draws from the Swift packages around it, grounded against real
+//! `xcodebuild -list`.
+//!
+//! `xcodebuild` resolves the whole *local* package graph and synthesizes
+//! schemes from it — a workspace's `FileRef` package members, the packages its
+//! member projects declare or hold in their group tree, and everything those
+//! reach through `.package(path:)`. Naming any of it means evaluating Swift
+//! manifests, which is why the walk lives in
+//! [`sweetpad_core::package_members`] rather than in the file-format crate.
+//!
+//! The fixture (`fixtures/_synthetic-spm-graph`) puts one of each shape in
+//! reach of a single workspace:
+//!
+//! - `MultiLib`, a `FileRef` member — products and test targets;
+//! - `project/Dep`, declared by the member project and carrying a
+//!   `.swiftpm/xcode` scheme container — products, scheme files, test targets;
+//! - `NestedDep` and `DepChild`, reached only through `.package(path:)` —
+//!   products alone;
+//! - `MultiLib`'s `TC`, a target no product exposes, and `NestedDep`'s
+//!   `NestedTests`, a test target in a package nobody opened — neither is a
+//!   scheme.
+//!
+//! Both tests need the Swift toolchain (manifests are Swift source) and skip
+//! cleanly without it. `SPM_LIVE_ORACLE=1` adds the comparison against
+//! `xcodebuild -list -json` itself, which additionally needs Xcode.
+
+mod common;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use common::{JsonValue, parse_json};
+use sweetpad_core::package_members::{self, PackageRole};
+use sweetpad_lib::{project, workspace};
+
+/// `xcodebuild -list -workspace Graph.xcworkspace`, in its own order.
+const WORKSPACE_SCHEMES: &[&str] = &[
+    "Dep",
+    "DepChildLib",
+    "DepTests",
+    "ExecB",
+    "LibA",
+    "NestedLib",
+    "SpmApp",
+    "TATests",
+];
+
+/// Member-project targets first, then each package's, in the order the graph
+/// walk reaches them: the workspace's own member, the member project's
+/// package, then their path dependencies.
+const WORKSPACE_TARGETS: &[&str] = &[
+    "SpmApp",
+    "TA",
+    "TB",
+    "TC",
+    "TATests",
+    "Dep",
+    "DepTests",
+    "Nested",
+    "NestedTests",
+    "DC",
+    "DCTests",
+];
+
+/// `xcodebuild -list -project SpmApp.xcodeproj` — the same graph minus the
+/// workspace's own member package.
+const PROJECT_SCHEMES: &[&str] = &["Dep", "DepChildLib", "DepTests", "SpmApp"];
+
+fn fixture() -> PathBuf {
+    common::fixtures_root().join("_synthetic-spm-graph")
+}
+
+/// Manifests are Swift source, so every assertion here needs the toolchain.
+fn have_swift() -> bool {
+    Command::new("swift")
+        .arg("--version")
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
+#[test]
+fn a_workspace_lists_every_local_package_it_reaches() {
+    if !have_swift() {
+        eprintln!("skipping: needs the Swift toolchain to evaluate package manifests");
+        return;
+    }
+    let ws = workspace::open(&fixture().join("Graph.xcworkspace")).unwrap();
+    assert_eq!(ws.package_refs, vec![fixture().join("MultiLib")]);
+    assert_eq!(
+        ws.project_package_refs(),
+        vec![fixture().join("project/Dep")]
+    );
+
+    let members = package_members::resolve_workspace(&ws, None);
+    assert_eq!(
+        ws.merged_schemes_with_packages(&package_members::scheme_pairs(&members)),
+        WORKSPACE_SCHEMES
+    );
+    assert_eq!(
+        ws.merged_targets_with_packages(&package_members::target_pairs(&members)),
+        WORKSPACE_TARGETS
+    );
+
+    // The roles behind those names: only the `FileRef` member is a member, and
+    // a package reached through `.package(path:)` keeps its test targets out
+    // of the scheme list.
+    let member = members
+        .iter()
+        .find(|m| m.path.ends_with("MultiLib"))
+        .expect("the workspace's own package is in the graph");
+    assert_eq!(member.role, PackageRole::WorkspaceMember);
+    assert_eq!(member.schemes, vec!["ExecB", "LibA", "TATests"]);
+    let nested = members
+        .iter()
+        .find(|m| m.path.ends_with("NestedDep"))
+        .expect("a member's path dependency is in the graph");
+    assert_eq!(nested.role, PackageRole::Dependency);
+    assert_eq!(nested.schemes, vec!["NestedLib"]);
+}
+
+#[test]
+fn a_bare_project_lists_the_packages_it_declares() {
+    if !have_swift() {
+        eprintln!("skipping: needs the Swift toolchain to evaluate package manifests");
+        return;
+    }
+    let proj = project::open(&fixture().join("project/SpmApp.xcodeproj")).unwrap();
+    assert_eq!(proj.package_refs, vec![fixture().join("project/Dep")]);
+
+    let members = package_members::resolve_project(&proj, None);
+    assert_eq!(
+        proj.schemes_with_packages(&package_members::scheme_pairs(&members)),
+        PROJECT_SCHEMES
+    );
+
+    // `Dep` ships a scheme container naming a target its manifest still has,
+    // which is what makes `DepTests` a scheme for a package the project only
+    // depends on.
+    let dep = members
+        .iter()
+        .find(|m| m.path.ends_with("Dep"))
+        .expect("the declared package is in the graph");
+    assert_eq!(dep.role, PackageRole::Dependency);
+    assert_eq!(dep.schemes, vec!["Dep", "DepTests"]);
+}
+
+#[test]
+fn live_xcodebuild_lists_the_same_schemes() {
+    if std::env::var("SPM_LIVE_ORACLE").is_err() {
+        eprintln!(
+            "skipping: set SPM_LIVE_ORACLE=1 to compare against xcodebuild (needs macOS + Xcode + swift)"
+        );
+        return;
+    }
+    assert_eq!(
+        xcodebuild_schemes("-workspace", "Graph.xcworkspace", "workspace"),
+        WORKSPACE_SCHEMES
+    );
+    assert_eq!(
+        xcodebuild_schemes("-project", "project/SpmApp.xcodeproj", "project"),
+        PROJECT_SCHEMES
+    );
+}
+
+/// The `schemes` array of `xcodebuild -list -json`, whose one top-level key is
+/// `workspace` or `project` depending on what was listed.
+fn xcodebuild_schemes(flag: &str, container_path: &str, container_key: &str) -> Vec<String> {
+    let out = Command::new("xcodebuild")
+        .args([
+            "-list",
+            "-json",
+            flag,
+            &fixture().join(container_path).display().to_string(),
+        ])
+        .output()
+        .expect("xcodebuild runs");
+    assert!(
+        out.status.success(),
+        "xcodebuild -list failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = String::from_utf8_lossy(&out.stdout);
+    let start = text.find('{').expect("JSON in xcodebuild output");
+    let json = parse_json(&text[start..]).expect("xcodebuild -list -json parses");
+    json.as_object()
+        .and_then(|o| o.get(container_key))
+        .and_then(JsonValue::as_object)
+        .and_then(|o| o.get("schemes"))
+        .and_then(JsonValue::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(JsonValue::as_string)
+                .map(str::to_owned)
+                .collect()
+        })
+        .expect("a schemes array")
+}

--- a/sweetpad-lib/DOCS.md
+++ b/sweetpad-lib/DOCS.md
@@ -230,6 +230,7 @@ Hand-built fixtures cover paths no real corpus project exercises:
 | `_synthetic-multiplatform` | One `SDKROOT = auto` target with `SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx` — the IceCubesApp shape that keeps the SDK-binding regression in CI |
 | `_synthetic-{coredata,assetsym,strcat,intents,cocoapods,macro,tests}` | BSP generated-source / CocoaPods / Swift-macro / XCTest coverage — each a forced `Probe*.swift` referencing a build-time-generated / Pod / macro-expanded symbol |
 | `_synthetic-spm`, `_synthetic-workspace` | SwiftPM package products (`-F …/PackageFrameworks`); multi-project `.xcworkspace` resolution |
+| `_synthetic-spm-graph` | One workspace reaching a local package four ways — its own `FileRef` member, the member project's declared package, and both of their `.package(path:)` dependencies — plus a package carrying a `.swiftpm/xcode` scheme container (`tests/spm_graph_oracle.rs` in sweetpad-core) |
 | `_global` | Per-SDK metadata (`sdks/<sdk>.json`), xcodebuild version banner |
 | `_tuist-src` | Generated tuist examples adding a command-line tool (`mh_execute`) and a standalone dynamic library (`mh_dylib`) to the compiler-args oracle |
 
@@ -434,10 +435,12 @@ the imported `examples_xcode_<dir>` spelling.
 
 Schemes `xcodebuild` synthesizes from Swift *package* manifests (41 across
 ice-cubes/netnewswire) are outside the pbxproj surface and are tallied by the
-discovery oracle, not failed. They are instead grounded directly against the
-toolchain by the SwiftPM CLI oracle (`tests/spm_oracle.rs`, roadmap D15 — done):
-sweetpad reads package schemes from `swift package dump-package` (products plus
-the `<name>-Package` aggregate) rather than the pbxproj resolver.
+discovery oracle, not failed. They are grounded against the toolchain instead,
+by two oracles that read `swift package dump-package` rather than the pbxproj
+resolver: `sweetpad-cli/tests/spm_oracle.rs` for a package opened on its own
+(products plus the `<name>-Package` aggregate, roadmap D15 — done), and
+`sweetpad-core/tests/spm_graph_oracle.rs` for the local package graph around an
+Xcode container (§9's "Schemes from a local Swift package").
 
 ## 7. Compiler-argument resolution
 
@@ -702,9 +705,9 @@ Methods: `build/initialize`, `workspace/buildTargets`, `buildTarget/sources`,
 
 Tracks which Xcode build-system features have a real example in the corpus.
 Hand-maintained; re-verify against the generated `fixtures/FIXTURES.md`
-after each capture run. Current tally: **121 ✅ / 18 ❌**
+after each capture run. Current tally: **124 ✅ / 19 ❌**
 (reconciled 2026-05-30 against the captured corpus with concrete evidence per
-row; scheme-discovery rows updated 2026-06-10).
+row; scheme-discovery rows updated 2026-06-10, package-graph rows 2026-08-26).
 
 Legend: ✅ at least one fixture exercises it (rows marked *hermetic, not
 corpus* are covered by tests building the layout in temp dirs — covered, but
@@ -814,6 +817,39 @@ unit tests rather than a corpus capture.
 | Scheme with custom test plan (`.xctestplan`) | ✅ | fixtures/alamofire/.../Alamofire iOS.xcscheme |
 | Scheme using parallel testing config | ❌ | — (roadmap D18: hermetic) |
 | Scheme overriding `buildImplicitDependencies` | ✅ | fixtures/tuist-fixtures/.../examples_xcode_generated_app_with_custom_scheme |
+
+#### Schemes from a local Swift package
+
+`xcodebuild -list` resolves the whole *local* package graph in reach of the
+container and synthesizes schemes from every package in it: the
+`.xcworkspace`'s own `FileRef` members, the packages a member project declares
+(`XCLocalSwiftPackageReference`) or keeps in its group tree as a plain folder
+reference, and everything those pull in through `.package(path:)`. Naming any
+of it needs `swift package dump-package`, so the walk lives in
+`sweetpad-core/src/package_members.rs` (whose module docs carry the reasoning)
+rather than in this crate.
+
+What each package contributes, measured against Xcode 26.5:
+
+| Reached as | products | `.swiftpm/xcode` scheme files | test targets |
+|---|---|---|---|
+| `FileRef` in the `.xcworkspace` | ✅ | ✅ | ✅ |
+| package whose scheme container still resolves | ✅ | ✅ | ✅ |
+| any other local package | ✅ | ✅ | — |
+
+A target no product exposes is never a scheme, and the `<name>-Package`
+aggregate exists only for a package opened on its own. A scheme container
+counts as resolving when one of its schemes names a buildable the manifest
+still declares — ice-cubes' `Env` ships an `Env.xcscheme` and gets `EnvTests`
+alongside it, while its `NetworkClient` ships only a `NetworkTests.xcscheme`
+left over from a rename and gets nothing autocreated.
+
+| Test case | Status | Where |
+|---|---|---|
+| Package products as schemes, across the whole `.package(path:)` graph | ✅ | fixtures/_synthetic-spm-graph (sweetpad-core/tests/spm_graph_oracle.rs) |
+| A package a project declares or holds as a folder reference | ✅ | fixtures/_synthetic-spm-graph/project/SpmApp.xcodeproj (both spellings) |
+| A package's own scheme files, and the test targets a live container unlocks | ✅ | fixtures/_synthetic-spm-graph/project/Dep/.swiftpm |
+| A *remote* package's scheme files | ❌ | ice-cubes' `RevenueCatUI` — they live in a `SourcePackages` checkout under DerivedData that only a resolved build knows the path to |
 
 ### SDKs / platforms
 
@@ -1115,8 +1151,9 @@ Xcode 26.5. Probe the new toolchain:
 swift package --experimental-manifest-processing-mode only-parsed dump-package
 ```
 
-If the flag is accepted, the spawn in `sweetpad-core` that resolves a workspace
-member package's schemes (issue #327) can lean on it for the common case.
+If the flag is accepted, the spawn in `sweetpad-core` that resolves the local
+package graph's schemes (issue #327) can lean on it for the common case —
+it is one spawn per package, so a graph pays the most.
 
 ### 10.8 Green, docs, commit
 

--- a/sweetpad-lib/DOCS.md
+++ b/sweetpad-lib/DOCS.md
@@ -230,7 +230,7 @@ Hand-built fixtures cover paths no real corpus project exercises:
 | `_synthetic-multiplatform` | One `SDKROOT = auto` target with `SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx` — the IceCubesApp shape that keeps the SDK-binding regression in CI |
 | `_synthetic-{coredata,assetsym,strcat,intents,cocoapods,macro,tests}` | BSP generated-source / CocoaPods / Swift-macro / XCTest coverage — each a forced `Probe*.swift` referencing a build-time-generated / Pod / macro-expanded symbol |
 | `_synthetic-spm`, `_synthetic-workspace` | SwiftPM package products (`-F …/PackageFrameworks`); multi-project `.xcworkspace` resolution |
-| `_synthetic-spm-graph` | One workspace reaching a local package four ways — its own `FileRef` member, the member project's declared package, and both of their `.package(path:)` dependencies — plus a package carrying a `.swiftpm/xcode` scheme container (`tests/spm_graph_oracle.rs` in sweetpad-core) |
+| `_synthetic-spm-graph` | One workspace reaching a local package six ways — its own `FileRef` member, the member project's declared package, both of their `.package(path:)` dependencies, and two under a `PBXFileSystemSynchronizedRootGroup` — plus a package carrying a `.swiftpm/xcode` scheme container and one whose only target is an `executableTarget` (`tests/spm_graph_oracle.rs` in sweetpad-core) |
 | `_global` | Per-SDK metadata (`sdks/<sdk>.json`), xcodebuild version banner |
 | `_tuist-src` | Generated tuist examples adding a command-line tool (`mh_execute`) and a standalone dynamic library (`mh_dylib`) to the compiler-args oracle |
 
@@ -438,7 +438,7 @@ ice-cubes/netnewswire) are outside the pbxproj surface and are tallied by the
 discovery oracle, not failed. They are grounded against the toolchain instead,
 by two oracles that read `swift package dump-package` rather than the pbxproj
 resolver: `sweetpad-cli/tests/spm_oracle.rs` for a package opened on its own
-(products plus the `<name>-Package` aggregate, roadmap D15 — done), and
+(the product-count rule in §9, roadmap D15 — done), and
 `sweetpad-core/tests/spm_graph_oracle.rs` for the local package graph around an
 Xcode container (§9's "Schemes from a local Swift package").
 
@@ -705,7 +705,7 @@ Methods: `build/initialize`, `workspace/buildTargets`, `buildTarget/sources`,
 
 Tracks which Xcode build-system features have a real example in the corpus.
 Hand-maintained; re-verify against the generated `fixtures/FIXTURES.md`
-after each capture run. Current tally: **124 ✅ / 19 ❌**
+after each capture run. Current tally: **127 ✅ / 20 ❌**
 (reconciled 2026-05-30 against the captured corpus with concrete evidence per
 row; scheme-discovery rows updated 2026-06-10, package-graph rows 2026-08-26).
 
@@ -837,19 +837,52 @@ What each package contributes, measured against Xcode 26.5:
 | package whose scheme container still resolves | ✅ | ✅ | ✅ |
 | any other local package | ✅ | ✅ | — |
 
-A target no product exposes is never a scheme, and the `<name>-Package`
-aggregate exists only for a package opened on its own. A scheme container
-counts as resolving when one of its schemes names a buildable the manifest
-still declares — ice-cubes' `Env` ships an `Env.xcscheme` and gets `EnvTests`
-alongside it, while its `NetworkClient` ships only a `NetworkTests.xcscheme`
-left over from a rename and gets nothing autocreated.
+A target no product exposes is never a scheme. "Products" includes the ones
+SwiftPM synthesizes but the manifest never wrote: an `executableTarget` no
+declared product covers gets an implicit executable product of the same name,
+and `xcodebuild` schedules a scheme for it like any other. `swift package
+describe` reports those, but only after resolving the dependency graph, so
+`package_members.rs` reconstructs them from `dump-package`'s targets instead.
+
+A scheme container counts as resolving when one of its schemes names a
+buildable the manifest still declares — ice-cubes' `Env` ships an
+`Env.xcscheme` and gets `EnvTests` alongside it, while its `NetworkClient`
+ships only a `NetworkTests.xcscheme` left over from a rename and gets nothing
+autocreated.
+
+A package found under a `PBXFileSystemSynchronizedRootGroup` counts like any
+other. The folder lists no members in the pbxproj, so the walk scans the disk
+under it, at any depth and stopping at each package it finds — a
+`Package.swift` nested inside another package gets no schemes. NetNewsWire
+reaches all fourteen of its `Modules/*` this way and no other.
+
+**A package opened on its own is listed differently**, and how many products it
+has decides the shape:
+
+| products | schemes |
+|---|---|
+| none | `<name>-Package` alone |
+| one | `<name>` alone — the package's own name, whatever the product is called |
+| two or more | `<name>-Package` plus one scheme per product |
+
+The single-product collapse is easy to miss in both directions: a package with
+one library product answers to neither that product's name nor the aggregate,
+and one whose only product is an `executableTarget`'s implicit executable
+answers to the package name too. `Manifest::scheme_names` in
+`sweetpad-cli/src/cli/swiftpm.rs` and `packageSchemes` in the extension's
+`scripts.ts` both encode it; the two-product form is unchanged back to Xcode
+15.4 in the captures.
 
 | Test case | Status | Where |
 |---|---|---|
 | Package products as schemes, across the whole `.package(path:)` graph | ✅ | fixtures/_synthetic-spm-graph (sweetpad-core/tests/spm_graph_oracle.rs) |
 | A package a project declares or holds as a folder reference | ✅ | fixtures/_synthetic-spm-graph/project/SpmApp.xcodeproj (both spellings) |
 | A package's own scheme files, and the test targets a live container unlocks | ✅ | fixtures/_synthetic-spm-graph/project/Dep/.swiftpm |
+| A package under a synchronized folder, two levels down | ✅ | fixtures/_synthetic-spm-graph/project/Modules/Nest/Synced |
+| The implicit executable product behind a product-less `executableTarget` | ✅ | fixtures/_synthetic-spm-graph/project/Modules/Tool |
+| The product-count rule for a package opened on its own | ✅ | *hermetic, not corpus* — `Manifest::scheme_names` unit tests (sweetpad-cli/src/cli/swiftpm.rs) |
 | A *remote* package's scheme files | ❌ | ice-cubes' `RevenueCatUI` — they live in a `SourcePackages` checkout under DerivedData that only a resolved build knows the path to |
+| When a live scheme container does *not* unlock a test target | ❌ | NetNewsWire's `Articles` ships one `Articles.xcscheme` and `xcodebuild` lists no `ArticlesTests`, while ice-cubes' `Env` ships one `Env.xcscheme` and does get `EnvTests`; sweetpad follows the ice-cubes rule and offers that one extra scheme |
 
 ### SDKs / platforms
 

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/DepChild/Package.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/DepChild/Package.swift
@@ -1,0 +1,7 @@
+// swift-tools-version:5.9
+import PackageDescription
+let package = Package(
+  name: "DepChild",
+  products: [.library(name: "DepChildLib", targets: ["DC"])],
+  targets: [.target(name: "DC"), .testTarget(name: "DCTests", dependencies: ["DC"])]
+)

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/DepChild/Sources/DC/DC.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/DepChild/Sources/DC/DC.swift
@@ -1,0 +1,1 @@
+public func dc() {}

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/DepChild/Tests/DCTests/DCTests.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/DepChild/Tests/DCTests/DCTests.swift
@@ -1,0 +1,1 @@
+import XCTest

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/Graph.xcworkspace/contents.xcworkspacedata
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/Graph.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:project/SpmApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:MultiLib">
+   </FileRef>
+</Workspace>

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/MultiLib/Package.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/MultiLib/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.9
+import PackageDescription
+let package = Package(
+  name: "MultiLib",
+  products: [
+    .library(name: "LibA", targets: ["TA"]),
+    .executable(name: "ExecB", targets: ["TB"]),
+  ],
+  dependencies: [.package(path: "../NestedDep")],
+  targets: [
+    .target(name: "TA", dependencies: [.product(name: "NestedLib", package: "NestedDep")]),
+    .executableTarget(name: "TB"),
+    .target(name: "TC"),
+    .testTarget(name: "TATests", dependencies: ["TA"]),
+  ]
+)

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/MultiLib/Sources/TA/TA.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/MultiLib/Sources/TA/TA.swift
@@ -1,0 +1,1 @@
+public func ta() {}

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/MultiLib/Sources/TB/TB.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/MultiLib/Sources/TB/TB.swift
@@ -1,0 +1,1 @@
+@main struct TB { static func main() {} }

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/MultiLib/Sources/TC/TC.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/MultiLib/Sources/TC/TC.swift
@@ -1,0 +1,1 @@
+public func tc() {}

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/MultiLib/Tests/TATests/TATests.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/MultiLib/Tests/TATests/TATests.swift
@@ -1,0 +1,1 @@
+import XCTest

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/NestedDep/Package.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/NestedDep/Package.swift
@@ -1,0 +1,7 @@
+// swift-tools-version:5.9
+import PackageDescription
+let package = Package(
+  name: "NestedDep",
+  products: [.library(name: "NestedLib", targets: ["Nested"])],
+  targets: [.target(name: "Nested"), .testTarget(name: "NestedTests", dependencies: ["Nested"])]
+)

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/NestedDep/Sources/Nested/Nested.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/NestedDep/Sources/Nested/Nested.swift
@@ -1,0 +1,1 @@
+public func nested() {}

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/NestedDep/Tests/NestedTests/NestedTests.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/NestedDep/Tests/NestedTests/NestedTests.swift
@@ -1,0 +1,1 @@
+import XCTest

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/project/AppSources/App.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/project/AppSources/App.swift
@@ -1,0 +1,5 @@
+import Dep
+
+public func appGreeting() -> String {
+    Dep().hello()
+}

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Dep/.swiftpm/xcode/xcshareddata/xcschemes/Dep.xcscheme
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Dep/.swiftpm/xcode/xcshareddata/xcschemes/Dep.xcscheme
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Dep"
+               BuildableName = "Dep"
+               BlueprintName = "Dep"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+</Scheme>

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Dep/Package.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Dep/Package.swift
@@ -1,0 +1,11 @@
+// swift-tools-version:5.9
+import PackageDescription
+let package = Package(
+  name: "Dep",
+  products: [.library(name: "Dep", targets: ["Dep"])],
+  dependencies: [.package(path: "../../DepChild")],
+  targets: [
+    .target(name: "Dep", dependencies: [.product(name: "DepChildLib", package: "DepChild")]),
+    .testTarget(name: "DepTests", dependencies: ["Dep"]),
+  ]
+)

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Dep/Sources/Dep/Dep.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Dep/Sources/Dep/Dep.swift
@@ -1,0 +1,4 @@
+public struct Dep {
+    public init() {}
+    public func hello() -> String { "hi from Dep" }
+}

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Dep/Tests/DepTests/DepTests.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Dep/Tests/DepTests/DepTests.swift
@@ -1,0 +1,1 @@
+import XCTest

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Modules/Nest/Synced/Package.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Modules/Nest/Synced/Package.swift
@@ -1,0 +1,7 @@
+// swift-tools-version:5.9
+import PackageDescription
+let package = Package(
+  name: "Synced",
+  products: [.library(name: "SyncedLib", targets: ["SA"])],
+  targets: [.target(name: "SA")]
+)

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Modules/Nest/Synced/Sources/SA/SA.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Modules/Nest/Synced/Sources/SA/SA.swift
@@ -1,0 +1,1 @@
+public let synced = 1

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Modules/Tool/Package.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Modules/Tool/Package.swift
@@ -1,0 +1,6 @@
+// swift-tools-version:5.9
+import PackageDescription
+let package = Package(
+  name: "Tool",
+  targets: [.executableTarget(name: "SyncedTool")]
+)

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Modules/Tool/Sources/SyncedTool/main.swift
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/project/Modules/Tool/Sources/SyncedTool/main.swift
@@ -1,0 +1,1 @@
+print("tool")

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/project/SpmApp.xcodeproj/project.pbxproj
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/project/SpmApp.xcodeproj/project.pbxproj
@@ -1,0 +1,332 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BB773FE09B0B3D988EE3B0EC /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B150BBA08217C2FDE166C7 /* App.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		96C7126A91CEDD7B684161FA /* Dep */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Dep; path = Dep; sourceTree = SOURCE_ROOT; };
+		A9B150BBA08217C2FDE166C7 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
+		AFAD51C6F25DC44832F28AF4 /* libSpmApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpmApp.a; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		11D65D3A67DABC5F9EE22321 = {
+			isa = PBXGroup;
+			children = (
+				A3E8AC10F636350588E4601B /* AppSources */,
+				391B6A363762698F8672FF71 /* Packages */,
+				2694553E8E497C40D66E3785 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		2694553E8E497C40D66E3785 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AFAD51C6F25DC44832F28AF4 /* libSpmApp.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		391B6A363762698F8672FF71 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				96C7126A91CEDD7B684161FA /* Dep */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		A3E8AC10F636350588E4601B /* AppSources */ = {
+			isa = PBXGroup;
+			children = (
+				A9B150BBA08217C2FDE166C7 /* App.swift */,
+			);
+			path = AppSources;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		642B7940145F8E96BCF73854 /* SpmApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CE116132122A2C97B8FA7D34 /* Build configuration list for PBXNativeTarget "SpmApp" */;
+			buildPhases = (
+				676ED8862A08E3E9DF011AFE /* Sources */,
+				3839728066FAC7F994829DD5 /* Copy Swift Objective-C Interface Header */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CDDADDCAEEA3E0AD8D1B0D7D /* PBXTargetDependency */,
+			);
+			name = SpmApp;
+			packageProductDependencies = (
+				4A02055B1596722124C1FFC2 /* Dep */,
+			);
+			productName = SpmApp;
+			productReference = AFAD51C6F25DC44832F28AF4 /* libSpmApp.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		2C26E08C24E34BA92BFB3209 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+				};
+			};
+			buildConfigurationList = 8B485679BF9B03151FA77EFC /* Build configuration list for PBXProject "SpmApp" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 11D65D3A67DABC5F9EE22321;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				36D08622332CAE5D1D1245A9 /* XCLocalSwiftPackageReference "Dep" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 2694553E8E497C40D66E3785 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				642B7940145F8E96BCF73854 /* SpmApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3839728066FAC7F994829DD5 /* Copy Swift Objective-C Interface Header */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(DERIVED_SOURCES_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			name = "Copy Swift Objective-C Interface Header";
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/include/$(PRODUCT_MODULE_NAME)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "ditto \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		676ED8862A08E3E9DF011AFE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB773FE09B0B3D988EE3B0EC /* App.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		CDDADDCAEEA3E0AD8D1B0D7D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 4A02055B1596722124C1FFC2 /* Dep */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		1B92A25ED8993DAF598A1C0A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.SpmApp;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		327430B4CA362EFD0F7369EE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.SpmApp;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		530BEE30E4A5A28208E2F935 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		D153BCE0C3DE3A896B09097A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		8B485679BF9B03151FA77EFC /* Build configuration list for PBXProject "SpmApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D153BCE0C3DE3A896B09097A /* Debug */,
+				530BEE30E4A5A28208E2F935 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		CE116132122A2C97B8FA7D34 /* Build configuration list for PBXNativeTarget "SpmApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				327430B4CA362EFD0F7369EE /* Debug */,
+				1B92A25ED8993DAF598A1C0A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		36D08622332CAE5D1D1245A9 /* XCLocalSwiftPackageReference "Dep" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Dep;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		4A02055B1596722124C1FFC2 /* Dep */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Dep;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 2C26E08C24E34BA92BFB3209 /* Project object */;
+}

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/project/SpmApp.xcodeproj/project.pbxproj
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/project/SpmApp.xcodeproj/project.pbxproj
@@ -16,12 +16,17 @@
 		AFAD51C6F25DC44832F28AF4 /* libSpmApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpmApp.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		AA00SYNCR00T0000000000AA /* Modules */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Modules; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXGroup section */
 		11D65D3A67DABC5F9EE22321 = {
 			isa = PBXGroup;
 			children = (
 				A3E8AC10F636350588E4601B /* AppSources */,
 				391B6A363762698F8672FF71 /* Packages */,
+				AA00SYNCR00T0000000000AA /* Modules */,
 				2694553E8E497C40D66E3785 /* Products */,
 			);
 			sourceTree = "<group>";

--- a/sweetpad-lib/fixtures/_synthetic-spm-graph/project/SpmApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/sweetpad-lib/fixtures/_synthetic-spm-graph/project/SpmApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/sweetpad-lib/src/project.rs
+++ b/sweetpad-lib/src/project.rs
@@ -35,6 +35,16 @@ pub struct Project {
     /// that `xcodebuild` additionally synthesizes from Swift *package*
     /// manifests are out of scope — they aren't derivable from the pbxproj.
     pub schemes: Vec<String>,
+    /// Absolute paths to the local SwiftPM packages the project declares
+    /// (`XCLocalSwiftPackageReference`), in `packageReferences` order, keeping
+    /// only directories that hold a `Package.swift`.
+    ///
+    /// `xcodebuild -list` gives each of their *products* a scheme, on top of
+    /// the project's own targets. Naming a product means evaluating a Swift
+    /// manifest, so this crate reports the membership and leaves the naming to
+    /// a caller that can run `swift package dump-package` — the same split as
+    /// [`crate::workspace::Workspace::package_refs`].
+    pub package_refs: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone)]
@@ -169,7 +179,173 @@ pub fn open_from_value(value: &Value, xcodeproj_path: &Path) -> Result<Project, 
         configurations,
         default_configuration,
         schemes,
+        package_refs: local_package_refs(value, objects, project_obj, xcodeproj_path),
     })
+}
+
+impl Project {
+    /// [`Project::schemes`] plus the schemes a caller resolved from the
+    /// project's local package graph, sorted the way `xcodebuild -list
+    /// -project` prints them.
+    ///
+    /// Product names need `swift package dump-package` — see
+    /// [`Project::package_refs`] — so a caller with nothing resolved gets
+    /// exactly `schemes`.
+    #[must_use]
+    pub fn schemes_with_packages(&self, package_schemes: &[(PathBuf, Vec<String>)]) -> Vec<String> {
+        let mut set: BTreeSet<String> = self.schemes.iter().cloned().collect();
+        for (_, names) in package_schemes {
+            set.extend(names.iter().cloned());
+        }
+        let mut out: Vec<String> = set.into_iter().collect();
+        crate::scheme::sort_like_xcodebuild(&mut out);
+        out
+    }
+
+    /// The project's target names plus the targets a caller read from its
+    /// local package graph, packages appended after the project's own targets
+    /// in the order the caller resolved them.
+    #[must_use]
+    pub fn targets_with_packages(&self, package_targets: &[(PathBuf, Vec<String>)]) -> Vec<String> {
+        let mut out: Vec<String> = self.targets.iter().map(|t| t.name.clone()).collect();
+        let mut seen: std::collections::HashSet<String> = out.iter().cloned().collect();
+        for (_, names) in package_targets {
+            for name in names {
+                if seen.insert(name.clone()) {
+                    out.push(name.clone());
+                }
+            }
+        }
+        out
+    }
+}
+
+/// The local SwiftPM packages a pbxproj reaches, resolved to absolute
+/// directories: the ones it declares in `packageReferences`, then the ones
+/// sitting in its group tree.
+///
+/// Both spellings are in the wild. "Add Local…" writes an
+/// `XCLocalSwiftPackageReference` whose `relativePath` is anchored at the
+/// directory *containing* the `.xcodeproj` (`Dep` for a sibling, `../Dep` for
+/// one a level up, or an absolute path). Dragging a package folder into the
+/// navigator instead leaves a plain `PBXFileReference` at the directory, with
+/// nothing but the manifest inside to say it is a package — how ice-cubes
+/// references all thirteen of its `Packages/*`, every one of which
+/// `xcodebuild -list` gives a scheme.
+///
+/// Remote packages are skipped: they live in a checkout Xcode manages, and
+/// `xcodebuild` synthesizes no schemes from their manifests. A path with no
+/// `Package.swift` is dropped rather than reported, so a reference left behind
+/// by a moved package cannot invent a scheme.
+fn local_package_refs(
+    value: &Value,
+    objects: &Dict,
+    project_obj: &Value,
+    xcodeproj_path: &Path,
+) -> Vec<PathBuf> {
+    let project_dir = abs_project_dir(xcodeproj_path);
+    let declared = crate::spm_pbxproj::list_packages(value)
+        .into_iter()
+        .filter_map(|pkg| match pkg.kind {
+            crate::spm_pbxproj::PackageKind::Local { relative_path } => Some(relative_path),
+            crate::spm_pbxproj::PackageKind::Remote { .. } => None,
+        })
+        .map(|rel| {
+            let p = PathBuf::from(&rel);
+            if p.is_absolute() {
+                p
+            } else {
+                join_normalized(&project_dir, &rel)
+            }
+        });
+
+    let mut out: Vec<PathBuf> = Vec::new();
+    let mut seen: BTreeSet<PathBuf> = BTreeSet::new();
+    for dir in declared.chain(group_tree_package_refs(objects, project_obj, &project_dir)) {
+        if dir.join("Package.swift").is_file() && seen.insert(dir.clone()) {
+            out.push(dir);
+        }
+    }
+    out
+}
+
+/// Package directories reachable from the project's `mainGroup`, in navigator
+/// order. Only leaves that could name a directory are stat'd — checking every
+/// leaf would mean one `stat` per file reference in the project.
+fn group_tree_package_refs(
+    objects: &Dict,
+    project_obj: &Value,
+    project_dir: &Path,
+) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Some(main_group_id) = project_obj.get("mainGroup").and_then(Value::as_str) {
+        walk_for_packages(
+            objects,
+            main_group_id,
+            project_dir,
+            project_dir,
+            &mut out,
+            &mut BTreeSet::new(),
+            0,
+        );
+    }
+    out
+}
+
+fn walk_for_packages<'a>(
+    objects: &'a Dict,
+    node_id: &'a str,
+    parent_base: &Path,
+    project_dir: &Path,
+    out: &mut Vec<PathBuf>,
+    visited: &mut BTreeSet<&'a str>,
+    depth: usize,
+) {
+    let Some(node) = objects.get(node_id) else {
+        return;
+    };
+    let base = node_base(node, parent_base, project_dir);
+    match node.get("isa").and_then(Value::as_str).unwrap_or("") {
+        "PBXGroup" | "PBXVariantGroup" | "XCVersionGroup" => {
+            if depth >= MAX_GROUP_DEPTH || !visited.insert(node_id) {
+                return;
+            }
+            if let Some(children) = node.get("children").and_then(Value::as_array) {
+                for child in children {
+                    if let Some(cid) = child.as_str() {
+                        walk_for_packages(
+                            objects,
+                            cid,
+                            &base,
+                            project_dir,
+                            out,
+                            visited,
+                            depth + 1,
+                        );
+                    }
+                }
+            }
+        }
+        _ => {
+            if names_a_directory(node) {
+                out.push(base);
+            }
+        }
+    }
+}
+
+/// Whether a leaf node could be a directory: an explicit folder or wrapper
+/// type, or no declared type at all. Xcode spells a dragged-in package folder
+/// `wrapper` today and `folder` in projects old enough.
+fn names_a_directory(node: &Value) -> bool {
+    let kind = node
+        .get("lastKnownFileType")
+        .or_else(|| node.get("explicitFileType"))
+        .and_then(Value::as_str);
+    match kind {
+        None => true,
+        Some(k) => k == "folder" || k == "wrapper" || k.starts_with("folder."),
+    }
 }
 
 /// Whether Xcode's scheme autocreation materializes a scheme for `target`.
@@ -4771,6 +4947,37 @@ mod tests {
         // Synthetic project has no scheme files at all, so the autocreated
         // per-target schemes surface (matching `xcodebuild -list`).
         assert_eq!(project.schemes, vec!["Scratch"]);
+    }
+
+    #[test]
+    fn reads_the_local_packages_a_project_declares() {
+        let root = fixtures_root().join("_synthetic-spm/project");
+        let project = open(&root.join("SpmApp.xcodeproj")).unwrap();
+        // `XCLocalSwiftPackageReference "Dep"` — a relative path anchored at
+        // the directory holding the .xcodeproj.
+        assert_eq!(project.package_refs, vec![root.join("Dep")]);
+        // Their products are not in `schemes`: naming one needs the toolchain.
+        assert_eq!(project.schemes, vec!["SpmApp"]);
+    }
+
+    #[test]
+    fn package_names_merge_into_the_projects_own() {
+        let root = fixtures_root().join("_synthetic-spm/project");
+        let project = open(&root.join("SpmApp.xcodeproj")).unwrap();
+        let resolved = vec![(root.join("Dep"), vec!["Dep".to_string()])];
+        assert_eq!(
+            project.schemes_with_packages(&resolved),
+            vec!["Dep", "SpmApp"]
+        );
+        assert_eq!(
+            project.targets_with_packages(&[(
+                root.join("Dep"),
+                vec!["Dep".to_string(), "DepTests".to_string()],
+            )]),
+            vec!["SpmApp", "Dep", "DepTests"]
+        );
+        // Nothing resolved leaves both lists exactly as the pbxproj has them.
+        assert_eq!(project.schemes_with_packages(&[]), project.schemes);
     }
 
     #[test]

--- a/sweetpad-lib/src/project.rs
+++ b/sweetpad-lib/src/project.rs
@@ -271,7 +271,9 @@ fn local_package_refs(
 
 /// Package directories reachable from the project's `mainGroup`, in navigator
 /// order. Only leaves that could name a directory are stat'd — checking every
-/// leaf would mean one `stat` per file reference in the project.
+/// leaf would mean one `stat` per file reference in the project — and a
+/// synchronized folder, which lists no members at all, is scanned on disk by
+/// [`packages_under_synchronized_folder`].
 fn group_tree_package_refs(
     objects: &Dict,
     project_obj: &Value,
@@ -326,10 +328,60 @@ fn walk_for_packages<'a>(
                 }
             }
         }
+        // A folder reference (Xcode 16+): the pbxproj lists none of its
+        // members, so a package under it is found by looking at the disk.
+        "PBXFileSystemSynchronizedRootGroup" => {
+            if base.join("Package.swift").is_file() {
+                out.push(base);
+            } else {
+                packages_under_synchronized_folder(&base, out, 0);
+            }
+        }
         _ => {
             if names_a_directory(node) {
                 out.push(base);
             }
+        }
+    }
+}
+
+/// Package directories physically under `dir`, a synchronized folder.
+///
+/// Everything below such a folder belongs to the project without the pbxproj
+/// naming it, and `xcodebuild` gives a package found there schemes at any
+/// depth — NetNewsWire reaches all fourteen of its `Modules/*` this way, and a
+/// package two levels down is listed just the same. Descent stops at a
+/// directory that is itself a package, since a package's subdirectories are
+/// its own sources: a `Package.swift` nested inside another package gets no
+/// schemes.
+///
+/// Names carrying a `.` are skipped — `.build`, `.git`, `Foo.xcassets`,
+/// `en.lproj`. A package directory never has one, and skipping them keeps the
+/// scan off the resource trees that are most of what a synchronized folder
+/// holds: NetNewsWire's eight folders cost 82 `read_dir` calls this way.
+fn packages_under_synchronized_folder(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
+    if depth >= MAX_GROUP_DEPTH {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    // `read_dir` order is the filesystem's, which would leave the target list
+    // this feeds in a different order run to run.
+    let mut children: Vec<PathBuf> = entries
+        .flatten()
+        // `file_type` does not follow symlinks, so a link pointing back up the
+        // tree ends the descent instead of looping.
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+        .filter(|e| !e.file_name().to_string_lossy().contains('.'))
+        .map(|e| e.path())
+        .collect();
+    children.sort();
+    for child in children {
+        if child.join("Package.swift").is_file() {
+            out.push(child);
+        } else {
+            packages_under_synchronized_folder(&child, out, depth + 1);
         }
     }
 }
@@ -4958,6 +5010,35 @@ mod tests {
         assert_eq!(project.package_refs, vec![root.join("Dep")]);
         // Their products are not in `schemes`: naming one needs the toolchain.
         assert_eq!(project.schemes, vec!["SpmApp"]);
+    }
+
+    /// A synchronized folder names none of its members, so the packages under
+    /// it are found on disk. `xcodebuild -list` gives a package there schemes
+    /// at any depth (grounded on Xcode 26.5), a `Package.swift` nested inside
+    /// another package gets none, and dotted names are never packages.
+    #[test]
+    fn finds_packages_under_a_synchronized_folder() {
+        let root = std::env::temp_dir().join(format!("sweetpad-sync-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        for rel in [
+            "Modules/Shallow",
+            "Modules/Nest/Deep",
+            "Modules/Shallow/Inner",
+            "Modules/Resources.xcassets/Nope",
+        ] {
+            fs::create_dir_all(root.join(rel)).unwrap();
+            fs::write(root.join(rel).join("Package.swift"), "// package").unwrap();
+        }
+        // Not a package, and not a parent of one either.
+        fs::create_dir_all(root.join("Modules/Plain/Sources")).unwrap();
+
+        let mut found = Vec::new();
+        packages_under_synchronized_folder(&root.join("Modules"), &mut found, 0);
+        assert_eq!(
+            found,
+            vec![root.join("Modules/Nest/Deep"), root.join("Modules/Shallow")]
+        );
+        let _ = fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/sweetpad-lib/src/workspace.rs
+++ b/sweetpad-lib/src/workspace.rs
@@ -46,11 +46,16 @@ pub struct Workspace {
     /// in declaration order.
     pub project_refs: Vec<PathBuf>,
     /// Absolute paths to every local SwiftPM package referenced by the
-    /// workspace (a `FileRef` at a directory holding a `Package.swift`), in
-    /// declaration order. A package's schemes are its manifest's products,
-    /// and a manifest is Swift source that only the toolchain can evaluate —
-    /// so this crate reports the membership and leaves naming to a caller
-    /// that can run `swift package dump-package`.
+    /// workspace itself (a `FileRef` at a directory holding a
+    /// `Package.swift`), in declaration order. A package's schemes are its
+    /// manifest's products, and a manifest is Swift source that only the
+    /// toolchain can evaluate — so this crate reports the membership and
+    /// leaves naming to a caller that can run `swift package dump-package`.
+    ///
+    /// A member listed here is the workspace's own package, which is why it
+    /// also gets a scheme per *test* target; the packages a member project
+    /// declares ([`Workspace::project_package_refs`]) contribute products
+    /// only.
     pub package_refs: Vec<PathBuf>,
     /// The workspace bundle's own scheme names (shared plus per-user files),
     /// sorted alphabetically. Member-project schemes are merged in by
@@ -165,13 +170,18 @@ impl Workspace {
     }
 
     /// [`Workspace::merged_schemes`] plus the schemes a caller resolved from
-    /// each member package's manifest, keyed by package path. Names for a
-    /// package this workspace doesn't reference are ignored, so a stale cache
-    /// entry can't invent a scheme.
+    /// the workspace's local package graph, each entry paired with the package
+    /// directory it came from.
     ///
     /// The split exists because product names need `swift package
     /// dump-package` — see [`Workspace::package_refs`]. A caller with no
     /// resolved names gets exactly `merged_schemes`.
+    ///
+    /// The graph reaches past this workspace's own `FileRef` members — a
+    /// member project's packages and everything those pull in through
+    /// `.package(path:)` are in it too — and only a caller that evaluated the
+    /// manifests knows how far it went, so the names are merged as given
+    /// rather than filtered against [`Workspace::package_refs`].
     #[must_use]
     pub fn merged_schemes_with_packages(
         &self,
@@ -179,10 +189,8 @@ impl Workspace {
     ) -> Vec<String> {
         let mut set: std::collections::BTreeSet<String> =
             self.merged_schemes().into_iter().collect();
-        for (path, names) in package_schemes {
-            if self.package_refs.iter().any(|p| p == path) {
-                set.extend(names.iter().cloned());
-            }
+        for (_, names) in package_schemes {
+            set.extend(names.iter().cloned());
         }
         let mut out: Vec<String> = set.into_iter().collect();
         crate::scheme::sort_like_xcodebuild(&mut out);
@@ -198,15 +206,14 @@ impl Workspace {
         self.merged_from_projects(|proj| proj.targets.into_iter().map(|t| t.name))
     }
 
-    /// [`Workspace::merged_targets`] plus the targets a caller read from each
-    /// member package's manifest, keyed by package path — packages appended
-    /// after the projects, in declaration order. Names for a package this
-    /// workspace doesn't reference are ignored, so a stale cache entry can't
-    /// invent a target.
+    /// [`Workspace::merged_targets`] plus the targets a caller read from the
+    /// workspace's local package graph — packages appended after the projects,
+    /// in the order the caller resolved them.
     ///
     /// Target names need `swift package dump-package`; see
     /// [`Workspace::package_refs`]. A caller with nothing resolved gets
-    /// exactly `merged_targets`.
+    /// exactly `merged_targets`. The names are merged as given, for the reason
+    /// [`Workspace::merged_schemes_with_packages`] gives.
     #[must_use]
     pub fn merged_targets_with_packages(
         &self,
@@ -214,13 +221,38 @@ impl Workspace {
     ) -> Vec<String> {
         let mut out = self.merged_targets();
         let mut seen: std::collections::HashSet<String> = out.iter().cloned().collect();
-        for package_path in &self.package_refs {
-            let Some((_, names)) = package_targets.iter().find(|(p, _)| p == package_path) else {
-                continue;
-            };
+        for (_, names) in package_targets {
             for name in names {
                 if seen.insert(name.clone()) {
                     out.push(name.clone());
+                }
+            }
+        }
+        out
+    }
+
+    /// The local SwiftPM packages the member *projects* declare
+    /// (`XCLocalSwiftPackageReference`), in project order then declaration
+    /// order, with duplicates and this workspace's own `FileRef` members
+    /// dropped.
+    ///
+    /// `xcodebuild -list -workspace` gives these packages' products schemes
+    /// just like a `FileRef` member's, which is why they have to be resolved
+    /// too — a package dragged into an app project rather than into the
+    /// workspace is the common way to end up here. Projects that fail to open
+    /// are skipped.
+    #[must_use]
+    pub fn project_package_refs(&self) -> Vec<PathBuf> {
+        let mut seen: std::collections::HashSet<PathBuf> =
+            self.package_refs.iter().cloned().collect();
+        let mut out = Vec::new();
+        for project_path in &self.project_refs {
+            let Ok(proj) = project::open(project_path) else {
+                continue;
+            };
+            for dir in proj.package_refs {
+                if seen.insert(dir.clone()) {
+                    out.push(dir);
                 }
             }
         }
@@ -596,20 +628,24 @@ mod tests {
     }
 
     #[test]
-    fn resolved_package_schemes_merge_in_and_stale_paths_are_ignored() {
+    fn resolved_package_schemes_merge_in_from_across_the_graph() {
         let (ws_path, _proj) = scratch_workspace("pkg-merge");
         let pkg = add_package(&ws_path, "MyLib");
         let ws = open(&ws_path).unwrap();
 
         let resolved = vec![
             (pkg, vec!["LibA".to_string(), "LibB".to_string()]),
-            // A cache entry for a package this workspace dropped must not
-            // resurrect its schemes.
-            (PathBuf::from("/gone/Old"), vec!["Ghost".to_string()]),
+            // A package reached through a member's `.package(path:)` is no
+            // `FileRef` of this workspace, and its products are schemes all
+            // the same.
+            (
+                PathBuf::from("/elsewhere/Nested"),
+                vec!["NestedLib".to_string()],
+            ),
         ];
         assert_eq!(
             ws.merged_schemes_with_packages(&resolved),
-            vec!["LibA", "LibB", "Scratch"]
+            vec!["LibA", "LibB", "NestedLib", "Scratch"]
         );
         // With nothing resolved it degrades to exactly `merged_schemes`.
         assert_eq!(ws.merged_schemes_with_packages(&[]), ws.merged_schemes());
@@ -632,13 +668,77 @@ mod tests {
                     "LibATests".to_string(),
                 ],
             ),
-            (PathBuf::from("/gone/Old"), vec!["Ghost".to_string()]),
+            (
+                PathBuf::from("/elsewhere/Nested"),
+                vec!["NestedLib".to_string()],
+            ),
         ];
         assert_eq!(
             ws.merged_targets_with_packages(&resolved),
-            vec!["Scratch", "LibA", "LibATests"]
+            vec!["Scratch", "LibA", "LibATests", "NestedLib"]
         );
         assert_eq!(ws.merged_targets_with_packages(&[]), ws.merged_targets());
+        let _ = fs::remove_dir_all(ws_path.parent().unwrap());
+    }
+
+    /// A workspace holding the `_synthetic-spm` fixture project, which
+    /// declares `XCLocalSwiftPackageReference "Dep"`. `absolute:` keeps the
+    /// scratch workspace from having to copy the fixture.
+    fn workspace_over_the_spm_fixture(tag: &str, also_reference_the_package: bool) -> PathBuf {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static N: AtomicU32 = AtomicU32::new(0);
+        let n = N.fetch_add(1, Ordering::Relaxed);
+        let spm = fixtures_root().join("_synthetic-spm/project");
+        let root =
+            std::env::temp_dir().join(format!("sweetpad-ws-{tag}-{}-{n}", std::process::id()));
+        let ws_path = root.join("Test.xcworkspace");
+        fs::create_dir_all(&ws_path).unwrap();
+        let package_ref = if also_reference_the_package {
+            format!(
+                "  <FileRef location=\"absolute:{}\"/>\n",
+                spm.join("Dep").display()
+            )
+        } else {
+            String::new()
+        };
+        fs::write(
+            ws_path.join("contents.xcworkspacedata"),
+            format!(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Workspace version=\"1.0\">\n  <FileRef location=\"absolute:{}\"/>\n{package_ref}</Workspace>\n",
+                spm.join("SpmApp.xcodeproj").display()
+            ),
+        )
+        .unwrap();
+        ws_path
+    }
+
+    #[test]
+    fn a_member_projects_local_packages_are_reported_apart_from_the_workspaces_own() {
+        let ws_path = workspace_over_the_spm_fixture("project-pkg", false);
+        let ws = open(&ws_path).unwrap();
+
+        // The workspace declares no package itself; the project it holds does,
+        // and `xcodebuild -list` gives that package's products schemes too.
+        assert!(ws.package_refs.is_empty());
+        assert_eq!(
+            ws.project_package_refs(),
+            vec![fixtures_root().join("_synthetic-spm/project/Dep")]
+        );
+        let _ = fs::remove_dir_all(ws_path.parent().unwrap());
+    }
+
+    #[test]
+    fn a_package_the_workspace_already_names_is_not_reported_twice() {
+        let ws_path = workspace_over_the_spm_fixture("both-ways", true);
+        let ws = open(&ws_path).unwrap();
+
+        // Referenced by the workspace *and* by its project: the membership
+        // wins, since that is the role that also makes test targets schemes.
+        assert_eq!(
+            ws.package_refs,
+            vec![fixtures_root().join("_synthetic-spm/project/Dep")]
+        );
+        assert!(ws.project_package_refs().is_empty());
         let _ = fs::remove_dir_all(ws_path.parent().unwrap());
     }
 

--- a/sweetpad-vscode/CHANGELOG.md
+++ b/sweetpad-vscode/CHANGELOG.md
@@ -5,7 +5,7 @@ New features, improvements and bug fixes for SweetPad are documented in this fil
 ## [0.2.15] - 2026-08-26
 
 - Fix missing schemes from Swift packages a project references ([#327](https://github.com/sweetpad-dev/sweetpad/issues/327), thanks [@rssole](https://github.com/rssole))
-- Stop listing schemes Xcode doesn't offer for product-less packages
+- Fix wrong scheme names for a standalone Swift package
 
 ## [0.2.14] - 2026-08-26
 

--- a/sweetpad-vscode/CHANGELOG.md
+++ b/sweetpad-vscode/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 New features, improvements and bug fixes for SweetPad are documented in this file.
 
+## [0.2.15] - 2026-08-26
+
+- Fix missing schemes from Swift packages a project references ([#327](https://github.com/sweetpad-dev/sweetpad/issues/327), thanks [@rssole](https://github.com/rssole))
+- Stop listing schemes Xcode doesn't offer for product-less packages
+
 ## [0.2.14] - 2026-08-26
 
 - Fix apps not launching when the workspace name has a space ([#329](https://github.com/sweetpad-dev/sweetpad/issues/329), thanks [@richardgroves](https://github.com/richardgroves))

--- a/sweetpad-vscode/native/src/lib.rs
+++ b/sweetpad-vscode/native/src/lib.rs
@@ -125,29 +125,32 @@ fn is_workspace(path: &Path) -> bool {
     path.extension().and_then(|e| e.to_str()) == Some("xcworkspace")
 }
 
-/// Whether a container's names include what its local SwiftPM packages
-/// declare. Naming those means running `swift package dump-package`, which
-/// takes seconds on a cold manifest cache — so the calls that need it are
-/// promises, computed on a worker thread rather than on the event loop the
+/// Which names to read. Both include what the container's local SwiftPM
+/// packages declare, and naming those means running `swift package
+/// dump-package`, which takes seconds on a cold manifest cache — so the calls
+/// are promises, computed on a worker thread rather than on the event loop the
 /// whole editor shares.
 enum Names {
     Schemes,
     Targets,
 }
 
-/// Read `path`'s names, evaluating member package manifests when it is a
-/// workspace. Runs off the main thread (see [`NamesTask`]).
+/// Read `path`'s names, evaluating the manifests of every local package the
+/// container reaches. Runs off the main thread (see [`NamesTask`]).
 fn read_names(path: &str, which: &Names) -> napi::Result<Vec<String>> {
     let p = Path::new(path);
     if !is_workspace(p) {
         let project = project::open(p).map_err(to_napi_err)?;
+        let members = sweetpad_core::package_members::resolve_project(&project, None);
         return Ok(match which {
-            Names::Schemes => project.schemes,
-            Names::Targets => project.targets.into_iter().map(|t| t.name).collect(),
+            Names::Schemes => project
+                .schemes_with_packages(&sweetpad_core::package_members::scheme_pairs(&members)),
+            Names::Targets => project
+                .targets_with_packages(&sweetpad_core::package_members::target_pairs(&members)),
         });
     }
     let ws = workspace::open(p).map_err(to_napi_err)?;
-    let members = sweetpad_core::package_members::resolve(&ws.package_refs, None);
+    let members = sweetpad_core::package_members::resolve_workspace(&ws, None);
     Ok(match which {
         Names::Schemes => {
             ws.merged_schemes_with_packages(&sweetpad_core::package_members::scheme_pairs(&members))
@@ -177,9 +180,9 @@ impl napi::Task for NamesTask {
 }
 
 /// Scheme names for a `.xcodeproj` or `.xcworkspace` — shared and per-user
-/// scheme files, falling back to autocreated per-target schemes when none
-/// exist. For a workspace, merged across the bundle, every member project, and
-/// every local SwiftPM package's products, sorted like
+/// scheme files, plus autocreated per-target schemes, plus the products of
+/// every local SwiftPM package the container reaches. For a workspace, merged
+/// across the bundle and every member project, sorted like
 /// `xcodebuild -list -workspace`.
 #[napi(ts_return_type = "Promise<Array<string>>")]
 #[must_use]
@@ -191,9 +194,9 @@ pub fn schemes(path: String) -> napi::bindgen_prelude::AsyncTask<NamesTask> {
 }
 
 /// Target names for a `.xcodeproj` or `.xcworkspace`. For a workspace, the
-/// distinct targets across member projects in first-seen order, then each
-/// local package's targets — test targets included, since a target list drives
-/// `-only-testing:`.
+/// distinct targets across member projects in first-seen order; then, for
+/// either, each local package's targets — test targets included, since a
+/// target list drives `-only-testing:`.
 #[napi(ts_return_type = "Promise<Array<string>>")]
 #[must_use]
 pub fn targets(path: String) -> napi::bindgen_prelude::AsyncTask<NamesTask> {

--- a/sweetpad-vscode/src/common/cli/scripts.spec.ts
+++ b/sweetpad-vscode/src/common/cli/scripts.spec.ts
@@ -5,7 +5,7 @@ import * as vscode from "vscode";
 import { ExtensionError } from "../errors";
 import { exec } from "../exec";
 import { getShellDeveloperDir } from "../tasks/shell-env";
-import { getBuildSettingsList, getXcodeBuildCommand, parseCliJsonOutput } from "./scripts";
+import { getBuildSettingsList, getXcodeBuildCommand, packageSchemes, parseCliJsonOutput } from "./scripts";
 
 vi.mock("../exec", () => ({ exec: vi.fn() }));
 vi.mock("../tasks/shell-env", () => ({ getShellDeveloperDir: vi.fn() }));
@@ -302,5 +302,48 @@ describe("getBuildSettingsList", () => {
     expect(settings[0].target).toBe("MyPackage");
     expect(mockBuildSettings).not.toHaveBeenCalled();
     expect(mockExec).toHaveBeenCalledWith(expect.objectContaining({ cwd: "/proj" }));
+  });
+});
+
+describe("packageSchemes", () => {
+  it("offers only the aggregate when the package has no products", () => {
+    expect(packageSchemes({ name: "P", products: [], targets: [{ name: "Lib", type: "regular" }] })).toEqual([
+      "P-Package",
+    ]);
+  });
+
+  // Grounded on `xcodebuild -list` (26.5): one product means one scheme, named
+  // after the package rather than the product, and no aggregate.
+  it("collapses a single product to the package's own name", () => {
+    expect(
+      packageSchemes({
+        name: "P",
+        products: [{ name: "Lib", type: { library: ["automatic"] }, targets: ["T"] }],
+        targets: [{ name: "T", type: "regular" }],
+      }),
+    ).toEqual(["P"]);
+  });
+
+  it("counts an uncovered executable target as a product of its own", () => {
+    expect(
+      packageSchemes({
+        name: "D",
+        products: [{ name: "LibA", type: { library: ["automatic"] }, targets: ["TA"] }],
+        targets: [
+          { name: "TA", type: "regular" },
+          { name: "TC", type: "executable" },
+        ],
+      }),
+    ).toEqual(["D-Package", "LibA", "TC"]);
+  });
+
+  it("gives an executable target already behind a product no second product", () => {
+    expect(
+      packageSchemes({
+        name: "E",
+        products: [{ name: "tool", type: { executable: null }, targets: ["e1"] }],
+        targets: [{ name: "e1", type: "executable" }],
+      }),
+    ).toEqual(["E"]);
   });
 });

--- a/sweetpad-vscode/src/common/cli/scripts.ts
+++ b/sweetpad-vscode/src/common/cli/scripts.ts
@@ -589,24 +589,13 @@ async function dumpPackage(packageDir: string): Promise<any> {
 }
 
 /**
- * Scheme names for a local package that belongs to an `.xcworkspace`: one per
- * declared product, whatever its kind (a `.plugin` product gets a scheme too).
- * Falls back to non-test target names for a package that declares no products.
- *
- * No `<name>-Package` aggregate: `xcodebuild -list` synthesizes that for a
- * package opened on its own but not for one inside a workspace, so offering it
- * here would name a scheme xcodebuild then rejects.
+ * Product names from a dumped manifest — `xcodebuild -list` gives each one a
+ * scheme, whatever its kind (a `.plugin` product gets one too). A target no
+ * product exposes gets no scheme of its own.
  */
-function packageMemberSchemes(packageInfo: any): string[] {
-  const products: string[] = (packageInfo?.products ?? [])
+function packageProducts(packageInfo: any): string[] {
+  return (packageInfo?.products ?? [])
     .map((product: any) => product?.name)
-    .filter((name: unknown): name is string => typeof name === "string");
-  if (products.length > 0) {
-    return products;
-  }
-  return (packageInfo?.targets ?? [])
-    .filter((target: any) => !isTestTarget(target))
-    .map((target: any) => target?.name)
     .filter((name: unknown): name is string => typeof name === "string");
 }
 
@@ -614,16 +603,10 @@ function packageMemberSchemes(packageInfo: any): string[] {
  * Every target a package declares, tests included — a target list drives
  * `-only-testing:`, where a test target is the whole point.
  */
-function packageMemberTargets(packageInfo: any): string[] {
+function packageTargets(packageInfo: any): string[] {
   return (packageInfo?.targets ?? [])
     .map((target: any) => target?.name)
     .filter((name: unknown): name is string => typeof name === "string");
-}
-
-/** `dump-package` tags a test target as `{"test":{}}`; older dumps use `"test"`. */
-function isTestTarget(target: any): boolean {
-  const type = target?.type;
-  return typeof type === "string" ? type === "test" : Boolean(type?.test);
 }
 
 export async function getSchemes(options: { xcworkspace: string | undefined }): Promise<XcodeScheme[]> {
@@ -635,19 +618,11 @@ export async function getSchemes(options: { xcworkspace: string | undefined }): 
       const packageDir = getSwiftPMDirectory(options.xcworkspace ?? "");
       const packageInfo = await dumpPackage(packageDir);
 
-      const schemeNames = new Set<string>(packageMemberSchemes(packageInfo));
-
-      // Add standalone executable targets not already covered
-      if (packageInfo.targets) {
-        for (const target of packageInfo.targets) {
-          if (target.type === "executable" && !schemeNames.has(target.name)) {
-            schemeNames.add(target.name);
-          }
-        }
-      }
+      const schemeNames = new Set<string>(packageProducts(packageInfo));
 
       // A package opened on its own also gets the `<name>-Package` aggregate
-      // scheme that builds everything; include it to match Xcode's list.
+      // scheme that builds everything; include it to match Xcode's list. It is
+      // all a package with no products has to offer.
       if (packageInfo.name) {
         schemeNames.add(`${packageInfo.name}-Package`);
       }
@@ -678,7 +653,7 @@ export async function getTargets(options: { xcworkspace: string }): Promise<stri
   if (workspaceType === "spm") {
     try {
       const packageDir = getSwiftPMDirectory(options.xcworkspace ?? "");
-      return packageMemberTargets(await dumpPackage(packageDir));
+      return packageTargets(await dumpPackage(packageDir));
     } catch (error) {
       commonLogger.error("Failed to get SPM targets", {
         error: error,

--- a/sweetpad-vscode/src/common/cli/scripts.ts
+++ b/sweetpad-vscode/src/common/cli/scripts.ts
@@ -589,14 +589,51 @@ async function dumpPackage(packageDir: string): Promise<any> {
 }
 
 /**
- * Product names from a dumped manifest — `xcodebuild -list` gives each one a
- * scheme, whatever its kind (a `.plugin` product gets one too). A target no
- * product exposes gets no scheme of its own.
+ * The package's products as SwiftPM sees them: the ones the manifest declares,
+ * whatever their kind (a `.plugin` product is one too), plus the implicit
+ * executable product SwiftPM synthesizes for each `executableTarget` no
+ * declared product already covers.
+ *
+ * `dump-package` reports only what the manifest wrote — `swift package
+ * describe` is what shows the implicit ones, and it resolves the whole
+ * dependency graph to do it.
  */
 function packageProducts(packageInfo: any): string[] {
-  return (packageInfo?.products ?? [])
+  const declared: string[] = (packageInfo?.products ?? [])
     .map((product: any) => product?.name)
     .filter((name: unknown): name is string => typeof name === "string");
+  const covered = new Set<string>(
+    (packageInfo?.products ?? []).flatMap((product: any) =>
+      (product?.targets ?? []).filter((name: unknown): name is string => typeof name === "string"),
+    ),
+  );
+  const implicit: string[] = (packageInfo?.targets ?? [])
+    .filter((target: any) => target?.type === "executable")
+    .map((target: any) => target?.name)
+    .filter((name: unknown): name is string => typeof name === "string" && !covered.has(name));
+  return [...declared, ...implicit];
+}
+
+/**
+ * Scheme names for a package opened on its own, matching what `xcodebuild
+ * -list` prints in a package directory. How many products the package has
+ * decides the shape (measured on Xcode 26.5):
+ *
+ * - none: the `<name>-Package` aggregate alone;
+ * - one: `<name>` alone — the package's own name, whatever the product is
+ *   called, and no aggregate;
+ * - two or more: the aggregate plus one scheme per product.
+ *
+ * Exported for its spec: the rule is subtle enough that this copy would drift
+ * from `Manifest::scheme_names` in the CLI without one.
+ */
+export function packageSchemes(packageInfo: any): string[] {
+  const name = typeof packageInfo?.name === "string" ? packageInfo.name : "";
+  const products = packageProducts(packageInfo);
+  if (products.length === 1 && name) {
+    return [name];
+  }
+  return name ? [`${name}-Package`, ...products] : products;
 }
 
 /**
@@ -618,15 +655,7 @@ export async function getSchemes(options: { xcworkspace: string | undefined }): 
       const packageDir = getSwiftPMDirectory(options.xcworkspace ?? "");
       const packageInfo = await dumpPackage(packageDir);
 
-      const schemeNames = new Set<string>(packageProducts(packageInfo));
-
-      // A package opened on its own also gets the `<name>-Package` aggregate
-      // scheme that builds everything; include it to match Xcode's list. It is
-      // all a package with no products has to offer.
-      if (packageInfo.name) {
-        schemeNames.add(`${packageInfo.name}-Package`);
-      }
-
+      const schemeNames = new Set<string>(packageSchemes(packageInfo));
       return Array.from(schemeNames).map((name) => ({ name }));
     } catch (error) {
       commonLogger.error("Failed to get SPM package info", {


### PR DESCRIPTION
xcodebuild resolves the whole local package graph — the workspace's FileRef members, the packages a member project declares, keeps as a folder reference, or holds under a synchronized folder, and everything those pull in through `.package(path:)` — and synthesizes schemes from all of it, while SweetPad read only the workspace's own members. It now walks the same graph, counting SwiftPM's implicit executable products alongside the declared ones and adding each package's scheme files and the test targets Xcode counts. A package opened on its own is listed the way xcodebuild lists it: under its own name when it has exactly one product, under `<name>-Package` when it has none, and under both when it has more.
